### PR TITLE
New build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /doc/
-/target/
-/Cargo.lock
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,28 +4,27 @@ name = "openssl"
 version = "0.0.1"
 authors = ["Steven Fackler <sfackler@gmail.com"]
 
-[lib]
-
-name = "openssl"
-path = "src/lib.rs"
-
 [features]
-tlsv1_2 = []
-tlsv1_1 = []
-sslv2 = []
+tlsv1_2 = ["openssl-sys/tlsv1_2"]
+tlsv1_1 = ["openssl-sys/tlsv1_1"]
+sslv2 = ["openssl-sys/sslv2"]
 
 [target.i686-apple-darwin.dependencies.openssl-sys]
-  git = "https://github.com/alexcrichton/openssl-sys"
+  path = "openssl-sys"
 [target.x86_64-apple-darwin.dependencies.openssl-sys]
-  git = "https://github.com/alexcrichton/openssl-sys"
+  path = "openssl-sys"
 [target.i686-unknown-linux-gnu.dependencies.openssl-sys]
-  git = "https://github.com/alexcrichton/openssl-sys"
+  path = "openssl-sys"
 [target.x86_64-unknown-linux-gnu.dependencies.openssl-sys]
-  git = "https://github.com/alexcrichton/openssl-sys"
+  path = "openssl-sys"
 [target.i686-unknown-freebsd.dependencies.openssl-sys]
-  git = "https://github.com/alexcrichton/openssl-sys"
+  path = "openssl-sys"
 [target.x86_64-unknown-freebsd.dependencies.openssl-sys]
-  git = "https://github.com/alexcrichton/openssl-sys"
+  path = "openssl-sys"
+[target.arm-apple-ios.dependencies.openssl-sys]
+  path = "openssl-sys"
+[target.i386-apple-ios.dependencies.openssl-sys]
+  path = "openssl-sys"
 
 [target.le32-unknown-nacl.dependencies.libressl-pnacl-sys]
 git = "https://github.com/DiamondLovesYou/libressl-pnacl-sys.git"

--- a/THIRD_PARTY
+++ b/THIRD_PARTY
@@ -1,0 +1,27 @@
+openssl-sys
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+
+name = "openssl-sys"
+version = "0.0.1"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+links = "openssl"
+build = "src/build.rs"
+
+[features]
+tlsv1_2 = []
+tlsv1_1 = []
+sslv2 = []
+
+[build-dependencies.pkg-config]
+git = "https://github.com/alexcrichton/pkg-config-rs"

--- a/openssl-sys/LICENSE-MIT
+++ b/openssl-sys/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/openssl-sys/src/build.rs
+++ b/openssl-sys/src/build.rs
@@ -1,0 +1,22 @@
+extern crate "pkg-config" as pkg_config;
+
+use std::os;
+
+fn main() {
+    if pkg_config::find_library("openssl").is_err() {
+        let mut flags = " -l crypto -l ssl".to_string();
+
+        let target = os::getenv("TARGET").unwrap();
+
+        let win_pos = target.find_str("windows")
+                            .or(target.find_str("win32"))
+                            .or(target.find_str("win64"));
+
+        // It's fun, but it looks like win32 and win64 both
+        // have all the libs with 32 sufix
+        if win_pos.is_some() {
+           flags.push_str(" -l gdi32 -l wsock32");
+        }
+        println!("cargo:rustc-flags={}", flags);
+    }
+}

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1,5 +1,9 @@
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
 #![allow(dead_code)]
+
+extern crate libc;
+extern crate sync;
+
 use libc::{c_void, c_int, c_char, c_ulong, c_long, c_uint, c_uchar, size_t};
 use std::mem;
 use std::ptr;
@@ -175,27 +179,6 @@ pub const X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE: c_int = 51;
 pub const X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE: c_int = 45;
 pub const X509_V_ERR_UNSUPPORTED_NAME_SYNTAX: c_int = 53;
 pub const X509_V_OK: c_int = 0;
