### PR TITLE
Server Support

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -403,6 +403,7 @@ extern "C" {
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
     pub fn SSL_get_rbio(ssl: *mut SSL) -> *mut BIO;
     pub fn SSL_get_wbio(ssl: *mut SSL) -> *mut BIO;
+    pub fn SSL_accept(ssl: *mut SSL) -> c_int;
     pub fn SSL_connect(ssl: *mut SSL) -> c_int;
     pub fn SSL_ctrl(ssl: *mut SSL, cmd: c_int, larg: c_long,
                     parg: *mut c_void) -> c_long;


### PR DESCRIPTION
This is quickly hacked on to the existing client support and, while the implementation is less than ideal, it is functional.

Prominently, I'm not using rust's type system to ensure that an ssl ctx initialized with a server method is actually used as a server, which means we have the potential for errors at runtime (from openssl) when we could probably catch them at build time.
