### PR TITLE
x509: add the api needed to obtain entries by nid

### DIFF
--- a/src/bn/mod.rs
+++ b/src/bn/mod.rs
@@ -369,7 +369,7 @@ impl BigNum {
             assert!(!buf.is_null());
             let c_str = CString::new(buf, false);
             let str = c_str.as_str().unwrap().to_string();
-            ffi::CRYPTO_free(buf);
+            ffi::CRYPTO_free(buf as *mut c_void);
             str
         }
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -275,7 +275,7 @@ extern "C" {
                                                            n: c_int,
                                                            file: *const c_char,
                                                            line: c_int));
-    pub fn CRYPTO_free(buf: *const c_char);
+    pub fn CRYPTO_free(buf: *mut c_void);
     pub fn CRYPTO_memcmp(a: *const c_void, b: *const c_void,
                          len: size_t) -> c_int;
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -28,6 +28,7 @@ pub type X509 = c_void;
 pub type X509_CRL = c_void;
 pub type X509_EXTENSION = c_void;
 pub type X509_NAME = c_void;
+pub type X509_NAME_ENTRY = c_void;
 pub type X509_REQ = c_void;
 pub type X509_STORE_CTX = c_void;
 
@@ -166,6 +167,193 @@ pub const X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE: c_int = 51;
 pub const X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE: c_int = 45;
 pub const X509_V_ERR_UNSUPPORTED_NAME_SYNTAX: c_int = 53;
 pub const X509_V_OK: c_int = 0;
+
+pub mod nid {
+    use std::mem;
+    use std::collections::enum_set::CLike;
+
+    #[allow(dead_code)]
+    #[allow(non_camel_case_types)]
+    #[repr(uint)]
+    pub enum Nid {
+        Undefined,
+        Rsadsi,
+        Pkcs,
+        MD2,
+        MD4,
+        MD5,
+        RC4,
+        RsaEncryption,
+        RSA_MD2,
+        RSA_MD5,
+        PBE_MD2_DES,
+        X500,
+        x509,
+        CN,
+        C,
+        L,
+        ST,
+        O,
+        OU,
+        RSA,
+        Pkcs7,
+        Pkcs7_data,
+        Pkcs7_signedData,
+        Pkcs7_envelopedData,
+        Pkcs7_signedAndEnvelopedData,
+        Pkcs7_digestData,
+        Pkcs7_encryptedData,
+        Pkcs3,
+        DhKeyAgreement,
+        DES_ECB,
+        DES_CFB,
+        DES_CBC,
+        DES_EDE,
+        DES_EDE3,
+        IDEA_CBC,
+        IDEA_ECB,
+        RC2_CBC,
+        RC2_ECB,
+        RC2_CFB,
+        RC2_OFB,
+        SHA,
+        RSA_SHA,
+        DES_EDE_CBC,
+        DES_EDE3_CBC,
+        DES_OFB,
+        IDEA_OFB,
+        Pkcs9,
+        Email,
+        UnstructuredName,
+        ContentType,
+        MessageDigest,
+        SigningTime,
+        CounterSignature,
+        UnstructuredAddress,
+        ExtendedCertificateAttributes,
+        Netscape,
+        NetscapeCertExtention,
+        NetscapeDatatype,
+        DES_EDE_CFB64,
+        DES_EDE3_CFB64,
+        DES_EDE_OFB64,
+        DES_EDE3_OFB64,
+        SHA1,
+        RSA_SHA1,
+        DSA_SHA,
+        DSA_OLD,
+        PBE_SHA1_RC2_64,
+        PBKDF2,
+        DSA_SHA1_OLD,
+        NetscapeCertType,
+        NetscapeBaseUrl,
+        NetscapeRevocationUrl,
+        NetscapeCARevocationUrl,
+        NetscapeRenewalUrl,
+        NetscapeCAPolicyUrl,
+        NetscapeSSLServerName,
+        NetscapeComment,
+        NetscapeCertSequence,
+        DESX_CBC,
+        ID_CE,
+        SubjectKeyIdentifier,
+        KeyUsage,
+        PrivateKeyUsagePeriod,
+        SubjectAltName,
+        IssuerAltName,
+        BasicConstraints,
+        CrlNumber,
+        CertificatePolicies,
+        AuthorityKeyIdentifier,
+        BF_CBC,
+        BF_ECB,
+        BF_OFB,
+        MDC2,
+        RSA_MDC2,
+        RC4_40,
+        RC2_40_CBC,
+        G,
+        S,
+        I,
+        UID,
+        CrlDistributionPoints,
+        RSA_NP_MD5,
+        SN,
+        T,
+        D,
+        CAST5_CBC,
+        CAST5_ECB,
+        CAST5_CFB,
+        CAST5_OFB,
+        PbeWithMD5AndCast5CBC,
+        DSA_SHA1, // 113
+        MD5_SHA1,
+        RSA_SHA1_2,
+        DSA,
+        RIPEMD160,
+        RSA_RIPEMD160,
+        RC5_CBC,
+        RC5_ECB,
+        RC5_CFB,
+        RC5_OFB,
+        RLE,
+        ZLIB,
+        ExtendedKeyUsage,
+        PKIX,
+        ID_KP,
+        ServerAuth,
+        ClientAuth,
+        CodeSigning,
+        EmailProtection,
+        TimeStamping,
+        MsCodeInd,
+        MsCodeCom,
+        MsCtlSigh,
+        MsSGC,
+        MsEFS,
+        NsSGC,
+        DeltaCRL,
+        CRLReason,
+        InvalidityDate,
+        SXNetID,
+        Pkcs12,
+        PBE_SHA1_RC4_128,
+        PBE_SHA1_RC4_40,
+        PBE_SHA1_3DES,
+        PBE_SHA1_2DES,
+        PBE_SHA1_RC2_128,
+        PBE_SHA1_RC2_40,
+        KeyBag,
+        Pkcs8ShroudedKeyBag,
+        CertBag,
+        CrlBag,
+        SecretBag,
+        SafeContentsBag,
+        FriendlyName,
+        LocalKeyID,
+        X509Certificate,
+        SdsiCertificate,
+        X509Crl,
+        PBES2,
+        PBMAC1,
+        HmacWithSha1,
+        ID_QT_CPS,
+        ID_QT_UNOTICE,
+        RC2_64_CBC,
+        SMIMECaps,
+
+    }
+
+    impl CLike for Nid {
+        fn to_uint(&self) -> uint {
+            *self as uint
+        }
+
+        fn from_uint(v: uint) -> Nid {
+            unsafe { mem::transmute(v) }
+        }
+    }
+}
 
 #[cfg( any( all(target_os = "macos", feature = "tlsv1_1"),all(target_os = "macos", feature = "tlsv1_2")))]
 #[link(name="ssl.1.0.0")]
