### PR TITLE
Add build and testing instructions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For some reason, the OpenSSL distribution for Windows is structured differently,
   * 32-bit: `C:\Program Files (x86)\Rust\bin\rustlib\i686-pc-mingw32\lib`
   * 64-bit: TODO
 4. Rename `libeay32.a` and `ssleay32.a` to `libcrypto.a` and `libssl.a`, respectively. 
-5. `cargo build`.
+5. Run `cargo build`.
 
 ###Testing
 Several tests expect a local test server to be running to bounce requests off of. It's easy to do this. Open a separate terminal window and `cd` to the rust-openssl directory. Then run one of the following commands:


### PR DESCRIPTION
Important: Windows dependencies and running test OpenSSL server

I originally solved the problem by moving the libs to my MinGW libs directory, but this approach does not require a MinGW install and should work in Command Prompt as well, as the rustlib folder is always added as a search path for the linker. In my experience, the Rust nightly installer did not delete or overwrite files added to the rustlib folder, so this shouldn't have to be done more than once.

Closes #41.
