### PR TITLE
Use BN_div instead of BN_mod

### DIFF
--- a/src/bn/mod.rs
+++ b/src/bn/mod.rs
@@ -34,7 +34,6 @@ extern {
     fn BN_mul(r: *mut BIGNUM, a: *mut BIGNUM, b: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;
     fn BN_sqr(r: *mut BIGNUM, a: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;
     fn BN_div(dv: *mut BIGNUM, rem: *mut BIGNUM, a: *mut BIGNUM, b: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;
-    fn BN_mod(rem: *mut BIGNUM, a: *mut BIGNUM, m: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;
     fn BN_nnmod(rem: *mut BIGNUM, a: *mut BIGNUM, m: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;
     fn BN_mod_add(r: *mut BIGNUM, a: *mut BIGNUM, b: *mut BIGNUM, m: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;
     fn BN_mod_sub(r: *mut BIGNUM, a: *mut BIGNUM, b: *mut BIGNUM, m: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;
@@ -356,7 +355,7 @@ impl BigNum {
 
     pub fn checked_mod(&self, a: &BigNum) -> Result<BigNum, SslError> {
         unsafe {
-            with_bn_in_ctx!(r, ctx, { BN_mod(r.raw(), self.raw(), a.raw(), ctx) == 1 })
+            with_bn_in_ctx!(r, ctx, { BN_div(ptr::mut_null(), r.raw(), self.raw(), a.raw(), ctx) == 1 })
         }
     }
 


### PR DESCRIPTION
BN_mod is not available on all plateform and can be replaced by BN_div with dv set as NULL.

I had an error from the linker about `_BN_mod` not found when I tried building rust-openssl. It seems like openssl 1.0.1g on OS X dosn't contain BN_mod. Will check if it is a bug in OpenSSL OS X build.

Meanwhile, an easy fix is to use instead BN_div as explained in the [man page](https://www.openssl.org/docs/crypto/BN_add.html):

```
BN_mod() corresponds to BN_div() with dv set to NULL.
```
