### PR TITLE
Enabling TLS1.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,16 @@ language: rust
 env:
   global:
     - secure: qLvBJoJOJcPPZ+e31175O6sMUGBHgHe/kBuI0FCPeifYmpFyeRAkEvGddEkf8t3rojV+wE14CNYzzGsT/W/+JY7xW0C1FQKW3r+8SZ1Cave/8ahee0aCQVXGf0XY8c52uG6MrLGiUlNZbOsyFSdFUc/Io+kYZas4DxrinRSOIEA=
+os:
+  - osx
+  - linux
 before_script:
   - openssl s_server -accept 15418 -www -cert test/cert.pem -key test/key.pem >/dev/null &
 script:
   - cargo build
   - cargo test
   - rustdoc src/lib.rs
+  - cargo build --features "sslv2"
+  - cargo build --features "tlsv1_1 tlsv1_2"
 after_script:
   - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ authors = ["Steven Fackler <sfackler@gmail.com"]
 
 name = "openssl"
 path = "src/lib.rs"
+
+[features]
+tlsv1_2 = []
+tlsv1_1 = []
+sslv2 = []

--- a/src/ssl/ffi.rs
+++ b/src/ssl/ffi.rs
@@ -103,13 +103,14 @@ pub static X509_FILETYPE_PEM: c_int = 1;
 pub static X509_FILETYPE_ASN1: c_int = 2;
 pub static X509_FILETYPE_DEFAULT: c_int = 3;
 
-#[cfg(target_os = "macos")]
+#[cfg(target_os = "macos", feature = "tlsv1_1")]
+#[cfg(target_os = "macos", feature = "tlsv1_2")]
 #[link(name="ssl.1.0.0")]
 #[link(name="crypto.1.0.0")]
 extern {}
 
-
 #[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "macos", not(feature = "tlsv1_1"), not(feature = "tlsv1_2"))]
 #[link(name="ssl")]
 #[link(name="crypto")]
 extern {}
@@ -125,11 +126,13 @@ extern "C" {
 
     pub fn SSL_library_init() -> c_int;
 
-    #[cfg(sslv2)]
+    #[cfg(feature = "sslv2")]
     pub fn SSLv2_method() -> *const SSL_METHOD;
     pub fn SSLv3_method() -> *const SSL_METHOD;
     pub fn TLSv1_method() -> *const SSL_METHOD;
+    #[cfg(feature = "tlsv1_1")]
     pub fn TLSv1_1_method() -> *const SSL_METHOD;
+    #[cfg(feature = "tlsv1_2")]
     pub fn TLSv1_2_method() -> *const SSL_METHOD;
     pub fn SSLv23_method() -> *const SSL_METHOD;
 

--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -50,7 +50,7 @@ fn init() {
 #[deriving(Show, Hash, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 pub enum SslMethod {
-    #[cfg(sslv2)]
+    #[cfg(feature = "sslv2")]
     /// Only support the SSLv2 protocol
     Sslv2,
     /// Only support the SSLv3 protocol
@@ -59,19 +59,23 @@ pub enum SslMethod {
     Tlsv1,
     /// Support the SSLv2, SSLv3 and TLSv1 protocols
     Sslv23,
+    #[cfg(feature = "tlsv1_1")]
     Tlsv1_1,
+    #[cfg(feature = "tlsv1_2")]
     Tlsv1_2,
 }
 
 impl SslMethod {
     unsafe fn to_raw(&self) -> *const ffi::SSL_METHOD {
         match *self {
-            #[cfg(sslv2)]
+            #[cfg(feature = "sslv2")]
             Sslv2 => ffi::SSLv2_method(),
             Sslv3 => ffi::SSLv3_method(),
             Tlsv1 => ffi::TLSv1_method(),
             Sslv23 => ffi::SSLv23_method(),
+            #[cfg(feature = "tlsv1_1")]
             Tlsv1_1 => ffi::TLSv1_1_method(),
+            #[cfg(feature = "tlsv1_2")]
             Tlsv1_2 => ffi::TLSv1_2_method()
         }
     }


### PR DESCRIPTION
Unfortunately OS X comes with 0.9.8 bundled. There is a way to
install a recent version through homebrew, however it is
extremely hard to make it link agains brewed version without
tricking link version
