### PR TITLE
Correct init mutexes and locking function

### DIFF
--- a/src/asn1/mod.rs
+++ b/src/asn1/mod.rs
@@ -20,6 +20,8 @@ impl Asn1Time {
     }
 
     fn new_with_period(period: u64) -> Result<Asn1Time, SslError> {
+        ffi::init();
+
         let handle = unsafe {
             try_ssl_null!(ffi::X509_gmtime_adj(ptr::null_mut(),
                                                period as c_long))

--- a/src/bio/mod.rs
+++ b/src/bio/mod.rs
@@ -24,6 +24,8 @@ impl Drop for MemBio {
 impl MemBio {
     /// Creates a new owned memory based BIO
     pub fn new() -> Result<MemBio, SslError> {
+        ffi::init();
+
         let bio = unsafe { ffi::BIO_new(ffi::BIO_s_mem()) };
         try_ssl_null!(bio);
 

--- a/src/bn/mod.rs
+++ b/src/bn/mod.rs
@@ -79,8 +79,10 @@ macro_rules! with_bn_in_ctx(
 )
 
 impl BigNum {
+    // FIXME: squash 3 constructors into one
     pub fn new() -> Result<BigNum, SslError> {
         unsafe {
+            ffi::init();
             let v = ffi::BN_new();
             if v.is_null() {
                 Err(SslError::get())
@@ -92,6 +94,7 @@ impl BigNum {
 
     pub fn new_from(n: u64) -> Result<BigNum, SslError> {
         unsafe {
+            ffi::init();
             let bn = ffi::BN_new();
             if bn.is_null() || ffi::BN_set_word(bn, n as c_ulong) == 0 {
                 Err(SslError::get())
@@ -103,6 +106,7 @@ impl BigNum {
 
     pub fn new_from_slice(n: &[u8]) -> Result<BigNum, SslError> {
         unsafe {
+            ffi::init();
             let bn = ffi::BN_new();
             if bn.is_null() || ffi::BN_bin2bn(n.as_ptr(), n.len() as c_int, bn).is_null() {
                 Err(SslError::get())

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -36,6 +36,8 @@ pub struct Hasher {
 
 impl Hasher {
     pub fn new(ht: HashType) -> Hasher {
+        ffi::init();
+
         let ctx = unsafe { ffi::EVP_MD_CTX_create() };
         let (evp, mdlen) = evpmd(ht);
         unsafe {

--- a/src/crypto/hmac.rs
+++ b/src/crypto/hmac.rs
@@ -27,6 +27,8 @@ pub struct HMAC {
 #[allow(non_snake_case)]
 pub fn HMAC(ht: hash::HashType, key: &[u8]) -> HMAC {
     unsafe {
+        ffi::init();
+
         let (evp, mdlen) = hash::evpmd(ht);
 
         let mut ctx : ffi::HMAC_CTX = ::std::mem::uninitialized();

--- a/src/crypto/pkcs5.rs
+++ b/src/crypto/pkcs5.rs
@@ -9,6 +9,8 @@ pub fn pbkdf2_hmac_sha1(pass: &str, salt: &[u8], iter: uint, keylen: uint) -> Ve
 
         let mut out = Vec::with_capacity(keylen);
 
+        ffi::init();
+
         let r = ffi::PKCS5_PBKDF2_HMAC_SHA1(
                 pass.as_ptr(), pass.len() as c_int,
                 salt.as_ptr(), salt.len() as c_int,

--- a/src/crypto/pkey.rs
+++ b/src/crypto/pkey.rs
@@ -55,6 +55,8 @@ pub struct PKey {
 impl PKey {
     pub fn new() -> PKey {
         unsafe {
+            ffi::init();
+
             PKey {
                 evp: ffi::EVP_PKEY_new(),
                 parts: Neither,

--- a/src/crypto/rand.rs
+++ b/src/crypto/rand.rs
@@ -5,6 +5,7 @@ pub fn rand_bytes(len: uint) -> Vec<u8> {
     unsafe {
         let mut out = Vec::with_capacity(len);
 
+        ffi::init();
         let r = ffi::RAND_bytes(out.as_mut_ptr(), len as c_int);
         if r != 1 as c_int { fail!() }
 

--- a/src/crypto/symm.rs
+++ b/src/crypto/symm.rs
@@ -50,6 +50,8 @@ pub struct Crypter {
 
 impl Crypter {
     pub fn new(t: Type) -> Crypter {
+        ffi::init();
+
         let ctx = unsafe { ffi::EVP_CIPHER_CTX_new() };
         let (evp, keylen, blocksz) = evpc(t);
         Crypter { evp: evp, ctx: ctx, keylen: keylen, blocksize: blocksz }

--- a/src/x509/mod.rs
+++ b/src/x509/mod.rs
@@ -272,6 +272,8 @@ impl X509Generator {
 
     /// Generates a private key and a signed certificate and returns them
     pub fn generate<'a>(&self) -> Result<(X509<'a>, PKey), SslError> {
+        ffi::init();
+
         let mut p_key = PKey::new();
         p_key.gen(self.bits);
 


### PR DESCRIPTION
`libcrypto` uses locks quite intensively even without SSL. 
So they should be initialized before everything else to 
function properly in multi-threaded apps in which SSL 
operations are absent or delayed.

Finishes #79
