### PR TITLE
Upgrade to latest Rust

### DIFF
--- a/openssl-sys/src/probe.rs
+++ b/openssl-sys/src/probe.rs
@@ -1,5 +1,5 @@
 use std::os;
-use std::io::fs::PathExtensions;
+use std::old_io::fs::PathExtensions;
 
 pub struct ProbeResult {
     pub cert_file: Option<Path>,

--- a/src/bio/mod.rs
+++ b/src/bio/mod.rs
@@ -1,6 +1,6 @@
 use libc::{c_void, c_int};
-use std::io::{EndOfFile, IoResult, IoError, OtherIoError};
-use std::io::{Reader, Writer};
+use std::old_io::{EndOfFile, IoResult, IoError, OtherIoError};
+use std::old_io::{Reader, Writer};
 use std::ptr;
 
 use ffi;
@@ -87,7 +87,7 @@ impl Reader for MemBio {
 }
 
 impl Writer for MemBio {
-    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
         let ret = unsafe {
             ffi::BIO_write(self.bio, buf.as_ptr() as *const c_void,
                            buf.len() as c_int)

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -1,6 +1,6 @@
 use libc::c_uint;
 use std::ptr;
-use std::io;
+use std::old_io;
 use std::iter::repeat;
 
 use ffi;
@@ -59,8 +59,8 @@ pub struct Hasher {
     len: u32,
 }
 
-impl io::Writer for Hasher {
-    fn write(&mut self, buf: &[u8]) -> io::IoResult<()> {
+impl old_io::Writer for Hasher {
+    fn write_all(&mut self, buf: &[u8]) -> old_io::IoResult<()> {
         self.update(buf);
         Ok(())
     }
@@ -163,7 +163,7 @@ mod tests {
 
     pub fn hash_writer(t: super::HashType, data: &[u8]) -> Vec<u8> {
         let mut h = super::Hasher::new(t);
-        h.write(data).unwrap();
+        h.write_all(data).unwrap();
         h.finalize()
     }
 

--- a/src/crypto/pkey.rs
+++ b/src/crypto/pkey.rs
@@ -149,7 +149,7 @@ impl PKey {
 
         }
         let buf = try!(mem_bio.read_to_end().map_err(StreamError));
-        writer.write(buf.as_slice()).map_err(StreamError)
+        writer.write_all(buf.as_slice()).map_err(StreamError)
     }
 
     /**

--- a/src/ssl/error.rs
+++ b/src/ssl/error.rs
@@ -5,7 +5,7 @@ use libc::c_ulong;
 use std::error;
 use std::fmt;
 use std::ffi::c_str_to_bytes;
-use std::io::IoError;
+use std::old_io::IoError;
 
 use ffi;
 

--- a/src/ssl/tests.rs
+++ b/src/ssl/tests.rs
@@ -1,6 +1,6 @@
 use serialize::hex::FromHex;
-use std::io::net::tcp::TcpStream;
-use std::io::{Writer};
+use std::old_io::net::tcp::TcpStream;
+use std::old_io::{Writer};
 use std::thread::Thread;
 
 use crypto::hash::HashType::{SHA256};
@@ -179,9 +179,9 @@ fn test_verify_callback_data() {
 fn test_write() {
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut stream = SslStream::new(&SslContext::new(Sslv23).unwrap(), stream).unwrap();
-    stream.write("hello".as_bytes()).unwrap();
+    stream.write_all("hello".as_bytes()).unwrap();
     stream.flush().unwrap();
-    stream.write(" there".as_bytes()).unwrap();
+    stream.write_all(" there".as_bytes()).unwrap();
     stream.flush().unwrap();
 }
 
@@ -189,7 +189,7 @@ fn test_write() {
 fn test_read() {
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut stream = SslStream::new(&SslContext::new(Sslv23).unwrap(), stream).unwrap();
-    stream.write("GET /\r\n\r\n".as_bytes()).unwrap();
+    stream.write_all("GET /\r\n\r\n".as_bytes()).unwrap();
     stream.flush().unwrap();
     stream.read_to_end().ok().expect("read error");
 }
@@ -200,7 +200,7 @@ fn test_clone() {
     let mut stream = SslStream::new(&SslContext::new(Sslv23).unwrap(), stream).unwrap();
     let mut stream2 = stream.clone();
     let _t = Thread::spawn(move || {
-        stream2.write("GET /\r\n\r\n".as_bytes()).unwrap();
+        stream2.write_all("GET /\r\n\r\n".as_bytes()).unwrap();
         stream2.flush().unwrap();
     });
     stream.read_to_end().ok().expect("read error");

--- a/src/x509/mod.rs
+++ b/src/x509/mod.rs
@@ -371,7 +371,7 @@ impl<'ctx> X509<'ctx> {
     pub fn from_pem<R>(reader: &mut R) -> Result<X509<'ctx>, SslError> where R: Reader {
         let mut mem_bio = try!(MemBio::new());
         let buf = try!(reader.read_to_end().map_err(StreamError));
-        try!(mem_bio.write(buf.as_slice()).map_err(StreamError));
+        try!(mem_bio.write_all(buf.as_slice()).map_err(StreamError));
 
         unsafe {
             let handle = try_ssl_null!(ffi::PEM_read_bio_X509(mem_bio.get_handle(),
@@ -417,7 +417,7 @@ impl<'ctx> X509<'ctx> {
                                              self.handle));
         }
         let buf = try!(mem_bio.read_to_end().map_err(StreamError));
-        writer.write(buf.as_slice()).map_err(StreamError)
+        writer.write_all(buf.as_slice()).map_err(StreamError)
     }
 }
 

--- a/src/x509/tests.rs
+++ b/src/x509/tests.rs
@@ -1,6 +1,6 @@
 use serialize::hex::FromHex;
-use std::io::{File, Open, Read};
-use std::io::util::NullWriter;
+use std::old_io::{File, Open, Read};
+use std::old_io::util::NullWriter;
 
 use crypto::hash::HashType::{SHA256};
 use x509::{X509, X509Generator};


### PR DESCRIPTION
- Rename Writer's write method to write_all
- Rename std::io to std::old_io

No other changes.