### PR TITLE
OpenSSL-sys: Cfg off target_os instead off feature.

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate libc;
 
-#[cfg(feature = "libressl-pnacl-sys")]
+#[cfg(target_os = "nacl")]
 extern crate "libressl-pnacl-sys" as _for_linkage;
 
 use libc::{c_void, c_int, c_char, c_ulong, c_long, c_uint, c_uchar, size_t};


### PR DESCRIPTION
It seems cargo doesn't provide --cfg entries for dep crates after all.