### PR TITLE
Cert loading from PEM & restructuring

### DIFF
--- a/src/crypto/pkey.rs
+++ b/src/crypto/pkey.rs
@@ -142,7 +142,7 @@ impl PKey {
         let mut mem_bio = try!(MemBio::new());
         unsafe {
             try_ssl!(ffi::PEM_write_bio_PrivateKey(mem_bio.get_handle(), self.evp, ptr::null(),
-                                                   ptr::null_mut(), -1, ptr::null_mut(), ptr::null_mut()));
+                                                   ptr::null_mut(), -1, None, ptr::null_mut()));
 
         }
         let buf = try!(mem_bio.read_to_end().map_err(StreamError));

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -76,9 +76,9 @@ pub type CRYPTO_EX_dup = extern "C" fn(to: *mut CRYPTO_EX_DATA,
 pub type CRYPTO_EX_free = extern "C" fn(parent: *mut c_void, ptr: *mut c_void,
                                         ad: *mut CRYPTO_EX_DATA, idx: c_int,
                                         argl: c_long, argp: *mut c_void);
-pub type PrivateKeyWriteCallback = extern "C" fn(buf: *mut c_char, size: c_int,
-                                                 rwflag: c_int, user_data: *mut c_void)
-                                                 -> c_int;
+pub type PasswordCallback = extern "C" fn(buf: *mut c_char, size: c_int,
+                                          rwflag: c_int, user_data: *mut c_void)
+                                          -> c_int;
 
 pub const BIO_CTRL_EOF: c_int = 2;
 
@@ -356,9 +356,12 @@ extern "C" {
     pub fn HMAC_Final(ctx: *mut HMAC_CTX, output: *mut u8, len: *mut c_uint);
     pub fn HMAC_Update(ctx: *mut HMAC_CTX, input: *const u8, len: c_uint);
 
+
+    pub fn PEM_read_bio_X509(bio: *mut BIO, out: *mut *mut X509, callback: Option<PasswordCallback>,
+                             user_data: *mut c_void) -> *mut X509;
     pub fn PEM_write_bio_PrivateKey(bio: *mut BIO, pkey: *mut EVP_PKEY, cipher: *const EVP_CIPHER,
                                     kstr: *mut c_char, klen: c_int,
-                                    callback: *mut c_void,
+                                    callback: Option<PasswordCallback>,
                                     user_data: *mut c_void) -> c_int;
     pub fn PEM_write_bio_X509(bio: *mut BIO, x509: *mut X509) -> c_int;
 

--- a/src/x509/tests.rs
+++ b/src/x509/tests.rs
@@ -1,0 +1,49 @@
+use serialize::hex::FromHex;
+use std::io::{File, Open, Read};
+use std::io::util::NullWriter;
+
+use crypto::hash::{SHA256};
+use x509::{X509, X509Generator, DigitalSignature, KeyEncipherment, ClientAuth, ServerAuth};
+
+#[test]
+fn test_cert_gen() {
+    let gen = X509Generator::new()
+        .set_bitlength(2048)
+        .set_valid_period(365*2)
+        .set_CN("test_me")
+        .set_sign_hash(SHA256)
+        .set_usage([DigitalSignature, KeyEncipherment])
+        .set_ext_usage([ClientAuth, ServerAuth]);
+
+    let res = gen.generate();
+    assert!(res.is_ok());
+
+    let (cert, pkey) = res.unwrap();
+
+    let mut writer = NullWriter;
+    assert!(cert.write_pem(&mut writer).is_ok());
+    assert!(pkey.write_pem(&mut writer).is_ok());
+
+    // FIXME: check data in result to be correct, needs implementation
+    // of X509 getters
+}
+
+#[test]
+fn test_cert_loading() {
+    let cert_path = Path::new("test/cert.pem");
+    let mut file = File::open_mode(&cert_path, Open, Read)
+        .ok()
+        .expect("Failed to open `test/cert.pem`");
+
+    let cert = X509::from_pem(&mut file).ok().expect("Failed to load PEM");
+    let fingerprint = cert.fingerprint(SHA256).unwrap();
+
+    // Hash was generated as SHA256 hash of certificate "test/cert.pem"
+    // in DER format.
+    // Command: openssl x509 -in test/cert.pem  -outform DER | openssl dgst -sha256
+    // Please update if "test/cert.pem" will ever change
+    let hash_str = "6204f6617e1af7495394250655f43600cd483e2dfc2005e92d0fe439d0723c34";
+    let hash_vec = hash_str.from_hex().unwrap();
+
+    assert_eq!(fingerprint.as_slice(), hash_vec.as_slice());
+}


### PR DESCRIPTION
- Added cert loading
- Extracted X509 tests
- Extracted `hash_str_to_vec` function into `utils.rs` as it is used
  in a couple of tests now
- Fixed `hash_str_to_vec`, funny enough prev test with it was working
  because I’ve made another mistake by providing VerifyNone instead of
  VerifyPeer and those 2 mistakes compensated each other. Since
  `hash_str_to_vec` is private there was no errors on client code
