### PR TITLE
Add new HashType RIPEMD160

### DIFF
--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -8,7 +8,8 @@ pub enum HashType {
     SHA224,
     SHA256,
     SHA384,
-    SHA512
+    SHA512,
+    RIPEMD160
 }
 
 #[allow(dead_code)]
@@ -39,6 +40,7 @@ extern {
     fn EVP_sha256() -> *const EVP_MD;
     fn EVP_sha384() -> *const EVP_MD;
     fn EVP_sha512() -> *const EVP_MD;
+    fn EVP_ripemd160() -> *const EVP_MD;
 
     fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, typ: *const EVP_MD);
     fn EVP_DigestUpdate(ctx: *mut EVP_MD_CTX, data: *const u8, n: c_uint);
@@ -54,6 +56,7 @@ pub fn evpmd(t: HashType) -> (*const EVP_MD, uint) {
             SHA256 => (EVP_sha256(), 32u),
             SHA384 => (EVP_sha384(), 48u),
             SHA512 => (EVP_sha512(), 64u),
+            RIPEMD160 => (EVP_ripemd160(), 20u),
         }
     }
 }
@@ -182,6 +185,17 @@ mod tests {
 
         for test in tests.iter() {
             hash_test(super::SHA256, test);
+        }
+    }
+
+    #[test]
+    fn test_ripemd160() {
+        let tests = [
+            HashTest("616263", "8eb208f7e05d987a9b044a8e98c6b087f15a0bfc")
+            ];
+
+        for test in tests.iter() {
+            hash_test(super::RIPEMD160, test);
         }
     }
 }

--- a/src/crypto/pkey.rs
+++ b/src/crypto/pkey.rs
@@ -2,7 +2,7 @@ use libc::{c_char, c_int, c_uint};
 use libc;
 use std::mem;
 use std::ptr;
-use crypto::hash::{HashType, MD5, SHA1, SHA224, SHA256, SHA384, SHA512};
+use crypto::hash::{HashType, MD5, SHA1, SHA224, SHA256, SHA384, SHA512, RIPEMD160};
 
 #[allow(non_camel_case_types)]
 pub type EVP_PKEY = *mut libc::c_void;
@@ -64,12 +64,13 @@ fn openssl_padding_code(padding: EncryptionPadding) -> c_int {
 
 fn openssl_hash_nid(hash: HashType) -> c_int {
     match hash {
-        MD5    => 4,   // NID_md5,
-        SHA1   => 64,  // NID_sha1
-        SHA224 => 675, // NID_sha224
-        SHA256 => 672, // NID_sha256
-        SHA384 => 673, // NID_sha384
-        SHA512 => 674, // NID_sha512
+        MD5       => 4,   // NID_md5,
+        SHA1      => 64,  // NID_sha1
+        SHA224    => 675, // NID_sha224
+        SHA256    => 672, // NID_sha256
+        SHA384    => 673, // NID_sha384
+        SHA512    => 674, // NID_sha512
+        RIPEMD160 => 117, // NID_ripemd160
     }
 }
 


### PR DESCRIPTION
RIPEMD-160 hashes are used in the Bitcoin protocol, and apparently (according to `man RSA_sign`) RSA signatures.
