### PR TITLE
crypto/hash: impl Writer for Hasher to allow use of Reader-Writer convenience functions

### DIFF
--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -120,6 +120,12 @@ mod tests {
         assert!(calced == hashtest.expected_output);
     }
 
+    pub fn hash_writer(t: super::HashType, data: &[u8]) -> Vec<u8> {
+        let mut h = super::Hasher::new(t);
+        h.write(data);
+        h.finalize()
+    }
+
     // Test vectors from http://www.nsrl.nist.gov/testdata/
     #[test]
     fn test_md5() {
@@ -174,5 +180,12 @@ mod tests {
         for test in tests.iter() {
             hash_test(super::RIPEMD160, test);
         }
+    }
+
+    #[test]
+    fn test_writer() {
+        let tv = "rust-openssl".as_bytes();
+        let ht = super::RIPEMD160;
+        assert!(hash_writer(ht, tv) == super::hash(ht, tv));
     }
 }


### PR DESCRIPTION
It might make sense to get rid of update() entirely and just implement write() directly, but for now I've kept it.
