### PR TITLE
Hasher: static contract checking, context reuse

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -340,8 +340,10 @@ extern "C" {
     pub fn EVP_CipherFinal(ctx: *mut EVP_CIPHER_CTX, res: *mut u8, len: &mut c_int);
 
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, typ: *const EVP_MD);
+    pub fn EVP_DigestInit_ex(ctx: *mut EVP_MD_CTX, typ: *const EVP_MD, imple: *const ENGINE);
     pub fn EVP_DigestUpdate(ctx: *mut EVP_MD_CTX, data: *const u8, n: c_uint);
     pub fn EVP_DigestFinal(ctx: *mut EVP_MD_CTX, res: *mut u8, n: *mut u32);
+    pub fn EVP_DigestFinal_ex(ctx: *mut EVP_MD_CTX, res: *mut u8, n: *mut u32);
 
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);


### PR DESCRIPTION
This proposal is motivated by a desire to prevent illegal (if not unsafe) use of update() and finalize() (eg calling update after finalize or finalizing twice). If deemed appropriate the approach could be used for other classes. Also demonstrates context reuse under the new model.

---
- Store EVP_MD_CTX in a separate struct.
- Add from_context() constructor that uses an existing context.
- Switch to EVP_Digest(Init|Final)_ex for efficient context reuse.
- Make update() borrow &mut self.
- Make finalize() consume self. Add finalize_reuse() that also returns the
  context which can be passed to from_context() constructor for reuse.

These changes let the type system prevent illegal calls to update() and
finalize().
