### PR TITLE
Now that pkg-config 0.1.1 has been published, delegate bailout detection to pkg-config.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 license = "Apache-2.0"
 description = "OpenSSL bindings"

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-sys"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Alex Crichton <alex@alexcrichton.com>",
            "Steven Fackler <sfackler@gmail.com>"]
 license = "MIT"
@@ -17,7 +17,7 @@ sslv2 = []
 aes_xts = []
 
 [build-dependencies]
-pkg-config = "0.1"
+pkg-config = "0.1.1"
 
 [target.le32-unknown-nacl.dependencies]
 libressl-pnacl-sys = "2.1.0"

--- a/openssl-sys/src/build.rs
+++ b/openssl-sys/src/build.rs
@@ -5,7 +5,7 @@ use std::os;
 fn main() {
     // Without hackory, pkg-config will only look for host libraries.
     // So, abandon ship if we're cross compiling.
-    if os::getenv("HOST") != os::getenv("TARGET") { return; }
+    if !pkg_config::target_supported() { return; }
 
 
     if pkg_config::find_library("openssl").is_err() {


### PR DESCRIPTION
Also bump version minors for publishing. :)
