### PR TITLE
Add a Cargo.toml configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /doc/
 /build/
 /Makefile
+/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+
+name = "openssl"
+version = "0.0.1"
+authors = ["Steven Fackler <sfackler@gmail.com"]
+
+[[lib]]
+
+name = "openssl"
+path = "lib.rs"


### PR DESCRIPTION
Right now it doesn't support enabling v2, but once cargo supports profiles that should be possible
