### PR TITLE
Fix the ambiguous integer literal error

### DIFF
--- a/src/crypto/symm.rs
+++ b/src/crypto/symm.rs
@@ -92,7 +92,7 @@ impl Crypter {
     pub fn pad(&self, padding: bool) {
         if self.blocksize > 0 {
             unsafe {
-                let v = if padding { 1 } else { 0 } as c_int;
+                let v = if padding { 1 as c_int } else { 0 };
                 EVP_CIPHER_CTX_set_padding(self.ctx, v);
             }
         }


### PR DESCRIPTION
This commit fixes this:

```
src/crypto/symm.rs:95:25: 95:52 error: cannot determine a type for
this expression: cannot determine the type of this integer; add a
suffix to specify the type explicitly [E0101]
src/crypto/symm.rs:95                 let v = if padding { 1 } else { 0 } as c_int;
```

rustc version: rustc 0.12.0-pre (566b470e1 2014-08-27 02:31:20 +0000)
