### PR TITLE
Fix cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "openssl"
 version = "0.0.0"
 authors = ["Steven Fackler <sfackler@gmail.com"]
 
-[lib]
+[[lib]]
 
 name = "openssl"
 path = "src/lib.rs"


### PR DESCRIPTION
The latest commit to master breaks cargo (cargo 0.0.1-pre-nightly (bddcb49 2014-08-15 04:07:00 +0000)). This reverts that change.

The error message was:

```
Cargo.toml is not a valid manifest

expected a value of type `array`, but found a value of type `table` for the key `lib`
```
