### PR TITLE
Add support for 64-bit Windows to build.rs

### DIFF
--- a/openssl-sys/src/build.rs
+++ b/openssl-sys/src/build.rs
@@ -3,6 +3,13 @@ extern crate "pkg-config" as pkg_config;
 use std::os;
 
 fn main() {
+	// pkg-config doesn't support Win64, so do this instead:
+	if cfg!(all(target_os = "windows", target_word_size = "64")) {
+		let flags = "-l crypto -l ssl -l gdi32 -l wsock32".to_string();
+		println!("cargo:rustc-flags={}", flags);
+		return;
+	}
+	
     // Without hackory, pkg-config will only look for host libraries.
     // So, abandon ship if we're cross compiling.
     if !pkg_config::target_supported() { return; }


### PR DESCRIPTION
Fixes linker issues on 64-bit Windows.

pkg-config doesn't support 64-bit Windows as a target, so build.rs silently returns, leaving us without the build flags we need to link everything.

The 64-bit libraries from [here](http://slproweb.com/products/Win32OpenSSL.html) do not provide MinGW .a files, only VC files, so these must be converted before they can be used (see [here](https://github.com/sfackler/rust-openssl/issues/111)).
