### PR TITLE
Avoid duplicate calls to *_Final when dropping Hasher and HMAC

### DIFF
--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -153,10 +153,10 @@ impl Hasher {
         unsafe {
             let mut len = 0;
             let r = ffi::EVP_DigestFinal_ex(self.ctx, res.as_mut_ptr(), &mut len);
+            self.state = Finalized;
             assert_eq!(len as usize, md_len);
             assert_eq!(r, 1);
         }
-        self.state = Finalized;
         res
     }
 

--- a/src/crypto/hmac.rs
+++ b/src/crypto/hmac.rs
@@ -136,10 +136,10 @@ impl HMAC {
         unsafe {
             let mut len = 0;
             let r = ffi::HMAC_Final(&mut self.ctx, res.as_mut_ptr(), &mut len);
+            self.state = Finalized;
             assert_eq!(len as usize, md_len);
             assert_eq!(r, 1);
         }
-        self.state = Finalized;
         res
     }
 


### PR DESCRIPTION
An assertion triggered in finalize() would lead to drop() erroneously redoing the finalization. Set the state to Finalized unconditionally to prevent this.