### PR TITLE
Fix imports of libc

### DIFF
--- a/crypto/hash.rs
+++ b/crypto/hash.rs
@@ -1,5 +1,5 @@
-use libc;
-use libc::c_uint;
+use std::libc;
+use std::libc::c_uint;
 use std::ptr;
 use std::slice;
 

--- a/crypto/hmac.rs
+++ b/crypto/hmac.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use libc::{c_uchar, c_int, c_uint};
+use std::libc::{c_uchar, c_int, c_uint};
 use std::ptr;
 use std::slice;
 use crypto::hash;

--- a/crypto/pkcs5.rs
+++ b/crypto/pkcs5.rs
@@ -1,4 +1,4 @@
-use libc::c_int;
+use std::libc::c_int;
 use std::slice;
 
 #[link(name = "crypto")]

--- a/crypto/pkey.rs
+++ b/crypto/pkey.rs
@@ -1,6 +1,6 @@
 use std::cast;
-use libc::{c_char, c_int, c_uint};
-use libc;
+use std::libc;
+use std::libc::{c_char, c_int, c_uint};
 use std::ptr;
 use std::slice;
 use crypto::hash::{HashType, MD5, SHA1, SHA224, SHA256, SHA384, SHA512};

--- a/crypto/rand.rs
+++ b/crypto/rand.rs
@@ -1,4 +1,4 @@
-use libc::c_int;
+use std::libc::c_int;
 use std::slice;
 
 #[link(name = "crypto")]

--- a/crypto/symm.rs
+++ b/crypto/symm.rs
@@ -1,5 +1,5 @@
-use libc::{c_int, c_uint};
-use libc;
+use std::libc;
+use std::libc::{c_int, c_uint};
 use std::slice;
 
 #[allow(non_camel_case_types)]

--- a/lib.rs
+++ b/lib.rs
@@ -4,7 +4,6 @@
 #![crate_type="dylib"]
 #![doc(html_root_url="http://www.rust-ci.org/sfackler/rust-openssl/doc")]
 
-extern crate libc;
 #[cfg(test)]
 extern crate serialize;
 extern crate sync;

--- a/ssl/error.rs
+++ b/ssl/error.rs
@@ -1,4 +1,4 @@
-use libc::c_ulong;
+use std::libc::c_ulong;
 use std::io::IoError;
 
 use ssl::ffi;

--- a/ssl/ffi.rs
+++ b/ssl/ffi.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use libc::{c_int, c_void, c_long, c_ulong, c_char};
+use std::libc::{c_int, c_void, c_long, c_ulong, c_char};
 
 pub type SSL_CTX = c_void;
 pub type SSL_METHOD = c_void;

--- a/ssl/mod.rs
+++ b/ssl/mod.rs
@@ -1,6 +1,6 @@
 use sync::one::{Once, ONCE_INIT};
 use std::cast;
-use libc::{c_int, c_void, c_char};
+use std::libc::{c_int, c_void, c_char};
 use std::ptr;
 use std::io::{IoResult, IoError, EndOfFile, Stream, Reader, Writer};
 use std::unstable::mutex::NativeMutex;


### PR DESCRIPTION
It's possible I'm just doing something awfully wrong, but with a rustc built from master, or with `0.10`, I needed this patch to build rust-openssl.

Interestingly, on a different machine it built without issue, so it's entirely possible that it's something odd about my environment (But super interested to know what it is)
