### PR TITLE
Update for extern unsafe fn changes

### DIFF
--- a/crypto/pkey.rs
+++ b/crypto/pkey.rs
@@ -89,7 +89,7 @@ impl PKey {
         }
     }
 
-    fn _tostr(&self, f: extern "C" unsafe fn(*EVP_PKEY, **mut u8) -> c_int) -> Vec<u8> {
+    fn _tostr(&self, f: unsafe extern "C" fn(*EVP_PKEY, **mut u8) -> c_int) -> Vec<u8> {
         unsafe {
             let len = f(self.evp, ptr::null());
             if len < 0 as c_int { return vec!(); }
@@ -102,7 +102,7 @@ impl PKey {
         }
     }
 
-    fn _fromstr(&mut self, s: &[u8], f: extern "C" unsafe fn(c_int, **EVP_PKEY, **u8, c_uint) -> *EVP_PKEY) {
+    fn _fromstr(&mut self, s: &[u8], f: unsafe extern "C" fn(c_int, **EVP_PKEY, **u8, c_uint) -> *EVP_PKEY) {
         unsafe {
             let evp = ptr::null();
             f(6 as c_int, &evp, &s.as_ptr(), s.len() as c_uint);


### PR DESCRIPTION
```
$ rust -v
rustc 0.11-pre (adb8b0b 2014-05-10 23:21:44 -0700)
host: x86_64-unknown-linux-gnu
$ make
rustc -O --cfg ndebug  --dep-info build/openssl.d --out-dir build lib.rs
crypto/pkey.rs:92:36: 92:42 error: expected `fn`, found `unsafe`
crypto/pkey.rs:92     fn _tostr(&self, f: extern "C" unsafe fn(*EVP_PKEY, **mut u8) -> c_int) -> Vec<u8> {
                                                     ^~~~~~
Makefile:20: recipe for target 'build/libopenssl-06cd96fd-0.0.so' failed
make: *** [build/libopenssl-06cd96fd-0.0.so] Error 101
```
