### PR TITLE
Refactor code around initialization and error strings.

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 use libc::{c_void, c_int, c_char, c_ulong, c_long, c_uint, c_uchar, size_t};
 use std::ptr;
+use sync::one::{Once, ONCE_INIT};
 
 pub use bn::BIGNUM;
 
@@ -180,6 +181,17 @@ extern {}
 #[link(name="gdi32")]
 #[link(name="wsock32")]
 extern { }
+
+pub fn init() {
+    static mut INIT: Once = ONCE_INIT;
+
+    unsafe {
+        INIT.doit(|| {
+            SSL_library_init();
+            SSL_load_error_strings()
+        })
+    }
+}
 
 // Functions converted from macros
 pub unsafe fn BIO_eof(b: *mut BIO) -> bool {

--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -23,9 +23,8 @@ fn init() {
 
     unsafe {
         INIT.doit(|| {
-            ffi::SSL_library_init();
-            ffi::SSL_load_error_strings();
-            ffi::ERR_load_crypto_strings();
+            ffi::init();
+
             let verify_idx = ffi::SSL_CTX_get_ex_new_index(0, ptr::null(), None,
                                                            None, None);
             assert!(verify_idx >= 0);


### PR DESCRIPTION
@vhbit I implemented my interpretation of the conversation on #65. I'm not familiar with any other locations that we should invoke: `ffi::init()`. I moved the statics that init relies on into `ffi.rs` as well, let me know if something else is preferred. I got two successful builds back on my fork, hopefully there are no more build issues. 
