### PR TITLE
Allow passing in Android paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ For some reason, the OpenSSL distribution for Windows is structured differently,
 1. Run `sudo apt-get install libssl-dev`.
 2. Run `cargo build`.
 
+###Android
+1. Follow the steps [here](wiki.openssl.org/index.php/Android) to build OpenSSL for android
+2. Provide the path to the libssl and libcrypto binaries via `$OPENSSL_PATH`
+3. Build the package with `cargo build`
+
 ###Windows
 
 1. Grab the latest Win32 OpenSSL installer [here][1]. At the time of this writing, it's v1.0.1i. If you're using 64-bit Rust (coming to Windows soon), then you should get the Win64 installer instead.

--- a/openssl-sys/src/build.rs
+++ b/openssl-sys/src/build.rs
@@ -17,6 +17,16 @@ fn main() {
         if win_pos.is_some() {
            flags.push_str(" -l gdi32 -l wsock32");
         }
+
+        // Android doesn't have libcrypto/libssl,
+        // the toplevel Rust program should compile it themselves
+        if target.find_str("android").is_some() {
+            os::getenv("OPENSSL_PATH").expect("Android does not provide openssl libraries, please \
+                                               build them yourselves (instructions in the README) \
+                                               and provide their location through $OPENSSL_PATH.");
+            flags.push_str(" -L ${OPENSSL_PATH}");
+        }
+
         println!("cargo:rustc-flags={}", flags);
     }
 }


### PR DESCRIPTION
Using `[target.arch.openssl]` Cargo sections isn't going to work that well here since 
with Android this will have to be built by the top level package and there's no way to pass global rustc linker flags 
from a top level package without editing all the Cargo files of the deps.