-
-#[cfg(not(target_os = "nacl"))]
-mod link {
-    #[cfg( any( all(target_os = "macos", feature = "tlsv1_1"),
-                all(target_os = "macos", feature = "tlsv1_2")))]
-    #[link(name="ssl.1.0.0")]
-    #[link(name="crypto.1.0.0")]
-    extern {}
-
-    #[cfg(any( not( target_os = "macos"),
-               all(target_os = "macos", not(feature = "tlsv1_1"),
-                   not(feature = "tlsv1_2"))))]
-    #[link(name="ssl")]
-    #[link(name="crypto")]
-    extern {}
-
-    #[cfg(target_os = "win32")]
-    #[link(name="gdi32")]
-    #[link(name="wsock32")]
-    extern { }
-}
 
 static mut MUTEXES: *mut Vec<NativeMutex> = 0 as *mut Vec<NativeMutex>;
 
@@ -479,3 +462,5 @@ extern "C" {
     pub fn i2d_RSAPrivateKey(k: *mut RSA, buf: *const *mut u8) -> c_int;
     pub fn d2i_RSAPrivateKey(k: *const *mut RSA, buf: *const *const u8, len: c_uint) -> *mut RSA;
 }
+
+pub mod probe;

--- a/openssl-sys/src/probe.rs
+++ b/openssl-sys/src/probe.rs
@@ -1,0 +1,72 @@
+use std::os;
+use std::io::fs::PathExtensions;
+
+pub struct ProbeResult {
+    pub cert_file: Option<Path>,
+    pub cert_dir: Option<Path>,
+}
+
+/// Probe the system for the directory in which CA certificates should likely be
+/// found.
+///
+/// This will only search known system locations.
+pub fn find_certs_dirs() -> Vec<Path> {
+    // see http://gagravarr.org/writing/openssl-certs/others.shtml
+    [
+        "/var/ssl",
+        "/usr/share/ssl",
+        "/usr/local/ssl",
+        "/usr/local/openssl",
+        "/usr/local/share",
+        "/usr/lib/ssl",
+        "/usr/ssl",
+        "/etc/openssl",
+        "/etc/pki/tls",
+        "/etc/ssl",
+    ].iter().map(|s| Path::new(*s)).filter(|p| {
+        p.exists()
+    }).collect()
+}
+
+pub fn init_ssl_cert_env_vars() {
+    let ProbeResult { cert_file, cert_dir } = probe();
+    match cert_file {
+        Some(path) => put("SSL_CERT_FILE", path),
+        None => {}
+    }
+    match cert_dir {
+        Some(path) => put("SSL_CERT_DIR", path),
+        None => {}
+    }
+
+    fn put(var: &str, path: Path) {
+        // Don't stomp over what anyone else has set
+        match os::getenv(var) {
+            Some(..) => {}
+            None => os::setenv(var, path),
+        }
+    }
+}
+
+pub fn probe() -> ProbeResult {
+    let mut result = ProbeResult {
+        cert_file: os::getenv("SSL_CERT_FILE").map(Path::new),
+        cert_dir: os::getenv("SSL_CERT_DIR").map(Path::new),
+    };
+    for certs_dir in find_certs_dirs().iter() {
+        // cert.pem looks to be an openssl 1.0.1 thing, while
+        // certs/ca-certificates.crt appears to be a 0.9.8 thing
+        try(&mut result.cert_file, certs_dir.join("cert.pem"));
+        try(&mut result.cert_file, certs_dir.join("certs/ca-certificates.crt"));
+        try(&mut result.cert_file, certs_dir.join("certs/ca-root-nss.crt"));
+
+        try(&mut result.cert_dir, certs_dir.join("certs"));
+    }
+    result
+}
+
+fn try(dst: &mut Option<Path>, val: Path) {
+    if dst.is_none() && val.exists() {
+        *dst = Some(val);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,7 @@ extern crate libc;
 extern crate serialize;
 extern crate sync;
 
-#[cfg(target_os = "nacl")]
-extern crate "openssl-sys" as _unused;
+extern crate "openssl-sys" as ffi;
 
 mod macros;
 
@@ -18,6 +17,5 @@ pub mod asn1;
 pub mod bn;
 pub mod bio;
 pub mod crypto;
-mod ffi;
 pub mod ssl;
 pub mod x509;


### PR DESCRIPTION
Using new build script system for all platforms. 
- `openssl-sys` prototype taken [alexcricton's repo](https://github.com/alexcrichton/openssl-sys) but embedded as it should be much easier to develop while it's in-tree rather than in a separate repo. 
- dropped all external links but Windows ones. I'm not sure how it is correct to proceed here as don't have access to Windows. Perhaps they could be dropped too as almost every windows app will be linked against `gdi32` and `win32`, `wsock32` may be not.
