### PR TITLE
Squelch warnings

### DIFF
--- a/crypto/hash.rs
+++ b/crypto/hash.rs
@@ -11,6 +11,7 @@ pub enum HashType {
     SHA512
 }
 
+#[allow(dead_code)]
 #[allow(non_camel_case_types)]
 pub struct EVP_MD_CTX {
     digest: *EVP_MD,
@@ -57,6 +58,7 @@ pub fn evpmd(t: HashType) -> (*EVP_MD, uint) {
     }
 }
 
+#[allow(dead_code)]
 pub struct Hasher {
     evp: *EVP_MD,
     ctx: *EVP_MD_CTX,

--- a/crypto/hmac.rs
+++ b/crypto/hmac.rs
@@ -17,6 +17,7 @@
 use libc::{c_uchar, c_int, c_uint};
 use crypto::hash;
 
+#[allow(dead_code)]
 #[allow(non_camel_case_types)]
 pub struct HMAC_CTX {
     md: *hash::EVP_MD,
@@ -43,6 +44,7 @@ pub struct HMAC {
     len: uint,
 }
 
+#[allow(non_snake_case_functions)]
 pub fn HMAC(ht: hash::HashType, key: &[u8]) -> HMAC {
     unsafe {
         let (evp, mdlen) = hash::evpmd(ht);

--- a/ssl/mod.rs
+++ b/ssl/mod.rs
@@ -154,6 +154,7 @@ impl SslContext {
         }
     }
 
+    #[allow(non_snake_case_functions)]
     /// Specifies the file that contains trusted CA certificates.
     pub fn set_CA_file(&mut self, file: &str) -> Option<SslError> {
         let ret = file.with_c_str(|file| {
@@ -191,6 +192,7 @@ impl X509StoreContext {
     }
 }
 
+#[allow(dead_code)]
 /// A public key certificate
 pub struct X509<'ctx> {
     ctx: &'ctx X509StoreContext,
@@ -204,6 +206,7 @@ impl<'ctx> X509<'ctx> {
     }
 }
 
+#[allow(dead_code)]
 pub struct X509Name<'x> {
     x509: &'x X509<'x>,
     name: *ffi::X509_NAME
@@ -379,6 +382,7 @@ enum LibSslError {
     ErrorWantAccept = ffi::SSL_ERROR_WANT_ACCEPT,
 }
 
+#[allow(dead_code)]
 struct MemBioRef<'ssl> {
     ssl: &'ssl Ssl,
     bio: MemBio,


### PR DESCRIPTION
This squelches warnings from dead_code for many idiomatic structs.
This squelches warnings for non_camel_case_functions for idiomatically named fns.

With these warnings squelched, **rust-openssl** compiles cleanly.
