### PR TITLE
Declare the use of unstable libstd APIs

### DIFF
--- a/openssl-sys/src/build.rs
+++ b/openssl-sys/src/build.rs
@@ -1,4 +1,4 @@
-#![allow(unstable)]
+#![feature(core, collections, os)]
 
 extern crate "pkg-config" as pkg_config;
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
-#![allow(dead_code, unstable)]
+#![allow(dead_code)]
+#![feature(core, io, libc, os, path, std_misc)]
 
 extern crate libc;
 


### PR DESCRIPTION
This silences a handful of warnings