### PR TITLE
Fix #65: failing test case

### DIFF
--- a/src/ssl/error.rs
+++ b/src/ssl/error.rs
@@ -42,8 +42,8 @@ fn get_reason(err: c_ulong) -> String {
 }
 
 #[test]
-#[ignore] // FIXME #65
 fn test_uknown_error_should_have_correct_messages() {
+    unsafe { ffi::SSL_load_error_strings(); }
     let err = 336032784;
     let library = get_lib(err);
     let function = get_func(err);

--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -25,7 +25,7 @@ fn init() {
         INIT.doit(|| {
             ffi::SSL_library_init();
             ffi::SSL_load_error_strings();
-            ffi::ERR_load_crypto_strings();
+            ffi::ERR_load_crypto_strings(); // necessary?
             let verify_idx = ffi::SSL_CTX_get_ex_new_index(0, ptr::null(), None,
                                                            None, None);
             assert!(verify_idx >= 0);


### PR DESCRIPTION
I fixed the failing test case, and added a question about the need to call `load_crypto_strings`.
