### PR TITLE
Update hmac.rs

### DIFF
--- a/src/crypto/hmac.rs
+++ b/src/crypto/hmac.rs
@@ -55,6 +55,7 @@ impl HMAC {
             let mut res = Vec::from_elem(self.len, 0u8);
             let mut outlen = 0;
             ffi::HMAC_Final(&mut self.ctx, res.as_mut_ptr(), &mut outlen);
+            ffi::HMAC_CTX_cleanup(&mut self.ctx);
             assert!(self.len == outlen as uint)
             res
         }


### PR DESCRIPTION
I guess there is a memory leak without a call to 'HMAC_CTX_cleanup' in the finalize method.
