### PR TITLE
Using `Path`s instead of plain strings

### DIFF
--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -248,7 +248,7 @@ impl SslContext {
 
     #[allow(non_snake_case)]
     /// Specifies the file that contains trusted CA certificates.
-    pub fn set_CA_file(&mut self, file: &str) -> Option<SslError> {
+    pub fn set_CA_file(&mut self, file: &Path) -> Option<SslError> {
         wrap_ssl_result(file.with_c_str(|file| {
             unsafe {
                 ffi::SSL_CTX_load_verify_locations(self.ctx, file, ptr::null())
@@ -257,7 +257,7 @@ impl SslContext {
     }
 
     /// Specifies the file that is client certificate
-    pub fn set_certificate_file(&mut self, file: &str,
+    pub fn set_certificate_file(&mut self, file: &Path,
                                 file_type: X509FileType) -> Option<SslError> {
         wrap_ssl_result(file.with_c_str(|file| {
             unsafe {
@@ -267,7 +267,7 @@ impl SslContext {
     }
 
     /// Specifies the file that is client private key
-    pub fn set_private_key_file(&mut self, file: &str,
+    pub fn set_private_key_file(&mut self, file: &Path,
                                 file_type: X509FileType) -> Option<SslError> {
         wrap_ssl_result(file.with_c_str(|file| {
             unsafe {

--- a/src/ssl/tests.rs
+++ b/src/ssl/tests.rs
@@ -34,7 +34,7 @@ fn test_verify_trusted() {
     let stream = TcpStream::connect("127.0.0.1", 15418).unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
     ctx.set_verify(SslVerifyPeer, None);
-    match ctx.set_CA_file("test/cert.pem") {
+    match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => fail!("Unexpected error {}", err)
     }
@@ -77,7 +77,7 @@ fn test_verify_trusted_callback_override_ok() {
     let stream = TcpStream::connect("127.0.0.1", 15418).unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
     ctx.set_verify(SslVerifyPeer, Some(callback));
-    match ctx.set_CA_file("test/cert.pem") {
+    match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => fail!("Unexpected error {}", err)
     }
@@ -95,7 +95,7 @@ fn test_verify_trusted_callback_override_bad() {
     let stream = TcpStream::connect("127.0.0.1", 15418).unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
     ctx.set_verify(SslVerifyPeer, Some(callback));
-    match ctx.set_CA_file("test/cert.pem") {
+    match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => fail!("Unexpected error {}", err)
     }
@@ -123,7 +123,7 @@ fn test_verify_trusted_get_error_ok() {
     let stream = TcpStream::connect("127.0.0.1", 15418).unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
     ctx.set_verify(SslVerifyPeer, Some(callback));
-    match ctx.set_CA_file("test/cert.pem") {
+    match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => fail!("Unexpected error {}", err)
     }


### PR DESCRIPTION
Refs #45
