### PR TITLE
Fix openssl-sys.

### DIFF
--- a/src/bn/mod.rs
+++ b/src/bn/mod.rs
@@ -463,7 +463,7 @@ pub mod unchecked {
     }
 
     impl Neg<BigNum> for BigNum {
-        fn neg(&self) -> BigNum {
+        fn neg(self) -> BigNum {
             let mut n = self.clone();
             n.negate();
             n


### PR DESCRIPTION
This replaces the NativeMutex usage from rustrt (now removed) with StaticMutexes from std::sync. I had to use a `Vec<Option<StaticMutexGuard>>` in order to allow for unscoped unlocking like with NativeMutex. This fixes issue #127. This also fixes the Neg implementation for BigNum, as it has now changed.