@@ -426,6 +614,11 @@ extern "C" {
     pub fn X509_EXTENSION_free(ext: *mut X509_EXTENSION);
 
     pub fn X509_NAME_add_entry_by_txt(x: *mut X509, field: *const c_char, ty: c_int, bytes: *const c_char, len: c_int, loc: c_int, set: c_int) -> c_int;
+    pub fn X509_NAME_get_index_by_NID(n: *mut X509_NAME, nid: c_int, last_pos: c_int) ->c_int;
+    pub fn X509_NAME_get_entry(n: *mut X509_NAME, loc: c_int) -> *mut X509_NAME_ENTRY;
+    pub fn X509_NAME_ENTRY_get_data(ne: *mut X509_NAME_ENTRY) -> *mut ASN1_STRING;
+
+    pub fn ASN1_STRING_to_UTF8(out: *mut *mut c_char, s: *mut ASN1_STRING) -> c_int;
 
     pub fn X509_STORE_CTX_get_current_cert(ct: *mut X509_STORE_CTX) -> *mut X509;
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> c_int;

--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -513,3 +513,4 @@ impl<S: Stream> Writer for SslStream<S> {
         self.stream.flush()
     }
 }
+

--- a/src/x509/mod.rs
+++ b/src/x509/mod.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, c_long, c_uint};
+use libc::{c_int, c_long, c_uint, c_void, c_char};
 use std::mem;
 use std::ptr;
 
@@ -9,7 +9,79 @@ use crypto::pkey::{PKey};
 use crypto::rand::rand_bytes;
 use ffi;
 use ssl::error::{SslError, StreamError};
+use std::c_str::CString;
+use std::collections::enum_set::CLike;
 
+pub use ffi::nid as nid;
+
+#[allow(dead_code)]
+pub struct X509Name<'x> {
+    x509: &'x ffi::X509,
+    name: *mut ffi::X509_NAME
+}
+
+#[allow(dead_code)]
+pub struct X509NameEntry<'x> {
+    x509_name: &'x X509Name<'x>,
+    ne: *mut ffi::X509_NAME_ENTRY
+}
+
+#[allow(dead_code)]
+pub struct Asn1String<'x> {
+    x509_name_entry: &'x X509NameEntry<'x>,
+    asn1_str: *mut ffi::ASN1_STRING
+}
+
+#[deriving(Show)]
+pub struct SslCString {
+    c_str : CString
+}
+
+impl Drop for SslCString {
+    fn drop(&mut self) {
+        unsafe { ffi::CRYPTO_free(self.c_str.as_mut_ptr() as *mut c_void); }
+    }
+}
+
+impl SslCString {
+    pub unsafe fn new(buf: *const i8) -> SslCString {
+        SslCString {
+            c_str : CString::new(buf, false)
+        }
+    }
+}
+
+impl <'x> X509Name<'x> {
+    pub fn text_by_nid(&self, nid: nid::Nid) -> Option<SslCString> {
+        unsafe {
+            let loc = ffi::X509_NAME_get_index_by_NID(self.name, nid.to_uint() as c_int, -1);
+            if loc == -1 {
+                return None;
+            }
+
+            let ne = ffi::X509_NAME_get_entry(self.name, loc);
+            if ne.is_null() {
+                return None;
+            }
+
+            let asn1_str = ffi::X509_NAME_ENTRY_get_data(ne);
+            if asn1_str.is_null() {
+                return None;
+            }
+
+            let mut str_from_asn1 : *mut c_char = ptr::null_mut();
+            let utf8_succ = ffi::ASN1_STRING_to_UTF8(&mut str_from_asn1, asn1_str);
+
+            if utf8_succ < 0 {
+                return None
+            }
+
+            assert!(!str_from_asn1.is_null());
+
+            Some(SslCString::new(str_from_asn1 as *const i8))
+        }
+    }
+}
 
 #[repr(i32)]
 pub enum X509FileType {


### PR DESCRIPTION
Also includes a large list of nids (from openssl/object.h). Might be
transcoding errors on my part there.