### PR TITLE
BN_is_zero as a Rust function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@
 name = "openssl"
 version = "0.0.0"
 authors = ["Steven Fackler <sfackler@gmail.com"]
-build = "make"
 
 [lib]
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-ifneq ($(findstring i686,$(TARGET)),)
-	CFLAGS += -m32
-else
-	CFLAGS += -m64
-endif
-
-default:
-	$(CC) $(CFLAGS) -c native/bn_is_zero.c -o $(OUT_DIR)/bn_is_zero.o
-	$(AR) crus $(OUT_DIR)/libwrapped.a $(OUT_DIR)/bn_is_zero.o

--- a/src/bn/mod.rs
+++ b/src/bn/mod.rs
@@ -1,10 +1,20 @@
-use libc::{c_int, c_ulong};
+use libc::{c_int, c_ulong, c_void};
 use std::{fmt, ptr};
 use std::c_str::CString;
 use std::num::{One, Zero};
 
 use ffi;
 use ssl::error::SslError;
+
+#[allow(dead_code)]
+#[repr(C)]
+pub struct BIGNUM {
+    d: *mut c_void,
+    top: c_int,
+    dmax: c_int,
+    neg: c_int,
+    flags: c_int,
+}
 
 pub struct BigNum(*mut ffi::BIGNUM);
 
@@ -381,9 +391,11 @@ impl Zero for BigNum {
     fn zero() -> BigNum {
         BigNum::new_from(0).unwrap()
     }
+
     fn is_zero(&self) -> bool {
         unsafe {
-            ffi::BN_is_zero(self.raw()) == 1
+            // It is raw contents of BN_is_zero macro
+            (*self.raw()).top == 0
         }
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,6 +3,8 @@
 use libc::{c_void, c_int, c_char, c_ulong, c_long, c_uint, c_uchar, size_t};
 use std::ptr;
 
+pub use bn::BIGNUM;
+
 pub type ASN1_INTEGER = c_void;
 pub type ASN1_STRING = c_void;
 pub type ASN1_TIME = c_void;
@@ -27,16 +29,6 @@ pub type X509_EXTENSION = c_void;
 pub type X509_NAME = c_void;
 pub type X509_REQ = c_void;
 pub type X509_STORE_CTX = c_void;
-
-#[allow(dead_code)]
-#[repr(C)]
-pub struct BIGNUM {
-    d: *mut c_void,
-    top: c_int,
-    dmax: c_int,
-    pub neg: c_int,
-    flags: c_int,
-}
 
 #[repr(C)]
 pub struct EVP_MD_CTX {
@@ -188,15 +180,6 @@ extern {}
 #[link(name="gdi32")]
 #[link(name="wsock32")]
 extern { }
-
-/* Since the openssl BN_is_zero is sometimes a macro, this wrapper is necessary. */
-pub unsafe fn BN_is_zero(a: *mut BIGNUM) -> c_int { bn_is_zero(a) }
-
-/* Special import from native/bn_is_zero.c */
-#[link(name = "wrapped", kind = "static")]
-extern "C" {
-    pub fn bn_is_zero(a: *mut BIGNUM) -> c_int;
-}
 
 // Functions converted from macros
 pub unsafe fn BIO_eof(b: *mut BIO) -> bool {

--- a/src/ssl/tests.rs
+++ b/src/ssl/tests.rs
@@ -237,16 +237,3 @@ fn test_cert_gen() {
     // FIXME: check data in result to be correct, needs implementation
     // of X509 getters
 }
-
-#[test]
-fn test_bn_is_zero() {
-    use ffi;
-    use std::ptr;
-
-    unsafe {
-        let bn = ffi::BN_new();
-        assert!(bn != ptr::null_mut());
-        // Just make sure it is linked and resolved correctly
-        ffi::BN_is_zero(bn);
-    }
-}


### PR DESCRIPTION
Although wrapping was relatively easy it basically meant
that we depend on C compilation which becomes nightmare
as soon as multiple platforms are used. I’ve got a huge pain
once iOS was involved with 3 device archs and 2 simulator 
arches to support, not mentioning different set of include 
and lib flags.

So there are 2 different approaches:
- continue this way, maintaining all compilation issues like
  like managing correct flags, providing correct paths and so
  on. This way our Makefile will grow extremely fast and will
  actually take more efforts to maintain.
- doing it pure Rust way. In this case we provide all the 
  macros expansions inside our wrappers and there should be
  no other way to access raw data other than through those 
  wrappers. It might be fragile if OpenSSL internal data 
  structures will ever change, but I think (or hope) it is 
  pretty stable and wouldn’t change anytime soon.

This PR eliminates `BN_is_zero` at all from public API. It’s
functionality is implemented in `BigNum.is_zero` and should 
be enough. 

Additional notes:
1. I’ve moved `BIGNUM` into `bn` so it could access fields
   directly and keep it as an opaque structure for everyone 
   else
2. I’ve kept empty `Makefile` as I hope to land `feature-matrix`
   branch soon and I don’t like merging deleted/added file 
   conflicts.
