### PR TITLE
crypto::symm rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 env:
   global:
   - secure: J4i75AV4KMrU/UQrLIzzIh35Xix40Ki0uWjm8j05oxlXVl5aPU2zB30AemDne2QXYzkN4kRG/iRnNORE/8D0lF7YipQNSNxgfiBVoOEfj/NSogvI2BftYX9vlLZJUvt+s/nbE3xa/Pyge1IPv7itDYGO7SMe8RTSqitgqyfE2Eg=
-  - FEATURES="tlsv1_1 tlsv1_2 aes_xts"
+  - FEATURES="tlsv1_1 tlsv1_2 aes_ctr aes_gcm aes_xts"
 before_script:
 - openssl s_server -accept 15418 -www -cert openssl/test/cert.pem -key openssl/test/key.pem >/dev/null 2>&1 &
 script:

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -15,6 +15,8 @@ build = "build.rs"
 tlsv1_2 = []
 tlsv1_1 = []
 sslv2 = []
+aes_ctr = []
+aes_gcm = []
 aes_xts = []
 
 [build-dependencies]

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -397,11 +397,14 @@ extern "C" {
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 
+    pub fn EVP_CIPHER_key_length(ctx: *const EVP_CIPHER) -> c_int;
+
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
     pub fn EVP_CIPHER_CTX_set_padding(ctx: *mut EVP_CIPHER_CTX, padding: c_int) -> c_int;
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
     pub fn EVP_CIPHER_CTX_ctrl(ctx: *mut EVP_CIPHER_CTX, type_: c_int,
                                arg: c_int, ptr: *mut c_void) -> c_int;
+    pub fn EVP_CIPHER_CTX_iv_length(ctx: *mut EVP_CIPHER_CTX) -> c_int;
 
     pub fn EVP_CipherInit(ctx: *mut EVP_CIPHER_CTX, evp: *const EVP_CIPHER,
                           key: *const u8, iv: *const u8, mode: c_int) -> c_int;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -383,13 +383,17 @@ extern "C" {
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
     #[cfg(feature = "aes_xts")]
     pub fn EVP_aes_128_xts() -> *const EVP_CIPHER;
+    #[cfg(feature = "aes_ctr")]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
+    #[cfg(feature = "aes_gcm")]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
     #[cfg(feature = "aes_xts")]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
+    #[cfg(feature = "aes_ctr")]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
+    #[cfg(feature = "aes_gcm")]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -364,9 +364,13 @@ extern "C" {
 
     pub fn EVP_CipherInit(ctx: *mut EVP_CIPHER_CTX, evp: *const EVP_CIPHER,
                           key: *const u8, iv: *const u8, mode: c_int) -> c_int;
+    pub fn EVP_CipherInit_ex(ctx: *mut EVP_CIPHER_CTX, evp: *const EVP_CIPHER,
+                             imple: *const ENGINE, key: *const u8, iv: *const u8,
+                             mode: c_int) -> c_int;
     pub fn EVP_CipherUpdate(ctx: *mut EVP_CIPHER_CTX, outbuf: *mut u8,
                             outlen: &mut c_int, inbuf: *const u8, inlen: c_int) -> c_int;
     pub fn EVP_CipherFinal(ctx: *mut EVP_CIPHER_CTX, res: *mut u8, len: &mut c_int) -> c_int;
+    pub fn EVP_CipherFinal_ex(ctx: *mut EVP_CIPHER_CTX, res: *mut u8, len: &mut c_int) -> c_int;
 
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, typ: *const EVP_MD) -> c_int;
     pub fn EVP_DigestInit_ex(ctx: *mut EVP_MD_CTX, typ: *const EVP_MD, imple: *const ENGINE) -> c_int;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -383,13 +383,13 @@ extern "C" {
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
     #[cfg(feature = "aes_xts")]
     pub fn EVP_aes_128_xts() -> *const EVP_CIPHER;
-    // fn EVP_aes_128_ctr() -> EVP_CIPHER;
+    pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
     #[cfg(feature = "aes_xts")]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
-    // fn EVP_aes_256_ctr() -> EVP_CIPHER;
+    pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -104,6 +104,41 @@ pub type PasswordCallback = extern "C" fn(buf: *mut c_char, size: c_int,
                                           rwflag: c_int, user_data: *mut c_void)
                                           -> c_int;
 
+pub const EVP_MAX_KEY_LENGTH: usize = 64;
+pub const EVP_MAX_IV_LENGTH: usize = 16;
+pub const EVP_MAX_BLOCK_LENGTH: usize = 32;
+
+pub const EVP_CTRL_INIT: c_int = 0x0;
+pub const EVP_CTRL_SET_KEY_LENGTH: c_int = 0x1;
+pub const EVP_CTRL_GET_RC2_KEY_BITS: c_int = 0x2;
+pub const EVP_CTRL_SET_RC2_KEY_BITS: c_int = 0x3;
+pub const EVP_CTRL_GET_RC5_ROUNDS: c_int = 0x4;
+pub const EVP_CTRL_SET_RC5_ROUNDS: c_int = 0x5;
+pub const EVP_CTRL_RAND_KEY: c_int = 0x6;
+pub const EVP_CTRL_PBE_PRF_NID: c_int = 0x7;
+pub const EVP_CTRL_COPY: c_int = 0x8;
+pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
+pub const EVP_CTRL_GCM_GET_TAG: c_int = 0x10;
+pub const EVP_CTRL_GCM_SET_TAG: c_int = 0x11;
+pub const EVP_CTRL_GCM_SET_IV_FIXED: c_int = 0x12;
+pub const EVP_CTRL_GCM_IV_GEN: c_int = 0x13;
+pub const EVP_CTRL_CCM_SET_IVLEN: c_int = EVP_CTRL_GCM_SET_IVLEN;
+pub const EVP_CTRL_CCM_GET_TAG: c_int = EVP_CTRL_GCM_GET_TAG;
+pub const EVP_CTRL_CCM_SET_TAG: c_int = EVP_CTRL_GCM_SET_TAG;
+pub const EVP_CTRL_CCM_SET_L: c_int = 0x14;
+pub const EVP_CTRL_CCM_SET_MSGLEN: c_int = 0x15;
+pub const EVP_CTRL_AEAD_TLS1_AAD: c_int = 0x16;
+pub const EVP_CTRL_AEAD_SET_MAC_KEY: c_int = 0x17;
+pub const EVP_CTRL_GCM_SET_IV_INV: c_int = 0x18;
+pub const EVP_CTRL_TLS1_1_MULTIBLOCK_AAD: c_int = 0x19;
+pub const EVP_CTRL_TLS1_1_MULTIBLOCK_ENCRYPT: c_int = 0x1a;
+pub const EVP_CTRL_TLS1_1_MULTIBLOCK_DECRYPT: c_int = 0x1b;
+pub const EVP_CTRL_TLS1_1_MULTIBLOCK_MAX_BUFSIZE: c_int = 0x1c;
+pub const EVP_CTRL_SET_IVLEN: c_int = EVP_CTRL_GCM_SET_IVLEN;
+pub const EVP_CTRL_GET_TAG: c_int = EVP_CTRL_GCM_GET_TAG;
+pub const EVP_CTRL_SET_TAG: c_int = EVP_CTRL_GCM_SET_TAG;
+pub const EVP_CTRL_OCB_SET_TAGLEN: c_int = 0x1c;
+
 pub const BIO_CTRL_EOF: c_int = 2;
 
 pub const CRYPTO_LOCK: c_int = 1;
@@ -349,18 +384,20 @@ extern "C" {
     #[cfg(feature = "aes_xts")]
     pub fn EVP_aes_128_xts() -> *const EVP_CIPHER;
     // fn EVP_aes_128_ctr() -> EVP_CIPHER;
-    // fn EVP_aes_128_gcm() -> EVP_CIPHER;
+    pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
     #[cfg(feature = "aes_xts")]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
     // fn EVP_aes_256_ctr() -> EVP_CIPHER;
-    // fn EVP_aes_256_gcm() -> EVP_CIPHER;
+    pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
     pub fn EVP_CIPHER_CTX_set_padding(ctx: *mut EVP_CIPHER_CTX, padding: c_int) -> c_int;
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
+    pub fn EVP_CIPHER_CTX_ctrl(ctx: *mut EVP_CIPHER_CTX, type_: c_int,
+                               arg: c_int, ptr: *mut c_void) -> c_int;
 
     pub fn EVP_CipherInit(ctx: *mut EVP_CIPHER_CTX, evp: *const EVP_CIPHER,
                           key: *const u8, iv: *const u8, mode: c_int) -> c_int;

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -13,6 +13,8 @@ keywords = ["crypto", "tls", "ssl"]
 tlsv1_2 = ["openssl-sys/tlsv1_2"]
 tlsv1_1 = ["openssl-sys/tlsv1_1"]
 sslv2 = ["openssl-sys/sslv2"]
+aes_ctr = ["openssl-sys/aes_ctr"]
+aes_gcm = ["openssl-sys/aes_gcm"]
 aes_xts = ["openssl-sys/aes_xts"]
 
 [dependencies.openssl-sys]

--- a/openssl/src/crypto/mod.rs
+++ b/openssl/src/crypto/mod.rs
@@ -21,4 +21,5 @@ pub mod pkcs5;
 pub mod pkey;
 pub mod rand;
 pub mod symm;
+pub mod symm_new;
 pub mod memcmp;

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -164,7 +164,7 @@ trait SectorMode {
 // Subject to changes after std::io stabilization
 pub struct Filter<'a, T: 'a> {
     cipher: &'a mut T,
-    sink: &'a mut (Writer + 'a),
+    sink: &'a mut Writer,
 }
 
 const FILTER_BUFFER_LEN: usize = 16384;
@@ -174,7 +174,7 @@ impl <'a, T> Filter<'a, T> {
     /// to the `sink`.
     /// The `cipher` has to be `start`ed beforehand and `finish`ed after
     /// destroying the adapter.
-    pub fn new(cipher: &'a mut T, sink: &'a mut (Writer + 'a))
+    pub fn new(cipher: &'a mut T, sink: &'a mut Writer)
           -> Filter<'a, T> {
         Filter { cipher: cipher, sink: sink }
     }
@@ -205,7 +205,7 @@ impl <'a, T: PaddedFinish> PaddedFilter<'a, T> {
     /// The cipher has to be `start`ed beforehand and is finished explicitly
     /// with `close` or implicitly when the adapter is destroyed (in which case
     /// the last bytes won't reach the sink).
-    pub fn new(cipher: &'a mut T, sink: &'a mut (Writer + 'a))
+    pub fn new(cipher: &'a mut T, sink: &'a mut Writer)
           -> PaddedFilter<'a, T> {
         PaddedFilter { inner: Filter::new(cipher, sink), closed: false }
     }

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -601,8 +601,7 @@ pub mod gcm {
     use super::{Aes, Apply, Context, Direction, Error};
     use ffi;
 
-    // GCM mode is defined for 128-bit block ciphers
-    const BLOCK_LENGTH: usize = 16;
+    const TAG_LEN: usize = 16;
 
     fn evpc(algo: Aes) -> *const ffi::EVP_CIPHER {
         unsafe {
@@ -646,7 +645,7 @@ pub mod gcm {
         /// Returns the authetication tag. It can be truncated if needed.
         pub fn finish(&mut self) -> Vec<u8> {
             assert!(self.context.clean_finalize().is_ok());
-            let mut res = vec![0; BLOCK_LENGTH];
+            let mut res = vec![0; TAG_LEN];
             self.context.get_tag(&mut res);
             res
         }

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -444,7 +444,9 @@ mod test {
             let mut c = ECB::new_encrypt(ty, &*key);
             {
                 let mut w = c.start_writer(&mut res_ct);
-                let _ = ::std::old_io::util::copy(&mut &*pt, &mut w);
+                for byte in pt.iter() {
+                    let _ = w.write_all(&[*byte]);
+                }
             }
             assert!(ct == res_ct, "{:?} encrypt #{}", ty, n);
 
@@ -452,7 +454,9 @@ mod test {
             let mut d = ECB::new_decrypt(ty, &*key);
             {
                 let mut w = d.start_writer(&mut res_pt);
-                let _ = ::std::old_io::util::copy(&mut &*res_ct, &mut w);
+                for byte in res_ct.iter() {
+                    let _ = w.write_all(&[*byte]);
+                }
             }
             assert!(pt == res_pt, "{:?} decrypt #{}", ty, n);
 
@@ -496,7 +500,9 @@ mod test {
             let mut c = CBC::new_encrypt(ty, &*key);
             {
                 let mut w = c.start_writer(&*iv, &mut res_ct);
-                let _ = ::std::old_io::util::copy(&mut &*pt, &mut w);
+                for byte in pt.iter() {
+                    let _ = w.write_all(&[*byte]);
+                }
             }
             assert!(ct == res_ct, "{:?} encrypt #{}", ty, n);
 
@@ -504,7 +510,9 @@ mod test {
             let mut d = CBC::new_decrypt(ty, &*key);
             {
                 let mut w = d.start_writer(&*iv, &mut res_pt);
-                let _ = ::std::old_io::util::copy(&mut &*res_ct, &mut w);
+                for byte in res_ct.iter() {
+                    let _ = w.write_all(&[*byte]);
+                }
             }
             assert!(pt == res_pt, "{:?} decrypt #{}", ty, n);
 

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -127,11 +127,11 @@ struct Context {
     state: State,
 }
 
-/// A trait for ciphers that allow transcoding several chunks of data consequtively.
+/// A trait for ciphers that allow transcoding several chunks of data consecutively.
 pub trait Apply {
     /// Transcode the `data` into the `buf`.
     ///
-    /// The `buf` have enough space to fit `data` (plus a cipher block length
+    /// The `buf` must have enough space to fit `data` (plus a cipher block length
     /// in ECB and CBC modes).
     fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize;
 }

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -356,6 +356,8 @@ impl Drop for Context {
 
 pub mod ecb{
     //! ECB mode
+    //!
+    //! This mode doesn't use IVs so is not supposed to be used.
 
     use super::{Aes, Apply, Context, Direction, Error, PaddedFinish};
     use ffi;
@@ -375,7 +377,6 @@ pub mod ecb{
     /// AES in ECB mode without padding.
     ///
     /// The data length needs to be a multiple of AES block length.
-    /// This mode doesn't use IVs so is not supposed to be used.
     pub struct EcbRaw {
         context: Context,
     }
@@ -492,7 +493,6 @@ pub mod cbc {
     /// AES in CBC mode without padding.
     ///
     /// The data length needs to be a multiple of AES block length.
-    /// This mode doesn't use IVs so is not supposed to be used.
     pub struct CbcRaw {
         context: Context,
     }

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -471,11 +471,11 @@ mod test {
         let mut res: Vec<u8> = repeat(0).take(buf_len).collect();
         let mut len;
 
-        len = enc.apply(pt, &mut *res);
+        len = enc.apply(pt, &mut res);
         len += enc.finish(&mut res[len..]);
         assert!(ct == &res[..len], "{}[{}] encrypt", vec_name, n);
 
-        len = dec.apply(ct, &mut *res);
+        len = dec.apply(ct, &mut res);
         len += dec.finish(&mut res[len..]);
         assert!(pt == &res[..len], "{}[{}] decrypt", vec_name, n);
     }
@@ -511,11 +511,11 @@ mod test {
         for item in ECB_RAW_VEC.iter() {
             let (algo, key, pt, ct) = unpack3(item);
 
-            let mut enc = EcbRaw::new_encrypt(algo, &*key);
+            let mut enc = EcbRaw::new_encrypt(algo, &key);
             enc.start();
-            let mut dec = EcbRaw::new_decrypt(algo, &*key);
+            let mut dec = EcbRaw::new_decrypt(algo, &key);
             dec.start();
-            test_block_mode_apply("ECB_RAW_VEC", n, &*pt, &*ct, &mut enc, &mut dec);
+            test_block_mode_apply("ECB_RAW_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
             n += 1;
         }
@@ -524,11 +524,11 @@ mod test {
         for item in ECB_PADDED_VEC.iter() {
             let (algo, key, pt, ct) = unpack3(item);
 
-            let mut enc = EcbPadded::new_encrypt(algo, &*key);
+            let mut enc = EcbPadded::new_encrypt(algo, &key);
             enc.start();
-            let mut dec = EcbPadded::new_decrypt(algo, &*key);
+            let mut dec = EcbPadded::new_decrypt(algo, &key);
             dec.start();
-            test_block_mode_apply("ECB_PADDED_VEC", n, &*pt, &*ct, &mut enc, &mut dec);
+            test_block_mode_apply("ECB_PADDED_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
             n += 1;
         }
@@ -542,11 +542,11 @@ mod test {
         for item in ECB_RAW_VEC.iter() {
             let (algo, key, pt, ct) = unpack3(item);
 
-            let mut enc = EcbRaw::new_encrypt(algo, &*key);
+            let mut enc = EcbRaw::new_encrypt(algo, &key);
             enc.start();
-            let mut dec = EcbRaw::new_decrypt(algo, &*key);
+            let mut dec = EcbRaw::new_decrypt(algo, &key);
             dec.start();
-            test_block_mode_write("ECB_RAW_VEC", n, &*pt, &*ct, &mut enc, &mut dec);
+            test_block_mode_write("ECB_RAW_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
             n += 1;
         }
@@ -555,11 +555,11 @@ mod test {
         for item in ECB_PADDED_VEC.iter() {
             let (algo, key, pt, ct) = unpack3(item);
 
-            let mut enc = EcbPadded::new_encrypt(algo, &*key);
+            let mut enc = EcbPadded::new_encrypt(algo, &key);
             enc.start();
-            let mut dec = EcbPadded::new_decrypt(algo, &*key);
+            let mut dec = EcbPadded::new_decrypt(algo, &key);
             dec.start();
-            test_block_mode_write("ECB_PADDED_VEC", n, &*pt, &*ct, &mut enc, &mut dec);
+            test_block_mode_write("ECB_PADDED_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
             n += 1;
         }
@@ -573,11 +573,11 @@ mod test {
         for item in CBC_RAW_VEC.iter() {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
-            let mut enc = CbcRaw::new_encrypt(algo, &*key);
-            enc.start(&*iv);
-            let mut dec = CbcRaw::new_decrypt(algo, &*key);
-            dec.start(&*iv);
-            test_block_mode_apply("CBC_RAW_VEC", n, &*pt, &*ct, &mut enc, &mut dec);
+            let mut enc = CbcRaw::new_encrypt(algo, &key);
+            enc.start(&iv);
+            let mut dec = CbcRaw::new_decrypt(algo, &key);
+            dec.start(&iv);
+            test_block_mode_apply("CBC_RAW_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
             n += 1;
         }
@@ -586,11 +586,11 @@ mod test {
         for item in CBC_PADDED_VEC.iter() {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
-            let mut enc = CbcPadded::new_encrypt(algo, &*key);
-            enc.start(&*iv);
-            let mut dec = CbcPadded::new_decrypt(algo, &*key);
-            dec.start(&*iv);
-            test_block_mode_apply("CBC_PADDED_VEC", n, &*pt, &*ct, &mut enc, &mut dec);
+            let mut enc = CbcPadded::new_encrypt(algo, &key);
+            enc.start(&iv);
+            let mut dec = CbcPadded::new_decrypt(algo, &key);
+            dec.start(&iv);
+            test_block_mode_apply("CBC_PADDED_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
             n += 1;
         }
@@ -604,11 +604,11 @@ mod test {
         for item in CBC_RAW_VEC.iter() {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
-            let mut enc = CbcRaw::new_encrypt(algo, &*key);
-            enc.start(&*iv);
-            let mut dec = CbcRaw::new_decrypt(algo, &*key);
-            dec.start(&*iv);
-            test_block_mode_write("CBC_RAW_VEC", n, &*pt, &*ct, &mut enc, &mut dec);
+            let mut enc = CbcRaw::new_encrypt(algo, &key);
+            enc.start(&iv);
+            let mut dec = CbcRaw::new_decrypt(algo, &key);
+            dec.start(&iv);
+            test_block_mode_write("CBC_RAW_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
             n += 1;
         }
@@ -617,11 +617,11 @@ mod test {
         for item in CBC_PADDED_VEC.iter() {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
-            let mut enc = CbcPadded::new_encrypt(algo, &*key);
-            enc.start(&*iv);
-            let mut dec = CbcPadded::new_decrypt(algo, &*key);
-            dec.start(&*iv);
-            test_block_mode_write("CBC_PADDED_VEC", n, &*pt, &*ct, &mut enc, &mut dec);
+            let mut enc = CbcPadded::new_encrypt(algo, &key);
+            enc.start(&iv);
+            let mut dec = CbcPadded::new_decrypt(algo, &key);
+            dec.start(&iv);
+            test_block_mode_write("CBC_PADDED_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
             n += 1;
         }

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -249,6 +249,39 @@ impl Coder for ECB {
     }
 }
 
+#[cfg(test)]
+mod test {
+    use super::{ECB, ECBType, Coder};
+    use std::iter::repeat;
+    use serialize::hex::FromHex;
+
+    const ECB_Vec: [(u16, &'static str, &'static str, &'static str); 1] = [
+        (128, "00000000000000000000000000000000",
+              "ffffffffffffffff8000000000000000",
+              "41f992a856fb278b389a62f5d274d7e9"),
+    ];
+
+    #[test]
+    fn test_ecb_128_apply() {
+        for &(_, key, pt, ct) in ECB_Vec.iter().filter(|&x| x.0 == 128) {
+            let key = key.from_hex().unwrap();
+            let pt = pt.from_hex().unwrap();
+            let ct = ct.from_hex().unwrap();
+
+            let mut res_ct: Vec<u8> = repeat(0).take(pt.len() + super::MAX_BLOCK_LEN).collect();
+            let mut c = ECB::new_encrypt(ECBType::AES_128_RAW, &*key);
+            c.start();
+            let len = c.apply(&*pt, &mut *res_ct);
+            let len2 = c.finish(&mut res_ct[len..]);
+            res_ct.truncate(len + len2);
+            assert_eq!(ct, res_ct);
+
+            //let mut res_pt = repeat(0).take(pt.len() + super::MAX_BLOCK_LEN);
+            //let mut d = ECB::new_decrypt(ECBType::AES_128_RAW, &*key);
+
+        }
+    }
+
     #[test]
     fn test_symm_new_aes_256_ecb() {
         let k0 =
@@ -279,3 +312,4 @@ impl Coder for ECB {
         }
         assert!(p0 == p1);
     }
+}

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -1049,7 +1049,7 @@ mod test {
     #[test]
     fn test_ecb_raw_apply() {
         let mut n = 0;
-        for item in ECB_RAW_VEC.iter() {
+        for item in &ECB_RAW_VEC {
             let (algo, key, pt, ct) = unpack3(item);
             let mut res: Vec<u8> = repeat(0).take(
                 max(pt.len(), ct.len()) + ffi::EVP_MAX_BLOCK_LENGTH).collect();
@@ -1073,7 +1073,7 @@ mod test {
     #[test]
     fn test_ecb_padded_apply() {
         let mut n = 0;
-        for item in ECB_PADDED_VEC.iter() {
+        for item in &ECB_PADDED_VEC {
             let (algo, key, pt, ct) = unpack3(item);
             let mut res: Vec<u8> = repeat(0).take(
                 max(pt.len(), ct.len()) + ffi::EVP_MAX_BLOCK_LENGTH).collect();
@@ -1122,7 +1122,7 @@ mod test {
         let mut n;
 
         n = 0;
-        for item in ECB_RAW_VEC.iter() {
+        for item in &ECB_RAW_VEC {
             let (algo, key, pt, ct) = unpack3(item);
 
             let mut enc = EcbRaw::new_encrypt(algo, &key);
@@ -1156,7 +1156,7 @@ mod test {
         let mut n;
 
         n = 0;
-        for item in ECB_PADDED_VEC.iter() {
+        for item in &ECB_PADDED_VEC {
             let (algo, key, pt, ct) = unpack3(item);
 
             let mut enc = EcbPadded::new_encrypt(algo, &key);
@@ -1187,7 +1187,7 @@ mod test {
     fn test_ecb_raw_write() {
         let mut n = 0;
 
-        for item in ECB_RAW_VEC.iter() {
+        for item in &ECB_RAW_VEC {
             let (algo, key, pt, ct) = unpack3(item);
             let mut res: Vec<u8> = Vec::new();
 
@@ -1195,7 +1195,7 @@ mod test {
             enc.start();
             {
                 let mut w = Filter::new(&mut enc, &mut res);
-                for byte in pt.iter() {
+                for byte in &pt {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1207,7 +1207,7 @@ mod test {
             dec.start();
             {
                 let mut w = Filter::new(&mut dec, &mut res);
-                for byte in ct.iter() {
+                for byte in &ct {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1222,7 +1222,7 @@ mod test {
     fn test_ecb_padded_write() {
         let mut n = 0;
 
-        for item in ECB_PADDED_VEC.iter() {
+        for item in &ECB_PADDED_VEC {
             let (algo, key, pt, ct) = unpack3(item);
 
             let mut res: Vec<u8> = Vec::new();
@@ -1231,7 +1231,7 @@ mod test {
             enc.start();
             {
                 let mut w = PaddedFilter::new(&mut enc, &mut res);
-                for byte in pt.iter() {
+                for byte in &pt {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
                 assert!(w.close().is_ok(), "vec #{}", n);
@@ -1243,7 +1243,7 @@ mod test {
             dec.start();
             {
                 let mut w = PaddedFilter::new(&mut dec, &mut res);
-                for byte in ct.iter() {
+                for byte in &ct {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
                 assert!(w.close().is_ok(), "vec #{}", n);
@@ -1258,7 +1258,7 @@ mod test {
     fn test_ecb_padded_write_twice() {
         let mut n = 0;
 
-        for item in ECB_PADDED_VEC.iter() {
+        for item in &ECB_PADDED_VEC {
             let (algo, key, pt, ct) = unpack3(item);
 
             let mut res: Vec<u8> = Vec::new();
@@ -1267,7 +1267,7 @@ mod test {
             enc.start();
             {
                 let mut w = Filter::new(&mut enc, &mut res);
-                for byte in pt.iter() {
+                for byte in &pt {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1282,7 +1282,7 @@ mod test {
             dec.start();
             {
                 let mut w = Filter::new(&mut dec, &mut res);
-                for byte in ct.iter() {
+                for byte in &ct {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1299,7 +1299,7 @@ mod test {
     #[test]
     fn test_cbc_raw_apply() {
         let mut n = 0;
-        for item in CBC_RAW_VEC.iter() {
+        for item in &CBC_RAW_VEC {
             let (algo, key, iv, pt, ct) = unpack4(item);
             let mut res: Vec<u8> = repeat(0).take(
                 max(pt.len(), ct.len()) + ffi::EVP_MAX_BLOCK_LENGTH).collect();
@@ -1323,7 +1323,7 @@ mod test {
     #[test]
     fn test_cbc_padded_apply() {
         let mut n = 0;
-        for item in CBC_PADDED_VEC.iter() {
+        for item in &CBC_PADDED_VEC {
             let (algo, key, iv, pt, ct) = unpack4(item);
             let mut res: Vec<u8> = repeat(0).take(
                 max(pt.len(), ct.len()) + ffi::EVP_MAX_BLOCK_LENGTH).collect();
@@ -1372,7 +1372,7 @@ mod test {
         let mut n;
 
         n = 0;
-        for item in CBC_RAW_VEC.iter() {
+        for item in &CBC_RAW_VEC {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
             let mut enc = CbcRaw::new_encrypt(algo, &key);
@@ -1406,7 +1406,7 @@ mod test {
         let mut n;
 
         n = 0;
-        for item in CBC_PADDED_VEC.iter() {
+        for item in &CBC_PADDED_VEC {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
             let mut enc = CbcPadded::new_encrypt(algo, &key);
@@ -1437,7 +1437,7 @@ mod test {
     fn test_cbc_raw_write() {
         let mut n = 0;
 
-        for item in CBC_RAW_VEC.iter() {
+        for item in &CBC_RAW_VEC {
             let (algo, key, iv, pt, ct) = unpack4(item);
             let mut res: Vec<u8> = Vec::new();
 
@@ -1445,7 +1445,7 @@ mod test {
             enc.start(&iv);
             {
                 let mut w = Filter::new(&mut enc, &mut res);
-                for byte in pt.iter() {
+                for byte in &pt {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1457,7 +1457,7 @@ mod test {
             dec.start(&iv);
             {
                 let mut w = Filter::new(&mut dec, &mut res);
-                for byte in ct.iter() {
+                for byte in &ct {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1472,7 +1472,7 @@ mod test {
     fn test_cbc_padded_write() {
         let mut n = 0;
 
-        for item in CBC_PADDED_VEC.iter() {
+        for item in &CBC_PADDED_VEC {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
             let mut res: Vec<u8> = Vec::new();
@@ -1481,7 +1481,7 @@ mod test {
             enc.start(&iv);
             {
                 let mut w = PaddedFilter::new(&mut enc, &mut res);
-                for byte in pt.iter() {
+                for byte in &pt {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
                 assert!(w.close().is_ok(), "vec #{}", n);
@@ -1493,7 +1493,7 @@ mod test {
             dec.start(&iv);
             {
                 let mut w = PaddedFilter::new(&mut dec, &mut res);
-                for byte in ct.iter() {
+                for byte in &ct {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
                 assert!(w.close().is_ok(), "vec #{}", n);
@@ -1508,7 +1508,7 @@ mod test {
     fn test_cbc_padded_write_twice() {
         let mut n = 0;
 
-        for item in CBC_PADDED_VEC.iter() {
+        for item in &CBC_PADDED_VEC {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
             let mut res: Vec<u8> = Vec::new();
@@ -1517,7 +1517,7 @@ mod test {
             enc.start(&iv);
             {
                 let mut w = Filter::new(&mut enc, &mut res);
-                for byte in pt.iter() {
+                for byte in &pt {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1532,7 +1532,7 @@ mod test {
             dec.start(&iv);
             {
                 let mut w = Filter::new(&mut dec, &mut res);
-                for byte in ct.iter() {
+                for byte in &ct {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1550,7 +1550,7 @@ mod test {
     #[cfg(feature = "aes_gcm")]
     fn test_gcm_apply() {
         let mut n = 0;
-        for item in GCM_VEC.iter() {
+        for item in &GCM_VEC {
             let (algo, key, iv, aad, pt, ct, tag) = unpack6(item);
             let mut res: Vec<u8> = repeat(0).take(pt.len()).collect();
 
@@ -1586,7 +1586,7 @@ mod test {
     #[cfg(feature = "aes_gcm")]
     fn test_gcm_write() {
         let mut n = 0;
-        for item in GCM_VEC.iter() {
+        for item in &GCM_VEC {
             let (algo, key, iv, aad, pt, ct, tag) = unpack6(item);
             let mut res: Vec<u8> = Vec::new();
 
@@ -1599,7 +1599,7 @@ mod test {
             }
             {
                 let mut w = Filter::new(&mut enc, &mut res);
-                for byte in pt.iter() {
+                for byte in &pt {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1617,7 +1617,7 @@ mod test {
             }
             {
                 let mut w = Filter::new(&mut dec, &mut res);
-                for byte in ct.iter() {
+                for byte in &ct {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }
@@ -1635,7 +1635,7 @@ mod test {
         let dummy = vec![0xcd; 256];
         let mut dummy_res = vec![0; 256];
         let mut n = 0;
-        for item in GCM_VEC.iter() {
+        for item in &GCM_VEC {
             let (algo, key, iv, aad, pt, ct, tag) = unpack6(item);
             let mut res: Vec<u8> = repeat(0).take(pt.len()).collect();
 
@@ -1682,7 +1682,7 @@ mod test {
     fn test_gcm_auth_fail() {
         let garbage = b"This is dummy invalid input";
         let mut n = 0;
-        for item in GCM_VEC.iter() {
+        for item in &GCM_VEC {
             let (algo, key, iv, aad, pt, _, tag) = unpack6(item);
             let buf_len = max(pt.len(), garbage.len());
             let mut res: Vec<u8> = repeat(0).take(buf_len).collect();
@@ -1718,13 +1718,13 @@ mod test {
     fn test_gcm_var_tag_len() {
         let test_lens = vec![4, 8, 12, 13, 14, 15, 16];
         let mut n = 0;
-        for item in GCM_VEC.iter() {
+        for item in &GCM_VEC {
             let (algo, key, iv, aad, pt, ct, tag) = unpack6(item);
             let mut res: Vec<u8> = repeat(0).take(pt.len()).collect();
             let mut enc = GcmEncrypt::new(algo, &key);
             let mut dec = GcmDecrypt::new(algo, &key);
 
-            for tag_len in test_lens.iter() {
+            for tag_len in &test_lens {
                 let range = ..*tag_len;
                 if aad.len() > 0 {
                     enc.start(&iv, Some(&aad));
@@ -1751,7 +1751,7 @@ mod test {
     #[cfg(feature = "aes_ctr")]
     fn test_ctr_apply() {
         let mut n = 0;
-        for item in CTR_VEC.iter() {
+        for item in &CTR_VEC {
             let (algo, key, _, _, pt, ct) = unpack5(item);
             let iv: u64 = from_str_radix(item.2, 16).unwrap();
             let ctr: u64 = from_str_radix(item.3, 16).unwrap();
@@ -1774,7 +1774,7 @@ mod test {
         let dummy = vec![0xcd; 23];
         let mut dummy_res = vec![0; 256];
         let mut n = 0;
-        for item in CTR_VEC.iter() {
+        for item in &CTR_VEC {
             let (algo, key, _, _, pt, ct) = unpack5(item);
             let iv: u64 = from_str_radix(item.2, 16).unwrap();
             let ctr: u64 = from_str_radix(item.3, 16).unwrap();
@@ -1798,7 +1798,7 @@ mod test {
     #[cfg(feature = "aes_ctr")]
     fn test_ctr_write() {
         let mut n = 0;
-        for item in CTR_VEC.iter() {
+        for item in &CTR_VEC {
             let (algo, key, _, _, pt, ct) = unpack5(item);
             let iv: u64 = from_str_radix(item.2, 16).unwrap();
             let ctr: u64 = from_str_radix(item.3, 16).unwrap();
@@ -1808,7 +1808,7 @@ mod test {
             enc.start(iv, ctr);
             {
                 let mut w = Filter::new(&mut enc, &mut res);
-                for byte in pt.iter() {
+                for byte in &pt {
                     assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
                 }
             }

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -790,7 +790,7 @@ mod test {
     ];
 
     const GCM_VEC: [(Aes, &'static str, &'static str, &'static str,
-                     &'static str, &'static str, &'static str); 8] = [
+                     &'static str, &'static str, &'static str); 12] = [
         (Aes128,                                // algo
          "7fddb57453c241d03efbed3ac44e371c",    // key
          "ee283a3fc75575e33efd4887",            // iv
@@ -819,6 +819,20 @@ mod test {
           "3803a0727eeb0ade441e0ec107161ded2d425ec0d102f21f51bf2cf9947c7ec4aa72795b2f69b041596e8817d0a3c16f8fadeb",
           "b9a535864f48ea7b6b1367914978f9bfa087d854bb0e269bed8d279d2eea1210e48947338b22f9bad09093276a331e9c79c7f4",
           "4f71e72bde0018f555c5adcce062e005"),
+         (Aes128,
+          "2370e320d4344208e0ff5683f243b213",
+          "04dbb82f044d30831c441228",
+          "d43a8e5089eea0d026c03a85178b27da",
+          "",
+          "",
+          "2a049c049d25aa95969b451d93c31c6e"),
+         (Aes128,
+          "762da58bb000f5d499818bc859989a30",
+          "584c291ff1aa388a5112521e",
+          "91f92e8bbda7b5ec967ade766f4f26e9189eaafad416f37b4891d3e37d70cb9a267aa843dd202858ade020261223dfce",
+          "",
+          "",
+          "9ac7eb2d762facae06086c957959880e"),
          (Aes256,
           "4c8ebfe1444ec1b2d503c6986659af2c94fafe945f72c1e8486a5acfedb8a0f8",
           "473360e0ad24889959858995",
@@ -847,6 +861,20 @@ mod test {
           "b4d0ecc410c430b61c11a1a42802858a0e9ee12f9a912f2f6b0570c99177f6de4bd79830cf9efb30759055e1f70d21e3f74957",
           "b20542b61b8fa6f847198334cb82fdbcb2311be855a6b2b3662bdb06ff0796238bea092a8ea21b585d38ace950378f41224269",
           "3bdd1d0cc2bbcefffe0ed2121aecbd00"),
+         (Aes256,
+          "6dfdafd6703c285c01f14fd10a6012862b2af950d4733abb403b2e745b26945d",
+          "3749d0b3d5bacb71be06ade6",
+          "c0d249871992e70302ae008193d1e89f",
+          "",
+          "",
+          "4aa4cc69f84ee6ac16d9bfb4e05de500"),
+         (Aes256,
+          "752a9b3cc5f29bba64e773460c7396c13f911fe77de054097da5b682ea525d79",
+          "f93e50fe23883216de85d3b4",
+          "346dd8f25abaf85221fcbbccf794fe3c6794c0f16557e2ba14f9c03bffc99ee5539b9142d1952e66af35df91250e690b",
+          "",
+          "",
+          "f02936676e36e7598258c37210b4470f"),
     ];
 
     #[test]

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -1,0 +1,252 @@
+use libc::c_int;
+use std::old_io::{IoError, Writer};
+
+use ffi;
+
+#[derive(PartialEq, Copy)]
+enum State {
+    Reset,
+    Updated,
+    Finalized,
+}
+
+use self::State::*;
+
+#[derive(Copy, PartialEq)]
+enum Direction {
+    Decrypt,
+    Encrypt,
+}
+
+macro_rules! chk {
+    ($inp:expr) => (
+        {
+            let r = $inp;
+            assert!(r == 1);
+            r
+        }
+    );
+}
+
+struct Context {
+    ctx: *mut ffi::EVP_CIPHER_CTX,
+    state: State,
+}
+
+const MAX_BLOCK_LEN: usize = 16;
+const DEFAULT_BUF_LEN: usize = 16384;
+
+trait Type {
+    fn key_len(&self) -> usize;
+    fn padding(&self) -> bool;
+}
+
+trait EVPC {
+    fn evpc(&self) -> *const ffi::EVP_CIPHER;
+}
+
+impl Context {
+    fn new(cipher: *const ffi::EVP_CIPHER, dir: Direction, key: &[u8]) -> Context {
+        ffi::init();
+
+        let mut ctx;
+        unsafe {
+            ctx = ffi::EVP_CIPHER_CTX_new();
+            assert!(!ctx.is_null());
+            let enc = match dir {
+                Direction::Decrypt => 0,
+                Direction::Encrypt => 1,
+            };
+            chk!(ffi::EVP_CipherInit_ex(ctx, cipher, 0 as *const _,
+                                        key.as_ptr(), 0 as *const _, enc));
+        };
+
+        Context { ctx: ctx, state: Finalized }
+    }
+
+    fn init(&mut self) {
+        assert!(self.state == Finalized);
+        unsafe {
+            chk!(ffi::EVP_CipherInit_ex(self.ctx, 0 as *const _, 0 as *const _,
+                                        0 as *const _, 0 as *const _, -1));
+        }
+        self.state = Reset;
+    }
+
+    /*
+    unsafe fn init_with_iv(&mut self, iv: &[u8]) {
+        assert!(self.state == Finalized);
+        unsafe {
+            chk!(ffi::EVP_CipherInit_ex(self.ctx, 0 as *const _, 0 as *const _,
+                                        0 as *const _, iv.as_ptr(), -1));
+        }
+        self.state = Reset;
+    }
+    */
+
+    unsafe fn update(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
+        assert!(self.state != Finalized);
+        let len = unsafe {
+            let mut l = 0;
+            chk!(ffi::EVP_CipherUpdate(self.ctx, buf.as_mut_ptr(), &mut l,
+                                       data.as_ptr(), data.len() as c_int));
+            l as usize
+        };
+        assert!(len <= buf.len());
+        self.state = Updated;
+        len
+    }
+
+    fn checked_update(&mut self, data: &[u8], buf: &mut [u8], block_len: usize) -> usize {
+        assert!(buf.len() >= data.len() + block_len);
+        unsafe { self.update(data, buf) }
+    }
+
+    unsafe fn finalize(&mut self, buf: &mut [u8]) -> usize {
+        assert!(self.state != Finalized);
+        let len = unsafe {
+            let mut l = 0;
+            chk!(ffi::EVP_CipherFinal_ex(self.ctx, buf.as_mut_ptr(), &mut l));
+            l as usize
+        };
+        assert!(len <= buf.len());
+        self.state = Finalized;
+        len
+    }
+
+    fn checked_finalize(&mut self, buf: &mut [u8], block_len: usize) -> usize {
+        assert!(buf.len() >= block_len);
+        unsafe { self.finalize(buf) }
+    }
+
+    fn set_padding(&mut self, pad: bool) {
+        unsafe {
+            let p = match pad { true => 1, false => 0 };
+            chk!(ffi::EVP_CIPHER_CTX_set_padding(self.ctx, p));
+        }
+    }
+}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        unsafe {
+            if self.state != Finalized {
+                let mut buf: [u8; MAX_BLOCK_LEN] = ::std::mem::uninitialized();
+                let mut l = 0;
+                ffi::EVP_CipherFinal_ex(self.ctx, buf.as_mut_ptr(), &mut l);
+            }
+            ffi::EVP_CIPHER_CTX_free(self.ctx);
+        }
+    }
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Copy)]
+pub enum ECBType {
+    AES_128_PADDED,
+    AES_256_PADDED,
+    AES_128_RAW,
+    AES_256_RAW,
+}
+
+impl Type for ECBType {
+    fn key_len(&self) -> usize {
+        use self::ECBType::*;
+        match *self {
+            AES_128_PADDED | AES_128_RAW => 16,
+            AES_256_PADDED | AES_256_RAW => 32,
+        }
+    }
+
+    fn padding(&self) -> bool {
+        use self::ECBType::*;
+        match *self {
+            AES_128_PADDED | AES_256_PADDED => true,
+            AES_128_RAW | AES_256_RAW => false,
+        }
+    }
+}
+
+impl EVPC for ECBType {
+    fn evpc(&self) -> *const ffi::EVP_CIPHER {
+        use self::ECBType::*;
+        unsafe {
+            match *self {
+                AES_128_PADDED | AES_128_RAW => ffi::EVP_aes_128_ecb(),
+                AES_256_PADDED | AES_256_RAW => ffi::EVP_aes_256_ecb(),
+            }
+        }
+    }
+}
+
+pub struct ECB<'a> {
+    context: Context,
+    sink: Option<&'a mut (Writer + 'a)>,
+}
+
+impl <'a> ECB<'a> {
+    pub fn new_encrypt(ty: ECBType, key: &[u8]) -> ECB<'a> {
+        let mut c = Context::new(ty.evpc(), Direction::Encrypt, key);
+        c.set_padding(ty.padding());
+        ECB { context: c, sink: None }
+    }
+
+    pub fn start(&mut self, sink: &'a mut (Writer + 'a)) {
+        if self.context.state != Finalized {
+            self.finish();
+        }
+        self.sink = Some(sink);
+        self.context.init();
+    }
+
+    pub fn finish(&mut self) {
+        assert!(self.context.state != Finalized);
+        let mut sink = self.sink.as_mut().expect("start() never called");
+        let mut buf = [0; MAX_BLOCK_LEN];
+        let len = self.context.checked_finalize(&mut buf, MAX_BLOCK_LEN);
+        if len > 0 {
+            let _ = sink.write_all(&buf[..len]);
+        }
+    }
+}
+
+impl <'a> Writer for ECB<'a> {
+    fn write_all(&mut self, data: &[u8]) -> Result<(), IoError> {
+        if self.context.state == Finalized {
+            self.context.init();
+        }
+        let mut sink = self.sink.as_mut().expect("start() never called");
+        let mut buf = [0; DEFAULT_BUF_LEN + MAX_BLOCK_LEN];
+        for chunk in data.chunks(DEFAULT_BUF_LEN) {
+            let len = self.context.checked_update(chunk, &mut buf, MAX_BLOCK_LEN);
+            if len > 0 {
+                let _ = sink.write_all(&buf[..len]);
+            }
+        }
+        Ok(())
+    }
+}
+
+    #[test]
+    fn test_symm_new_aes_256_ecb() {
+        let k0 =
+           vec!(0x00u8, 0x01u8, 0x02u8, 0x03u8, 0x04u8, 0x05u8, 0x06u8, 0x07u8,
+              0x08u8, 0x09u8, 0x0au8, 0x0bu8, 0x0cu8, 0x0du8, 0x0eu8, 0x0fu8,
+              0x10u8, 0x11u8, 0x12u8, 0x13u8, 0x14u8, 0x15u8, 0x16u8, 0x17u8,
+              0x18u8, 0x19u8, 0x1au8, 0x1bu8, 0x1cu8, 0x1du8, 0x1eu8, 0x1fu8);
+        let p0 =
+           vec!(0x00u8, 0x11u8, 0x22u8, 0x33u8, 0x44u8, 0x55u8, 0x66u8, 0x77u8,
+              0x88u8, 0x99u8, 0xaau8, 0xbbu8, 0xccu8, 0xddu8, 0xeeu8, 0xffu8);
+        let c0 =
+           vec!(0x8eu8, 0xa2u8, 0xb7u8, 0xcau8, 0x51u8, 0x67u8, 0x45u8, 0xbfu8,
+              0xeau8, 0xfcu8, 0x49u8, 0x90u8, 0x4bu8, 0x49u8, 0x60u8, 0x89u8);
+
+        let mut r0 = Vec::new();
+        {
+            let mut c = ECB::new_encrypt(ECBType::AES_256_RAW, &*k0);
+            c.start(&mut r0);
+            let _ = ::std::old_io::util::copy(&mut &*p0, &mut c);
+            c.finish();
+        }
+        assert!(r0 == c0);
+    }

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -36,15 +36,6 @@ struct Context {
 const MAX_BLOCK_LEN: usize = 16;
 const DEFAULT_BUF_LEN: usize = 16384;
 
-trait Type {
-    fn key_len(&self) -> usize;
-    fn padding(&self) -> bool;
-}
-
-trait EVPC {
-    fn evpc(&self) -> *const ffi::EVP_CIPHER;
-}
-
 trait Coder {
     fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize;
     fn finish(&mut self, buf: &mut [u8]) -> usize;
@@ -107,16 +98,12 @@ impl Context {
         self.state = Reset;
     }
 
-    /*
     unsafe fn init_with_iv(&mut self, iv: &[u8]) {
-        assert!(self.state == Finalized);
-        unsafe {
-            chk!(ffi::EVP_CipherInit_ex(self.ctx, 0 as *const _, 0 as *const _,
-                                        0 as *const _, iv.as_ptr(), -1));
-        }
+        assert!(self.state == Finalized, "Illegal call order");
+        chk!(ffi::EVP_CipherInit_ex(self.ctx, 0 as *const _, 0 as *const _,
+                                    0 as *const _, iv.as_ptr(), -1));
         self.state = Reset;
     }
-    */
 
     unsafe fn update(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
         assert!(self.state != Finalized, "Illegal call order");
@@ -170,146 +157,358 @@ impl Drop for Context {
     }
 }
 
-#[allow(non_camel_case_types)]
-#[derive(Copy)]
-pub enum ECBType {
-    AES_128_PADDED,
-    AES_256_PADDED,
-    AES_128_RAW,
-    AES_256_RAW,
-}
+pub mod ecb{
+    use super::{Coder, Context, Direction, WriterAdapter};
+    use ffi;
 
-impl Type for ECBType {
-    fn key_len(&self) -> usize {
-        use self::ECBType::*;
-        match *self {
-            AES_128_PADDED | AES_128_RAW => 16,
-            AES_256_PADDED | AES_256_RAW => 32,
-        }
+    #[allow(non_camel_case_types)]
+    #[derive(Copy, PartialEq, Debug)]
+    pub enum Type {
+        AES_128_PADDED,
+        AES_256_PADDED,
+        AES_128_RAW,
+        AES_256_RAW,
     }
 
-    fn padding(&self) -> bool {
-        use self::ECBType::*;
-        match *self {
-            AES_128_PADDED | AES_256_PADDED => true,
-            AES_128_RAW | AES_256_RAW => false,
-        }
-    }
-}
-
-impl EVPC for ECBType {
-    fn evpc(&self) -> *const ffi::EVP_CIPHER {
-        use self::ECBType::*;
-        unsafe {
+    impl Type {
+        fn padding(&self) -> bool {
+            use self::Type::*;
             match *self {
-                AES_128_PADDED | AES_128_RAW => ffi::EVP_aes_128_ecb(),
-                AES_256_PADDED | AES_256_RAW => ffi::EVP_aes_256_ecb(),
+                AES_128_PADDED | AES_256_PADDED => true,
+                AES_128_RAW | AES_256_RAW => false,
+            }
+        }
+
+        fn evpc(&self) -> *const ffi::EVP_CIPHER {
+            use self::Type::*;
+            unsafe {
+                match *self {
+                    AES_128_PADDED | AES_128_RAW => ffi::EVP_aes_128_ecb(),
+                    AES_256_PADDED | AES_256_RAW => ffi::EVP_aes_256_ecb(),
+                }
             }
         }
     }
+
+    pub struct ECB {
+        context: Context,
+    }
+
+    impl ECB {
+        pub fn new_encrypt(ty: Type, key: &[u8]) -> ECB {
+            let mut c = Context::new(ty.evpc(), Direction::Encrypt, key);
+            c.set_padding(ty.padding());
+            ECB { context: c }
+        }
+
+        pub fn new_decrypt(ty: Type, key: &[u8]) -> ECB {
+            let mut c = Context::new(ty.evpc(), Direction::Decrypt, key);
+            c.set_padding(ty.padding());
+            ECB { context: c }
+        }
+
+        pub fn start(&mut self) {
+            self.context.init();
+        }
+
+        pub fn start_writer<'a>(&'a mut self, sink: &'a mut (Writer + 'a))
+                    -> WriterAdapter<'a, ECB> {
+            self.start();
+            WriterAdapter { parent: self, sink: sink }
+        }
+    }
+
+    impl Coder for ECB {
+        fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
+            let len = self.context.checked_update(data, buf, super::MAX_BLOCK_LEN);
+            len
+        }
+
+        fn finish(&mut self, buf: &mut [u8]) -> usize {
+            let len = self.context.checked_finalize(buf, super::MAX_BLOCK_LEN);
+            len
+        }
+    }
+
 }
 
-pub struct ECB {
-    context: Context,
+pub mod cbc {
+    use super::{Coder, Context, Direction, WriterAdapter};
+    use ffi;
+
+    #[allow(non_camel_case_types)]
+    #[derive(Copy, PartialEq, Debug)]
+    pub enum Type {
+        AES_128_PADDED,
+        AES_256_PADDED,
+        AES_128_RAW,
+        AES_256_RAW,
+    }
+
+    impl Type {
+        fn padding(&self) -> bool {
+            use self::Type::*;
+            match *self {
+                AES_128_PADDED | AES_256_PADDED => true,
+                AES_128_RAW | AES_256_RAW => false,
+            }
+        }
+
+        fn evpc(&self) -> *const ffi::EVP_CIPHER {
+            use self::Type::*;
+            unsafe {
+                match *self {
+                    AES_128_PADDED | AES_128_RAW => ffi::EVP_aes_128_cbc(),
+                    AES_256_PADDED | AES_256_RAW => ffi::EVP_aes_256_cbc(),
+                }
+            }
+        }
+    }
+
+    pub struct CBC {
+        context: Context,
+    }
+
+    impl CBC {
+        pub fn new_encrypt(ty: Type, key: &[u8]) -> CBC {
+            let mut c = Context::new(ty.evpc(), Direction::Encrypt, key);
+            c.set_padding(ty.padding());
+            CBC { context: c }
+        }
+
+        pub fn new_decrypt(ty: Type, key: &[u8]) -> CBC {
+            let mut c = Context::new(ty.evpc(), Direction::Decrypt, key);
+            c.set_padding(ty.padding());
+            CBC { context: c }
+        }
+
+        pub fn start(&mut self, iv: &[u8]) {
+            unsafe { self.context.init_with_iv(iv); }
+        }
+
+        pub fn start_writer<'a>(&'a mut self, iv: &[u8], sink: &'a mut (Writer + 'a))
+                    -> WriterAdapter<'a, CBC> {
+            self.start(iv);
+            WriterAdapter { parent: self, sink: sink }
+        }
+    }
+
+    impl Coder for CBC {
+        fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
+            let len = self.context.checked_update(data, buf, super::MAX_BLOCK_LEN);
+            len
+        }
+
+        fn finish(&mut self, buf: &mut [u8]) -> usize {
+            let len = self.context.checked_finalize(buf, super::MAX_BLOCK_LEN);
+            len
+        }
+    }
+
 }
-
-impl ECB {
-    pub fn new_encrypt(ty: ECBType, key: &[u8]) -> ECB {
-        let mut c = Context::new(ty.evpc(), Direction::Encrypt, key);
-        c.set_padding(ty.padding());
-        ECB { context: c }
-    }
-
-    pub fn new_decrypt(ty: ECBType, key: &[u8]) -> ECB {
-        let mut c = Context::new(ty.evpc(), Direction::Decrypt, key);
-        c.set_padding(ty.padding());
-        ECB { context: c }
-    }
-
-    pub fn start(&mut self) {
-        self.context.init();
-    }
-
-    pub fn start_writer<'a>(&'a mut self, sink: &'a mut (Writer + 'a))
-                -> WriterAdapter<'a, ECB> {
-        self.start();
-        WriterAdapter { parent: self, sink: sink }
-    }
-}
-
-impl Coder for ECB {
-    fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
-        let len = self.context.checked_update(data, buf, MAX_BLOCK_LEN);
-        len
-    }
-
-    fn finish(&mut self, buf: &mut [u8]) -> usize {
-        let len = self.context.checked_finalize(buf, MAX_BLOCK_LEN);
-        len
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use super::{ECB, ECBType, Coder};
+    use super::Coder;
+    use super::ecb::{self, ECB};
+    use super::cbc::{self, CBC};
     use std::iter::repeat;
     use serialize::hex::FromHex;
 
-    const ECB_Vec: [(u16, &'static str, &'static str, &'static str); 1] = [
-        (128, "00000000000000000000000000000000",
-              "ffffffffffffffff8000000000000000",
-              "41f992a856fb278b389a62f5d274d7e9"),
+    fn unpack3<T: Copy>(tup: &(T, &str, &str, &str))
+                       -> (T, Vec<u8>, Vec<u8>, Vec<u8>) {
+        (tup.0, tup.1.from_hex().unwrap(), tup.2.from_hex().unwrap(),
+         tup.3.from_hex().unwrap())
+    }
+
+    fn unpack4<T: Copy>(tup: &(T, &str, &str, &str, &str))
+                       -> (T, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) {
+        (tup.0, tup.1.from_hex().unwrap(), tup.2.from_hex().unwrap(),
+         tup.3.from_hex().unwrap(), tup.4.from_hex().unwrap())
+    }
+
+    const ECB_VEC: [(ecb::Type, &'static str, &'static str, &'static str); 8] = [
+        // One block
+        (ecb::Type::AES_128_RAW,
+         "99a5758d22880b01a4922f094dafceaa",
+         "d47b00a342faacdb9d7655c1bff4b8c3",
+         "5e69f8b8b97ebbf7e2754a3d7fb9fa99"),
+        (ecb::Type::AES_128_PADDED,
+         "99a5758d22880b01a4922f094dafceaa",
+         "d47b00a342faacdb9d7655c1",
+         "56ff92fb78bb6a00d0bd5165ae89b64d"),
+        (ecb::Type::AES_256_RAW,
+         "16bd7e90a390f53e11cfe51c6c44cefbd6bcd87e1b1925fdc679edc21985f0de",
+         "d47b00a342faacdb9d7655c1bff4b8c3",
+         "00512f8c8717266aa0b91eec01604d7c"),
+        (ecb::Type::AES_256_PADDED,
+         "16bd7e90a390f53e11cfe51c6c44cefbd6bcd87e1b1925fdc679edc21985f0de",
+         "d47b00a342faacdb9d7655c1",
+         "80c1deb5f8a465f00daf7c2f67fc861d"),
+        // Two blocks
+        (ecb::Type::AES_128_RAW,
+         "99a5758d22880b01a4922f094dafceaa",
+         "707071c411335f0acfc5aea1698eaf2bd47b00a342faacdb9d7655c1bff4b8c3",
+         "5cdd30b18d67d8a3670c0ed76913b5605e69f8b8b97ebbf7e2754a3d7fb9fa99"),
+        (ecb::Type::AES_128_PADDED,
+         "99a5758d22880b01a4922f094dafceaa",
+         "707071c411335f0acfc5aea1698eaf2bd47b00a342faacdb9d7655c1",
+         "5cdd30b18d67d8a3670c0ed76913b56056ff92fb78bb6a00d0bd5165ae89b64d"),
+        (ecb::Type::AES_256_RAW,
+         "16bd7e90a390f53e11cfe51c6c44cefbd6bcd87e1b1925fdc679edc21985f0de",
+         "707071c411335f0acfc5aea1698eaf2bd47b00a342faacdb9d7655c1bff4b8c3",
+         "9d1001068827dd328ed86a540d4496b200512f8c8717266aa0b91eec01604d7c"),
+        (ecb::Type::AES_256_PADDED,
+         "16bd7e90a390f53e11cfe51c6c44cefbd6bcd87e1b1925fdc679edc21985f0de",
+         "707071c411335f0acfc5aea1698eaf2bd47b00a342faacdb9d7655c1",
+         "9d1001068827dd328ed86a540d4496b280c1deb5f8a465f00daf7c2f67fc861d"),
+    ];
+
+    const CBC_VEC: [(cbc::Type, &'static str, &'static str, &'static str, &'static str); 8] = [
+        // One block
+        (cbc::Type::AES_128_RAW,
+         "99a5758d22880b01a4922f094dafceaa",
+         "4002ddc1cd72650c32b895b026a3bda4",
+         "d47b00a342faacdb9d7655c1bff4b8c3",
+         "3a44bd0d547d82235effd2da38dbafc3"),
+        (cbc::Type::AES_128_PADDED,
+         "99a5758d22880b01a4922f094dafceaa",
+         "4002ddc1cd72650c32b895b026a3bda4",
+         "d47b00a342faacdb9d7655c1",
+         "b0dfa61dc8f7fd500d03899d875bbd2a"),
+        (cbc::Type::AES_256_RAW,
+         "16bd7e90a390f53e11cfe51c6c44cefbd6bcd87e1b1925fdc679edc21985f0de",
+         "4002ddc1cd72650c32b895b026a3bda4",
+         "d47b00a342faacdb9d7655c1bff4b8c3",
+         "7b9a09eabe4bd9eef5fb8af84c7ee8dd"),
+        (cbc::Type::AES_256_PADDED,
+         "16bd7e90a390f53e11cfe51c6c44cefbd6bcd87e1b1925fdc679edc21985f0de",
+         "4002ddc1cd72650c32b895b026a3bda4",
+         "d47b00a342faacdb9d7655c1",
+         "53fe2c0e77d663c454ffd9d3c53e2632"),
+        // Two blocks
+        (cbc::Type::AES_128_RAW,
+         "99a5758d22880b01a4922f094dafceaa",
+         "4002ddc1cd72650c32b895b026a3bda4",
+         "707071c411335f0acfc5aea1698eaf2bd47b00a342faacdb9d7655c1bff4b8c3",
+         "698d24fa0a2fd282a3b724aafb8a1f547141be417fb40de785304c58452e713a"),
+        (cbc::Type::AES_128_PADDED,
+         "99a5758d22880b01a4922f094dafceaa",
+         "4002ddc1cd72650c32b895b026a3bda4",
+         "707071c411335f0acfc5aea1698eaf2bd47b00a342faacdb9d7655c1",
+         "698d24fa0a2fd282a3b724aafb8a1f5484046b796f05238ef8a6b551ab5fba66"),
+        (cbc::Type::AES_256_RAW,
+         "16bd7e90a390f53e11cfe51c6c44cefbd6bcd87e1b1925fdc679edc21985f0de",
+         "4002ddc1cd72650c32b895b026a3bda4",
+         "707071c411335f0acfc5aea1698eaf2bd47b00a342faacdb9d7655c1bff4b8c3",
+         "19a066de723ca454666290f8e8147a6d98288504b7ec8b80f3699954d1d930ff"),
+        (cbc::Type::AES_256_PADDED,
+         "16bd7e90a390f53e11cfe51c6c44cefbd6bcd87e1b1925fdc679edc21985f0de",
+         "4002ddc1cd72650c32b895b026a3bda4",
+         "707071c411335f0acfc5aea1698eaf2bd47b00a342faacdb9d7655c1",
+         "19a066de723ca454666290f8e8147a6ddde9fb1e6dbb8a52b5b09b24e228bc2d"),
     ];
 
     #[test]
-    fn test_ecb_128_apply() {
-        for &(_, key, pt, ct) in ECB_Vec.iter().filter(|&x| x.0 == 128) {
-            let key = key.from_hex().unwrap();
-            let pt = pt.from_hex().unwrap();
-            let ct = ct.from_hex().unwrap();
+    fn test_ecb_apply() {
+        let mut n = 0;
+        for item in ECB_VEC.iter() {
+            let (ty, key, pt, ct) = unpack3(item);
 
             let mut res_ct: Vec<u8> = repeat(0).take(pt.len() + super::MAX_BLOCK_LEN).collect();
-            let mut c = ECB::new_encrypt(ECBType::AES_128_RAW, &*key);
+            let mut c = ECB::new_encrypt(ty, &*key);
             c.start();
             let len = c.apply(&*pt, &mut *res_ct);
             let len2 = c.finish(&mut res_ct[len..]);
             res_ct.truncate(len + len2);
-            assert_eq!(ct, res_ct);
+            assert!(ct == res_ct, "{:?} encrypt #{}", ty, n);
 
-            //let mut res_pt = repeat(0).take(pt.len() + super::MAX_BLOCK_LEN);
-            //let mut d = ECB::new_decrypt(ECBType::AES_128_RAW, &*key);
+            let mut res_pt: Vec<u8> = repeat(0).take(res_ct.len() + super::MAX_BLOCK_LEN).collect();
+            let mut d = ECB::new_decrypt(ty, &*key);
+            d.start();
+            let len = d.apply(&*res_ct, &mut *res_pt);
+            let len2 = d.finish(&mut res_pt[len..]);
+            res_pt.truncate(len + len2);
+            assert!(pt == res_pt, "{:?} decrypt #{}", ty, n);
 
+            n += 1;
         }
     }
 
     #[test]
-    fn test_symm_new_aes_256_ecb() {
-        let k0 =
-           vec!(0x00u8, 0x01u8, 0x02u8, 0x03u8, 0x04u8, 0x05u8, 0x06u8, 0x07u8,
-              0x08u8, 0x09u8, 0x0au8, 0x0bu8, 0x0cu8, 0x0du8, 0x0eu8, 0x0fu8,
-              0x10u8, 0x11u8, 0x12u8, 0x13u8, 0x14u8, 0x15u8, 0x16u8, 0x17u8,
-              0x18u8, 0x19u8, 0x1au8, 0x1bu8, 0x1cu8, 0x1du8, 0x1eu8, 0x1fu8);
-        let p0 =
-           vec!(0x00u8, 0x11u8, 0x22u8, 0x33u8, 0x44u8, 0x55u8, 0x66u8, 0x77u8,
-              0x88u8, 0x99u8, 0xaau8, 0xbbu8, 0xccu8, 0xddu8, 0xeeu8, 0xffu8);
-        let c0 =
-           vec!(0x8eu8, 0xa2u8, 0xb7u8, 0xcau8, 0x51u8, 0x67u8, 0x45u8, 0xbfu8,
-              0xeau8, 0xfcu8, 0x49u8, 0x90u8, 0x4bu8, 0x49u8, 0x60u8, 0x89u8);
+    fn test_ecb_writer() {
+        let mut n = 0;
+        for item in ECB_VEC.iter() {
+            let (ty, key, pt, ct) = unpack3(item);
 
-        let mut r0 = Vec::new();
-        let mut c = ECB::new_encrypt(ECBType::AES_256_RAW, &*k0);
-        {
-            let mut w = c.start_writer(&mut r0);
-            let _ = ::std::old_io::util::copy(&mut &*p0, &mut w);
-        }
-        assert!(r0 == c0);
+            let mut res_ct = Vec::new();
+            let mut c = ECB::new_encrypt(ty, &*key);
+            {
+                let mut w = c.start_writer(&mut res_ct);
+                let _ = ::std::old_io::util::copy(&mut &*pt, &mut w);
+            }
+            assert!(ct == res_ct, "{:?} encrypt #{}", ty, n);
 
-        let mut p1 = Vec::new();
-        let mut d = ECB::new_decrypt(ECBType::AES_256_RAW, &*k0);
-        {
-            let mut w = d.start_writer(&mut p1);
-            let _ = ::std::old_io::util::copy(&mut &*c0, &mut w);
+            let mut res_pt = Vec::new();
+            let mut d = ECB::new_decrypt(ty, &*key);
+            {
+                let mut w = d.start_writer(&mut res_pt);
+                let _ = ::std::old_io::util::copy(&mut &*res_ct, &mut w);
+            }
+            assert!(pt == res_pt, "{:?} decrypt #{}", ty, n);
+
+            n += 1;
         }
-        assert!(p0 == p1);
+    }
+
+    #[test]
+    fn test_cbc_apply() {
+        let mut n = 0;
+        for item in CBC_VEC.iter() {
+            let (ty, key, iv, pt, ct) = unpack4(item);
+
+            let mut res_ct: Vec<u8> = repeat(0).take(pt.len() + super::MAX_BLOCK_LEN).collect();
+            let mut c = CBC::new_encrypt(ty, &*key);
+            c.start(&*iv);
+            let len = c.apply(&*pt, &mut *res_ct);
+            let len2 = c.finish(&mut res_ct[len..]);
+            res_ct.truncate(len + len2);
+            assert!(ct == res_ct, "{:?} encrypt #{}", ty, n);
+
+            let mut res_pt: Vec<u8> = repeat(0).take(res_ct.len() + super::MAX_BLOCK_LEN).collect();
+            let mut d = CBC::new_decrypt(ty, &*key);
+            d.start(&*iv);
+            let len = d.apply(&*res_ct, &mut *res_pt);
+            let len2 = d.finish(&mut res_pt[len..]);
+            res_pt.truncate(len + len2);
+            assert!(pt == res_pt, "{:?} decrypt #{}", ty, n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_cbc_writer() {
+        let mut n = 0;
+        for item in CBC_VEC.iter() {
+            let (ty, key, iv, pt, ct) = unpack4(item);
+
+            let mut res_ct = Vec::new();
+            let mut c = CBC::new_encrypt(ty, &*key);
+            {
+                let mut w = c.start_writer(&*iv, &mut res_ct);
+                let _ = ::std::old_io::util::copy(&mut &*pt, &mut w);
+            }
+            assert!(ct == res_ct, "{:?} encrypt #{}", ty, n);
+
+            let mut res_pt = Vec::new();
+            let mut d = CBC::new_decrypt(ty, &*key);
+            {
+                let mut w = d.start_writer(&*iv, &mut res_pt);
+                let _ = ::std::old_io::util::copy(&mut &*res_ct, &mut w);
+            }
+            assert!(pt == res_pt, "{:?} decrypt #{}", ty, n);
+
+            n += 1;
+        }
     }
 }

--- a/openssl/src/crypto/symm_new.rs
+++ b/openssl/src/crypto/symm_new.rs
@@ -1,4 +1,6 @@
-use libc::c_int;
+use std::{error, fmt, mem, ptr};
+use std::error::Error as StdError;
+use libc::{c_int, c_void};
 use std::old_io::{IoError, Writer};
 
 use ffi;
@@ -24,6 +26,43 @@ pub enum Aes {
     Aes256,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error {
+    IoError(Box<IoError>),
+    IncompleteBlock,
+    InvalidPadding,
+    AuthFailed,
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::IoError(_) => "An external IO error",
+            Error::IncompleteBlock => "Data length not a multiple of block length in raw mode",
+            Error::InvalidPadding => "Malformed or missing padding at the end",
+            Error::AuthFailed => "The supplied data has failed authentication.
+                           Any cipher output should be discarded",
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        if let Error::IoError(ref err) = *self {
+            write!(fmt, "{}: {}", self.description(), err)
+        }
+        else {
+            write!(fmt, "{}", self.description())
+        }
+    }
+}
+
+impl error::FromError<IoError> for Error {
+    fn from_error(err: IoError) -> Error {
+        Error::IoError(Box::new(err))
+    }
+}
+
 macro_rules! chk {
     ($inp:expr) => (
         {
@@ -40,18 +79,15 @@ struct Context {
     state: State,
 }
 
-const MAX_BLOCK_LEN: usize = 16;
-const DEFAULT_BUF_LEN: usize = 16384;
 
-/// A block mode cipher
-trait BlockApply {
+/// A cipher
+trait Apply {
     fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize;
-    fn finish(&mut self, buf: &mut [u8]) -> usize;
 }
 
-/// A stream(-like) mode cipher
-trait Apply {
-    fn apply(&mut self, data: &[u8], buf: &mut [u8]);
+/// A padded block mode cipher finalization
+trait PaddedFinish: Apply {
+    fn finish(&mut self, buf: &mut [u8]) -> Result<usize, Error>;
 }
 
 /// A cipher that works on large blocks (sectors)
@@ -66,6 +102,8 @@ pub struct Filter<'a, T: 'a> {
     sink: &'a mut (Writer + 'a),
 }
 
+const FILTER_BUFFER_LEN: usize = 16384;
+
 impl <'a, T> Filter<'a, T> {
     /// Create a `Writer` adapter for the `cipher`. The `cipher` has to be `start`ed.
     pub fn new(cipher: &'a mut T, sink: &'a mut (Writer + 'a))
@@ -74,28 +112,54 @@ impl <'a, T> Filter<'a, T> {
     }
 }
 
-impl <'a, T: BlockApply> Writer for Filter<'a, T> {
+impl <'a, T: Apply> Writer for Filter<'a, T> {
     fn write_all(&mut self, data: &[u8]) -> Result<(), IoError> {
-        let mut buf = [0; DEFAULT_BUF_LEN + MAX_BLOCK_LEN];
-        for chunk in data.chunks(DEFAULT_BUF_LEN) {
+        let mut buf = [0; FILTER_BUFFER_LEN + ffi::EVP_MAX_BLOCK_LENGTH];
+        for chunk in data.chunks(FILTER_BUFFER_LEN) {
             let len = self.cipher.apply(chunk, &mut buf);
             if len > 0 {
-                let _ = self.sink.write_all(&buf[..len]);
+                try!(self.sink.write_all(&buf[..len]));
             }
         }
         Ok(())
     }
 }
 
-#[unsafe_destructor]
-impl <'a, T: BlockApply> Drop for Filter<'a, T> {
-    // this should've been close()
-    fn drop(&mut self) {
-        let mut buf = [0; MAX_BLOCK_LEN];
-        // this could panic
-        let len = self.cipher.finish(&mut buf);
+/// Finishes the cipher after the last write
+pub struct PaddedFilter<'a, T: 'a> {
+    inner: Filter<'a, T>,
+    closed: bool,
+}
+
+impl <'a, T: PaddedFinish> PaddedFilter<'a, T> {
+    pub fn new(cipher: &'a mut T, sink: &'a mut (Writer + 'a))
+          -> PaddedFilter<'a, T> {
+        PaddedFilter { inner: Filter::new(cipher, sink), closed: false }
+    }
+
+    pub fn close(mut self) -> Result<(), Error> {
+        let mut buf = [0; ffi::EVP_MAX_BLOCK_LENGTH];
+        self.closed = true;
+        let len = try!(self.inner.cipher.finish(&mut buf));
         if len > 0 {
-            let _ = self.sink.write_all(&buf[..len]);
+            try!(self.inner.sink.write_all(&buf[..len]));
+        }
+        Ok(())
+    }
+}
+
+impl <'a, T: PaddedFinish> Writer for PaddedFilter<'a, T> {
+    fn write_all(&mut self, data: &[u8]) -> Result<(), IoError> {
+        self.inner.write_all(data)
+    }
+}
+
+#[unsafe_destructor]
+impl <'a, T: PaddedFinish> Drop for PaddedFilter<'a, T> {
+    fn drop(&mut self) {
+        if !self.closed {
+            let mut buf = [0; ffi::EVP_MAX_BLOCK_LENGTH];
+            let _ = self.inner.cipher.finish(&mut buf);
         }
     }
 }
@@ -146,24 +210,50 @@ impl Context {
         len
     }
 
+    fn update_aad(&mut self, data: &[u8]) {
+        assert!(self.state != Finalized, "Illegal call order");
+        unsafe {
+            let mut len = 0;
+            chk!(ffi::EVP_CipherUpdate(self.ctx, ptr::null_mut(), &mut len,
+                                       data.as_ptr(), data.len() as c_int));
+        }
+        self.state = Updated;
+    }
+
     fn checked_update(&mut self, data: &[u8], buf: &mut [u8], block_len: usize) -> usize {
         assert!(buf.len() >= data.len() + block_len);
         unsafe { self.update(data, buf) }
     }
 
-    unsafe fn finalize(&mut self, buf: &mut [u8]) -> usize {
+    unsafe fn finalize(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
         assert!(self.state != Finalized, "Illegal call order");
         let mut len = 0;
-        chk!(ffi::EVP_CipherFinal_ex(self.ctx, buf.as_mut_ptr(), &mut len));
+        let res = ffi::EVP_CipherFinal_ex(self.ctx, buf.as_mut_ptr(), &mut len);
+        self.state = Finalized;
         let len = len as usize;
         assert!(len <= buf.len());
-        self.state = Finalized;
-        len
+        if res == 1 {
+            Ok(len)
+        }
+        else {
+            Err(())
+        }
     }
 
-    fn checked_finalize(&mut self, buf: &mut [u8], block_len: usize) -> usize {
+    fn checked_finalize(&mut self, buf: &mut [u8], block_len: usize) -> Result<usize, ()> {
         assert!(buf.len() >= block_len);
         unsafe { self.finalize(buf) }
+    }
+
+    fn clean_finalize(&mut self) -> Result<(), ()> {
+        assert!(self.state != Finalized, "Illegal call order");
+        unsafe {
+            let mut buf: [u8; ffi::EVP_MAX_BLOCK_LENGTH] = mem::uninitialized();
+            match self.finalize(&mut buf) {
+                Ok(_) => Ok(()),
+                Err(_) => Err(()),
+            }
+        }
     }
 
     fn set_padding(&mut self, pad: bool) {
@@ -172,23 +262,41 @@ impl Context {
             chk!(ffi::EVP_CIPHER_CTX_set_padding(self.ctx, p));
         }
     }
+
+    fn get_tag(&mut self, buf: &mut [u8]) {
+        assert!(self.state == Finalized, "Illegal call order");
+        let len = buf.len() as c_int;
+        assert!(len == 4 || len == 8 || 12 <= len && len <= 16);
+        unsafe {
+            chk!(ffi::EVP_CIPHER_CTX_ctrl(self.ctx, ffi::EVP_CTRL_GCM_GET_TAG,
+                                          len, buf.as_mut_ptr() as *mut c_void));
+        }
+    }
+
+    fn set_tag(&mut self, buf: &[u8]) {
+        assert!(self.state == Reset, "Illegal call order");
+        let len = buf.len() as c_int;
+        assert!(len == 4 || len == 8 || 12 <= len && len <= 16);
+        unsafe {
+            chk!(ffi::EVP_CIPHER_CTX_ctrl(self.ctx, ffi::EVP_CTRL_GCM_SET_TAG,
+                                          len, buf.as_ptr() as *mut c_void));
+        }
+    }
 }
 
 impl Drop for Context {
     fn drop(&mut self) {
+        if self.state != Finalized {
+            let _ = self.clean_finalize();
+        }
         unsafe {
-            if self.state != Finalized {
-                let mut buf: [u8; MAX_BLOCK_LEN] = ::std::mem::uninitialized();
-                let mut l = 0;
-                ffi::EVP_CipherFinal_ex(self.ctx, buf.as_mut_ptr(), &mut l);
-            }
             ffi::EVP_CIPHER_CTX_free(self.ctx);
         }
     }
 }
 
 pub mod ecb{
-    use super::{Aes, BlockApply, Context, Direction};
+    use super::{Aes, Apply, Context, Direction, Error, PaddedFinish};
     use ffi;
 
     fn evpc(algo: Aes) -> *const ffi::EVP_CIPHER {
@@ -220,18 +328,23 @@ pub mod ecb{
         pub fn start(&mut self) {
             self.context.init();
         }
+
+        pub fn finish(&mut self) -> Result<(), Error> {
+            if self.context.clean_finalize().is_ok() {
+                Ok(())
+            }
+            else {
+                Err(Error::IncompleteBlock)
+            }
+        }
     }
 
-    impl BlockApply for EcbRaw {
+    impl Apply for EcbRaw {
         fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
-            let len = self.context.checked_update(data, buf, super::MAX_BLOCK_LEN);
+            let len = self.context.checked_update(data, buf, ffi::EVP_MAX_BLOCK_LENGTH);
             len
         }
 
-        fn finish(&mut self, buf: &mut [u8]) -> usize {
-            self.context.checked_finalize(buf, 0);
-            0
-        }
     }
 
     pub struct EcbPadded {
@@ -256,21 +369,27 @@ pub mod ecb{
         }
     }
 
-    impl BlockApply for EcbPadded {
+    impl Apply for EcbPadded {
         fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
-            let len = self.context.checked_update(data, buf, super::MAX_BLOCK_LEN);
+            let len = self.context.checked_update(data, buf, ffi::EVP_MAX_BLOCK_LENGTH);
             len
         }
+    }
 
-        fn finish(&mut self, buf: &mut [u8]) -> usize {
-            let len = self.context.checked_finalize(buf, super::MAX_BLOCK_LEN);
-            len
+    impl PaddedFinish for EcbPadded {
+        fn finish(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+            if let Ok(len) = self.context.checked_finalize(buf, ffi::EVP_MAX_BLOCK_LENGTH) {
+                Ok(len)
+            }
+            else {
+                Err(Error::InvalidPadding)
+            }
         }
     }
 }
 
 pub mod cbc {
-    use super::{Aes, BlockApply, Context, Direction};
+    use super::{Aes, Apply, Context, Direction, Error, PaddedFinish};
     use ffi;
 
     fn evpc(algo: Aes) -> *const ffi::EVP_CIPHER {
@@ -302,17 +421,21 @@ pub mod cbc {
         pub fn start(&mut self, iv: &[u8]) {
             unsafe { self.context.init_with_iv(iv); }
         }
+
+        pub fn finish(&mut self) -> Result<(), Error> {
+            if self.context.clean_finalize().is_ok() {
+                Ok(())
+            }
+            else {
+                Err(Error::IncompleteBlock)
+            }
+        }
     }
 
-    impl BlockApply for CbcRaw {
+    impl Apply for CbcRaw {
         fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
-            let len = self.context.checked_update(data, buf, super::MAX_BLOCK_LEN);
+            let len = self.context.checked_update(data, buf, ffi::EVP_MAX_BLOCK_LENGTH);
             len
-        }
-
-        fn finish(&mut self, buf: &mut [u8]) -> usize {
-            self.context.checked_finalize(buf, 0);
-            0
         }
     }
 
@@ -338,25 +461,127 @@ pub mod cbc {
         }
     }
 
-    impl BlockApply for CbcPadded {
+    impl Apply for CbcPadded {
         fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
-            let len = self.context.checked_update(data, buf, super::MAX_BLOCK_LEN);
+            let len = self.context.checked_update(data, buf, ffi::EVP_MAX_BLOCK_LENGTH);
             len
         }
+    }
 
-        fn finish(&mut self, buf: &mut [u8]) -> usize {
-            let len = self.context.checked_finalize(buf, super::MAX_BLOCK_LEN);
-            len
+    impl PaddedFinish for CbcPadded {
+        fn finish(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+            if let Ok(len) = self.context.checked_finalize(buf, ffi::EVP_MAX_BLOCK_LENGTH) {
+                Ok(len)
+            }
+            else {
+                Err(Error::InvalidPadding)
+            }
+        }
+    }
+}
+
+pub mod gcm {
+    use super::{Aes, Apply, Context, Direction, Error};
+    use ffi;
+
+    // GCM mode is defined for 128-bit block ciphers
+    const BLOCK_LENGTH: usize = 16;
+
+    fn evpc(algo: Aes) -> *const ffi::EVP_CIPHER {
+        unsafe {
+            match algo {
+                Aes::Aes128 => ffi::EVP_aes_128_gcm(),
+                Aes::Aes256 => ffi::EVP_aes_256_gcm(),
+            }
+        }
+    }
+
+    ///
+    pub struct GcmEncrypt {
+        context: Context,
+    }
+
+    impl GcmEncrypt {
+        pub fn new(algo: Aes, key: &[u8]) -> GcmEncrypt {
+            GcmEncrypt {
+                context: Context::new(evpc(algo), Direction::Encrypt, key),
+            }
+        }
+
+        pub fn start(&mut self, iv: &[u8], aad: Option<&[u8]>) {
+            unsafe {
+                self.context.init_with_iv(iv);
+                if let Some(aad) = aad {
+                    self.context.update_aad(aad);
+                }
+            }
+        }
+
+        pub fn finish(&mut self) -> Vec<u8> {
+            assert!(self.context.clean_finalize().is_ok());
+            let mut res = vec![0; BLOCK_LENGTH];
+            self.context.get_tag(&mut res);
+            res
+        }
+    }
+
+    impl Apply for GcmEncrypt {
+        fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
+            assert!(buf.len() >= data.len());
+            unsafe { self.context.update(data, buf); }
+            data.len()
+        }
+    }
+
+    ///
+    pub struct GcmDecrypt {
+        context: Context,
+    }
+
+    impl GcmDecrypt {
+        pub fn new(algo: Aes, key: &[u8]) -> GcmDecrypt {
+            GcmDecrypt {
+                context: Context::new(evpc(algo), Direction::Decrypt, key),
+            }
+        }
+
+        pub fn start(&mut self, iv: &[u8], aad: Option<&[u8]>, tag: &[u8]) {
+            unsafe {
+                self.context.init_with_iv(iv);
+                self.context.set_tag(tag);
+                if let Some(aad) = aad {
+                    self.context.update_aad(aad);
+                }
+            }
+        }
+
+        pub fn finish(&mut self) -> Result<(), Error> {
+            if self.context.clean_finalize().is_ok() {
+                Ok(())
+            }
+            else {
+                Err(Error::AuthFailed)
+            }
+        }
+    }
+
+    impl Apply for GcmDecrypt {
+        fn apply(&mut self, data: &[u8], buf: &mut [u8]) -> usize {
+            assert!(buf.len() >= data.len());
+            unsafe { self.context.update(data, buf); }
+            data.len()
         }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::{Aes, BlockApply, Filter};
+    use super::{Aes, Apply, PaddedFinish, Error, Filter, PaddedFilter};
     use super::Aes::*;
     use super::ecb::{EcbRaw, EcbPadded};
     use super::cbc::{CbcRaw, CbcPadded};
+    use super::gcm::{GcmEncrypt, GcmDecrypt};
+    use ffi;
     use std::iter::repeat;
     use std::cmp::max;
     use serialize::hex::FromHex;
@@ -371,6 +596,22 @@ mod test {
                        -> (T, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) {
         (tup.0, tup.1.from_hex().unwrap(), tup.2.from_hex().unwrap(),
          tup.3.from_hex().unwrap(), tup.4.from_hex().unwrap())
+    }
+
+    /*
+    fn unpack5<T: Copy>(tup: &(T, &str, &str, &str, &str, &str))
+                       -> (T, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) {
+        (tup.0, tup.1.from_hex().unwrap(), tup.2.from_hex().unwrap(),
+         tup.3.from_hex().unwrap(), tup.4.from_hex().unwrap(),
+         tup.5.from_hex().unwrap())
+    }
+    */
+
+    fn unpack6<T: Copy>(tup: &(T, &str, &str, &str, &str, &str, &str))
+                       -> (T, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) {
+        (tup.0, tup.1.from_hex().unwrap(), tup.2.from_hex().unwrap(),
+         tup.3.from_hex().unwrap(), tup.4.from_hex().unwrap(),
+         tup.5.from_hex().unwrap(), tup.6.from_hex().unwrap())
     }
 
     const ECB_RAW_VEC: [(Aes, &'static str, &'static str, &'static str); 4] = [
@@ -465,46 +706,139 @@ mod test {
          "19a066de723ca454666290f8e8147a6ddde9fb1e6dbb8a52b5b09b24e228bc2d"),
     ];
 
-    fn test_block_mode_apply<T: BlockApply>(vec_name: &str, n: i32, pt: &[u8],
-                                           ct: &[u8], enc: &mut T, dec: &mut T) {
-        let buf_len = max(pt.len(), ct.len()) + super::MAX_BLOCK_LEN;
-        let mut res: Vec<u8> = repeat(0).take(buf_len).collect();
-        let mut len;
+    const GCM_VEC: [(Aes, &'static str, &'static str, &'static str,
+                     &'static str, &'static str, &'static str); 8] = [
+        (Aes128,                                // algo
+         "7fddb57453c241d03efbed3ac44e371c",    // key
+         "ee283a3fc75575e33efd4887",            // iv
+         "",                                    // aad
+         "d5de42b461646c255c87bd2962d3b9a2",    // plaintext
+         "2ccda4a5415cb91e135c2a0f78c9b2fd",    // ciphertext
+         "b36d1df9b9d5e596f83e8b7f52971cb3"),   // tag
+        (Aes128,
+         "c939cc13397c1d37de6ae0e1cb7c423c",
+         "b3d8cc017cbb89b39e0f67e2",
+         "24825602bd12a984e0092d3e448eda5f",
+         "c3b3c41f113a31b73d9a5cd432103069",
+         "93fe7d9e9bfd10348a5606e5cafa7354",
+         "0032a1dc85f1c9786925a2e71d8272dd"),
+         (Aes128,
+          "93ae114052b7985d409a39a40df8c7ee",
+          "8ad733a4a9b8330690238c42",
+          "",
+          "3f3bb0644eac878b97d990d257f5b36e1793490dbc13fea4efe9822cebba7444cce4dee5a7f5dfdf285f96785792812200c279",
+          "bbb5b672a479afca2b11adb0a4c762b698dd565908fee1d101f6a01d63332c91b85d7f03ac48a477897d512b4572f9042cb7ea",
+          "4d78bdcb1366fcba02fdccee57e1ff44"),
+         (Aes128,
+          "af57f42c60c0fc5a09adb81ab86ca1c3",
+          "a2dc01871f37025dc0fc9a79",
+          "41dc38988945fcb44faf2ef72d0061289ef8efd8",
+          "3803a0727eeb0ade441e0ec107161ded2d425ec0d102f21f51bf2cf9947c7ec4aa72795b2f69b041596e8817d0a3c16f8fadeb",
+          "b9a535864f48ea7b6b1367914978f9bfa087d854bb0e269bed8d279d2eea1210e48947338b22f9bad09093276a331e9c79c7f4",
+          "4f71e72bde0018f555c5adcce062e005"),
+         (Aes256,
+          "4c8ebfe1444ec1b2d503c6986659af2c94fafe945f72c1e8486a5acfedb8a0f8",
+          "473360e0ad24889959858995",
+          "",
+          "7789b41cb3ee548814ca0b388c10b343",
+          "d2c78110ac7e8f107c0df0570bd7c90c",
+          "c26a379b6d98ef2852ead8ce83a833a7"),
+         (Aes256,
+          "54e352ea1d84bfe64a1011096111fbe7668ad2203d902a01458c3bbd85bfce14",
+          "df7c3bca00396d0c018495d9",
+          "7e968d71b50c1f11fd001f3fef49d045",
+          "85fc3dfad9b5a8d3258e4fc44571bd3b",
+          "426e0efc693b7be1f3018db7ddbb7e4d",
+          "ee8257795be6a1164d7e1d2d6cac77a7"),
+         (Aes256,
+          "4433db5fe066960bdd4e1d4d418b641c14bfcef9d574e29dcd0995352850f1eb",
+          "0e396446655582838f27f72f",
+          "",
+          "d602c06b947abe06cf6aa2c5c1562e29062ad6220da9bc9c25d66a60bd85a80d4fbcc1fb4919b6566be35af9819aba836b8b47",
+          "b0d254abe43bdb563ead669192c1e57e9a85c51dba0f1c8501d1ce92273f1ce7e140dcfac94757fabb128caad16912cead0607",
+          "ffd0b02c92dbfcfbe9d58f7ff9e6f506"),
+         (Aes256,
+          "aeb3830cb9ce31cae7b1d47511bb2d3dcc2131714ace202b21b98820e7079792",
+          "e7e87c45ec0a94c8e92353f1",
+          "07d9bb1fa3aea7ceeefbedae87dcd713",
+          "b4d0ecc410c430b61c11a1a42802858a0e9ee12f9a912f2f6b0570c99177f6de4bd79830cf9efb30759055e1f70d21e3f74957",
+          "b20542b61b8fa6f847198334cb82fdbcb2311be855a6b2b3662bdb06ff0796238bea092a8ea21b585d38ace950378f41224269",
+          "3bdd1d0cc2bbcefffe0ed2121aecbd00"),
+    ];
 
-        len = enc.apply(pt, &mut res);
-        len += enc.finish(&mut res[len..]);
-        assert!(ct == &res[..len], "{}[{}] encrypt", vec_name, n);
+    #[test]
+    fn test_ecb_raw_apply() {
+        let mut n = 0;
+        for item in ECB_RAW_VEC.iter() {
+            let (algo, key, pt, ct) = unpack3(item);
+            let mut res: Vec<u8> = repeat(0).take(
+                max(pt.len(), ct.len()) + ffi::EVP_MAX_BLOCK_LENGTH).collect();
 
-        len = dec.apply(ct, &mut res);
-        len += dec.finish(&mut res[len..]);
-        assert!(pt == &res[..len], "{}[{}] decrypt", vec_name, n);
-    }
+            let mut enc = EcbRaw::new_encrypt(algo, &key);
+            enc.start();
+            let len = enc.apply(&pt, &mut res);
+            assert!(enc.finish().is_ok(), "vec #{}", n);
+            assert!(ct == &res[..len], "vec #{}", n);
 
-    fn test_block_mode_write<T: BlockApply>(vec_name: &str, n: i32, pt: &[u8],
-                                           ct: &[u8], enc: &mut T, dec: &mut T) {
-        let mut res: Vec<u8> = Vec::new();
+            let mut dec = EcbRaw::new_decrypt(algo, &key);
+            dec.start();
+            let len = dec.apply(&ct, &mut res);
+            assert!(dec.finish().is_ok(), "vec #{}", n);
+            assert!(pt == &res[..len], "vec #{}", n);
 
-        {
-            let mut w = Filter::new(enc, &mut res);
-            for byte in pt.iter() {
-                let _ = w.write_all(&[*byte]);
-            }
+            n += 1;
         }
-        assert!(ct == res, "{}[{}] encrypt", vec_name, n);
-
-        res.truncate(0);
-
-        {
-            let mut w = Filter::new(dec, &mut res);
-            for byte in ct.iter() {
-                let _ = w.write_all(&[*byte]);
-            }
-        }
-        assert!(pt == res, "{}[{}] decrypt", vec_name, n);
     }
 
     #[test]
-    fn test_ecb_apply() {
+    fn test_ecb_padded_apply() {
+        let mut n = 0;
+        for item in ECB_PADDED_VEC.iter() {
+            let (algo, key, pt, ct) = unpack3(item);
+            let mut res: Vec<u8> = repeat(0).take(
+                max(pt.len(), ct.len()) + ffi::EVP_MAX_BLOCK_LENGTH).collect();
+
+            let mut enc = EcbPadded::new_encrypt(algo, &key);
+            enc.start();
+            let mut len = enc.apply(&pt, &mut res);
+            len += enc.finish(&mut res[len..]).unwrap();
+            assert!(ct == &res[..len], "vec #{}", n);
+
+            let mut dec = EcbPadded::new_decrypt(algo, &key);
+            dec.start();
+            let mut len = dec.apply(&ct, &mut res);
+            len += dec.finish(&mut res[len..]).unwrap();
+            assert!(pt == &res[..len], "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_ecb_bad_padding() {
+        let dummy = vec![0xcd; 23];
+        let mut res = vec![0; 256];
+
+        let mut enc = EcbRaw::new_encrypt(Aes::Aes128, &dummy[..16]);
+        enc.start();
+        enc.apply(&dummy, &mut res);
+        assert!(enc.finish() == Err(Error::IncompleteBlock));
+
+        let mut dec = EcbRaw::new_decrypt(Aes::Aes128, &dummy[..16]);
+        dec.start();
+        dec.apply(&dummy, &mut res);
+        assert!(dec.finish() == Err(Error::IncompleteBlock));
+
+        let mut dec = EcbPadded::new_decrypt(Aes::Aes128, &dummy[..16]);
+        dec.start();
+        dec.apply(&dummy, &mut res);
+        assert!(dec.finish(&mut res) == Err(Error::InvalidPadding));
+    }
+
+    #[test]
+    fn test_ecb_raw_recycle() {
+        let dummy = vec![0xcd; 256];
+        let mut res = vec![0; 512];
         let mut n;
 
         n = 0;
@@ -512,61 +846,207 @@ mod test {
             let (algo, key, pt, ct) = unpack3(item);
 
             let mut enc = EcbRaw::new_encrypt(algo, &key);
-            enc.start();
             let mut dec = EcbRaw::new_decrypt(algo, &key);
-            dec.start();
-            test_block_mode_apply("ECB_RAW_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
-            n += 1;
-        }
-
-        n = 0;
-        for item in ECB_PADDED_VEC.iter() {
-            let (algo, key, pt, ct) = unpack3(item);
-
-            let mut enc = EcbPadded::new_encrypt(algo, &key);
             enc.start();
-            let mut dec = EcbPadded::new_decrypt(algo, &key);
+            enc.apply(&dummy, &mut res);
+            let _ = enc.finish();
             dec.start();
-            test_block_mode_apply("ECB_PADDED_VEC", n, &pt, &ct, &mut enc, &mut dec);
+            dec.apply(&dummy, &mut res);
+            let _ = dec.finish();
+
+            enc.start();
+            let len = enc.apply(&pt, &mut res);
+            assert!(enc.finish().is_ok(), "vec #{}", n);
+            assert!(ct == &res[..len], "vec #{}", n);
+
+            dec.start();
+            let len = dec.apply(&ct, &mut res);
+            assert!(dec.finish().is_ok(), "vec #{}", n);
+            assert!(pt == &res[..len], "vec #{}", n);
 
             n += 1;
         }
     }
 
     #[test]
-    fn test_ecb_write() {
+    fn test_ecb_padded_recycle() {
+        let dummy = vec![0xcd; 256];
+        let mut res = vec![0; 512];
         let mut n;
 
         n = 0;
+        for item in ECB_PADDED_VEC.iter() {
+            let (algo, key, pt, ct) = unpack3(item);
+
+            let mut enc = EcbPadded::new_encrypt(algo, &key);
+            let mut dec = EcbPadded::new_decrypt(algo, &key);
+
+            enc.start();
+            enc.apply(&dummy, &mut res);
+            let _ = enc.finish(&mut res);
+            dec.start();
+            dec.apply(&dummy, &mut res);
+            let _ = dec.finish(&mut res);
+
+            enc.start();
+            let mut len = enc.apply(&pt, &mut res);
+            len += enc.finish(&mut res[len..]).unwrap();
+            assert!(ct == &res[..len], "vec #{}", n);
+
+            dec.start();
+            let mut len = dec.apply(&ct, &mut res);
+            len += dec.finish(&mut res[len..]).unwrap();
+            assert!(pt == &res[..len], "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_ecb_raw_write() {
+        let mut n = 0;
+
         for item in ECB_RAW_VEC.iter() {
             let (algo, key, pt, ct) = unpack3(item);
+            let mut res: Vec<u8> = Vec::new();
 
             let mut enc = EcbRaw::new_encrypt(algo, &key);
             enc.start();
+            {
+                let mut w = Filter::new(&mut enc, &mut res);
+                for byte in pt.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+            }
+            assert!(enc.finish().is_ok(), "vec #{}", n);
+            assert!(ct == res, "vec #{}", n);
+
+            res.truncate(0);
             let mut dec = EcbRaw::new_decrypt(algo, &key);
             dec.start();
-            test_block_mode_write("ECB_RAW_VEC", n, &pt, &ct, &mut enc, &mut dec);
+            {
+                let mut w = Filter::new(&mut dec, &mut res);
+                for byte in ct.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+            }
+            assert!(dec.finish().is_ok(), "vec #{}", n);
+            assert!(pt == res, "vec #{}", n);
 
             n += 1;
         }
+    }
 
-        n = 0;
+    #[test]
+    fn test_ecb_padded_write() {
+        let mut n = 0;
+
         for item in ECB_PADDED_VEC.iter() {
             let (algo, key, pt, ct) = unpack3(item);
 
+            let mut res: Vec<u8> = Vec::new();
+
             let mut enc = EcbPadded::new_encrypt(algo, &key);
             enc.start();
+            {
+                let mut w = PaddedFilter::new(&mut enc, &mut res);
+                for byte in pt.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+                assert!(w.close().is_ok(), "vec #{}", n);
+            }
+            assert!(ct == res, "vec #{}", n);
+
+            res.truncate(0);
             let mut dec = EcbPadded::new_decrypt(algo, &key);
             dec.start();
-            test_block_mode_write("ECB_PADDED_VEC", n, &pt, &ct, &mut enc, &mut dec);
+            {
+                let mut w = PaddedFilter::new(&mut dec, &mut res);
+                for byte in ct.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+                assert!(w.close().is_ok(), "vec #{}", n);
+            }
+            assert!(pt == res, "vec #{}", n);
 
             n += 1;
         }
     }
 
     #[test]
-    fn test_cbc_apply() {
+    fn test_cbc_raw_apply() {
+        let mut n = 0;
+        for item in CBC_RAW_VEC.iter() {
+            let (algo, key, iv, pt, ct) = unpack4(item);
+            let mut res: Vec<u8> = repeat(0).take(
+                max(pt.len(), ct.len()) + ffi::EVP_MAX_BLOCK_LENGTH).collect();
+
+            let mut enc = CbcRaw::new_encrypt(algo, &key);
+            enc.start(&iv);
+            let len = enc.apply(&pt, &mut res);
+            assert!(enc.finish().is_ok(), "vec #{}", n);
+            assert!(ct == &res[..len], "vec #{}", n);
+
+            let mut dec = CbcRaw::new_decrypt(algo, &key);
+            dec.start(&iv);
+            let len = dec.apply(&ct, &mut res);
+            assert!(dec.finish().is_ok(), "vec #{}", n);
+            assert!(pt == &res[..len], "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_cbc_padded_apply() {
+        let mut n = 0;
+        for item in CBC_PADDED_VEC.iter() {
+            let (algo, key, iv, pt, ct) = unpack4(item);
+            let mut res: Vec<u8> = repeat(0).take(
+                max(pt.len(), ct.len()) + ffi::EVP_MAX_BLOCK_LENGTH).collect();
+
+            let mut enc = CbcPadded::new_encrypt(algo, &key);
+            enc.start(&iv);
+            let mut len = enc.apply(&pt, &mut res);
+            len += enc.finish(&mut res[len..]).unwrap();
+            assert!(ct == &res[..len], "vec #{}", n);
+
+            let mut dec = CbcPadded::new_decrypt(algo, &key);
+            dec.start(&iv);
+            let mut len = dec.apply(&ct, &mut res);
+            len += dec.finish(&mut res[len..]).unwrap();
+            assert!(pt == &res[..len], "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_cbc_bad_padding() {
+        let dummy = vec![0xcd; 23];
+        let mut res = vec![0; 256];
+
+        let mut enc = CbcRaw::new_encrypt(Aes::Aes128, &dummy[..16]);
+        enc.start(&dummy[..16]);
+        enc.apply(&dummy, &mut res);
+        assert!(enc.finish() == Err(Error::IncompleteBlock));
+
+        let mut dec = CbcRaw::new_decrypt(Aes::Aes128, &dummy[..16]);
+        dec.start(&dummy[..16]);
+        dec.apply(&dummy, &mut res);
+        assert!(dec.finish() == Err(Error::IncompleteBlock));
+
+        let mut dec = CbcPadded::new_decrypt(Aes::Aes128, &dummy[..16]);
+        dec.start(&dummy[..16]);
+        dec.apply(&dummy, &mut res);
+        assert!(dec.finish(&mut res) == Err(Error::InvalidPadding));
+    }
+
+    #[test]
+    fn test_cbc_raw_recycle() {
+        let dummy = vec![0xcd; 256];
+        let mut res = vec![0; 512];
         let mut n;
 
         n = 0;
@@ -574,54 +1054,325 @@ mod test {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
             let mut enc = CbcRaw::new_encrypt(algo, &key);
-            enc.start(&iv);
             let mut dec = CbcRaw::new_decrypt(algo, &key);
-            dec.start(&iv);
-            test_block_mode_apply("CBC_RAW_VEC", n, &pt, &ct, &mut enc, &mut dec);
 
-            n += 1;
-        }
+            enc.start(&dummy[..16]);
+            enc.apply(&dummy, &mut res);
+            let _ = enc.finish();
+            dec.start(&dummy[..16]);
+            dec.apply(&dummy, &mut res);
+            let _ = dec.finish();
 
-        n = 0;
-        for item in CBC_PADDED_VEC.iter() {
-            let (algo, key, iv, pt, ct) = unpack4(item);
-
-            let mut enc = CbcPadded::new_encrypt(algo, &key);
             enc.start(&iv);
-            let mut dec = CbcPadded::new_decrypt(algo, &key);
+            let len = enc.apply(&pt, &mut res);
+            assert!(enc.finish().is_ok(), "vec #{}", n);
+            assert!(ct == &res[..len], "vec #{}", n);
+
             dec.start(&iv);
-            test_block_mode_apply("CBC_PADDED_VEC", n, &pt, &ct, &mut enc, &mut dec);
+            let len = dec.apply(&ct, &mut res);
+            assert!(dec.finish().is_ok(), "vec #{}", n);
+            assert!(pt == &res[..len], "vec #{}", n);
 
             n += 1;
         }
     }
 
     #[test]
-    fn test_cbc_write() {
+    fn test_cbc_padded_recycle() {
+        let dummy = vec![0xcd; 256];
+        let mut res = vec![0; 512];
         let mut n;
-
-        n = 0;
-        for item in CBC_RAW_VEC.iter() {
-            let (algo, key, iv, pt, ct) = unpack4(item);
-
-            let mut enc = CbcRaw::new_encrypt(algo, &key);
-            enc.start(&iv);
-            let mut dec = CbcRaw::new_decrypt(algo, &key);
-            dec.start(&iv);
-            test_block_mode_write("CBC_RAW_VEC", n, &pt, &ct, &mut enc, &mut dec);
-
-            n += 1;
-        }
 
         n = 0;
         for item in CBC_PADDED_VEC.iter() {
             let (algo, key, iv, pt, ct) = unpack4(item);
 
             let mut enc = CbcPadded::new_encrypt(algo, &key);
+            let mut dec = CbcPadded::new_decrypt(algo, &key);
+
+            enc.start(&dummy[..16]);
+            enc.apply(&dummy, &mut res);
+            let _ = enc.finish(&mut res);
+            dec.start(&dummy[..16]);
+            dec.apply(&dummy, &mut res);
+            let _ = dec.finish(&mut res);
+
             enc.start(&iv);
+            let mut len = enc.apply(&pt, &mut res);
+            len += enc.finish(&mut res[len..]).unwrap();
+            assert!(ct == &res[..len], "vec #{}", n);
+
+            dec.start(&iv);
+            let mut len = dec.apply(&ct, &mut res);
+            len += dec.finish(&mut res[len..]).unwrap();
+            assert!(pt == &res[..len], "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_cbc_raw_write() {
+        let mut n = 0;
+
+        for item in CBC_RAW_VEC.iter() {
+            let (algo, key, iv, pt, ct) = unpack4(item);
+            let mut res: Vec<u8> = Vec::new();
+
+            let mut enc = CbcRaw::new_encrypt(algo, &key);
+            enc.start(&iv);
+            {
+                let mut w = Filter::new(&mut enc, &mut res);
+                for byte in pt.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+            }
+            assert!(enc.finish().is_ok(), "vec #{}", n);
+            assert!(ct == res, "vec #{}", n);
+
+            res.truncate(0);
+            let mut dec = CbcRaw::new_decrypt(algo, &key);
+            dec.start(&iv);
+            {
+                let mut w = Filter::new(&mut dec, &mut res);
+                for byte in ct.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+            }
+            assert!(dec.finish().is_ok(), "vec #{}", n);
+            assert!(pt == res, "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_cbc_padded_write() {
+        let mut n = 0;
+
+        for item in CBC_PADDED_VEC.iter() {
+            let (algo, key, iv, pt, ct) = unpack4(item);
+
+            let mut res: Vec<u8> = Vec::new();
+
+            let mut enc = CbcPadded::new_encrypt(algo, &key);
+            enc.start(&iv);
+            {
+                let mut w = PaddedFilter::new(&mut enc, &mut res);
+                for byte in pt.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+                assert!(w.close().is_ok(), "vec #{}", n);
+            }
+            assert!(ct == res, "vec #{}", n);
+
+            res.truncate(0);
             let mut dec = CbcPadded::new_decrypt(algo, &key);
             dec.start(&iv);
-            test_block_mode_write("CBC_PADDED_VEC", n, &pt, &ct, &mut enc, &mut dec);
+            {
+                let mut w = PaddedFilter::new(&mut dec, &mut res);
+                for byte in ct.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+                assert!(w.close().is_ok(), "vec #{}", n);
+            }
+            assert!(pt == res, "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_gcm_apply() {
+        let mut n = 0;
+        for item in GCM_VEC.iter() {
+            let (algo, key, iv, aad, pt, ct, tag) = unpack6(item);
+            let mut res: Vec<u8> = repeat(0).take(pt.len()).collect();
+
+            let mut enc = GcmEncrypt::new(algo, &key);
+            if aad.len() > 0 {
+                enc.start(&iv, Some(&aad));
+            }
+            else {
+                enc.start(&iv, None);
+            }
+            enc.apply(&pt, &mut res);
+            let tag_res = enc.finish();
+            assert!(ct == res, "vec #{}", n);
+            assert!(tag == tag_res, "vec #{}", n);
+
+            let mut dec = GcmDecrypt::new(algo, &key);
+            if aad.len() > 0 {
+                dec.start(&iv, Some(&aad), &tag);
+            }
+            else {
+                dec.start(&iv, None, &tag);
+            }
+            dec.apply(&ct, &mut res);
+            let auth = dec.finish();
+            assert!(pt == res, "vec #{}", n);
+            assert!(auth.is_ok(), "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_gcm_write() {
+        let mut n = 0;
+        for item in GCM_VEC.iter() {
+            let (algo, key, iv, aad, pt, ct, tag) = unpack6(item);
+            let mut res: Vec<u8> = Vec::new();
+
+            let mut enc = GcmEncrypt::new(algo, &key);
+            if aad.len() > 0 {
+                enc.start(&iv, Some(&aad));
+            }
+            else {
+                enc.start(&iv, None);
+            }
+            {
+                let mut w = Filter::new(&mut enc, &mut res);
+                for byte in pt.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+            }
+            let tag_res = enc.finish();
+            assert!(ct == res, "vec #{}", n);
+            assert!(tag == tag_res, "vec #{}", n);
+
+            res.truncate(0);
+            let mut dec = GcmDecrypt::new(algo, &key);
+            if aad.len() > 0 {
+                dec.start(&iv, Some(&aad), &tag);
+            }
+            else {
+                dec.start(&iv, None, &tag);
+            }
+            {
+                let mut w = Filter::new(&mut dec, &mut res);
+                for byte in ct.iter() {
+                    assert!(w.write_all(&[*byte]).is_ok(), "vec #{}", n);
+                }
+            }
+            let auth = dec.finish();
+            assert!(pt == res, "vec #{}", n);
+            assert!(auth.is_ok(), "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_gcm_recycle() {
+        let dummy = vec![0xcd; 256];
+        let mut dummy_res = vec![0; 256];
+        let mut n = 0;
+        for item in GCM_VEC.iter() {
+            let (algo, key, iv, aad, pt, ct, tag) = unpack6(item);
+            let mut res: Vec<u8> = repeat(0).take(pt.len()).collect();
+
+            let mut enc = GcmEncrypt::new(algo, &key);
+
+            enc.start(&dummy[..12], None);
+            enc.apply(&dummy, &mut dummy_res);
+            enc.finish();
+
+            if aad.len() > 0 {
+                enc.start(&iv, Some(&aad));
+            }
+            else {
+                enc.start(&iv, None);
+            }
+            enc.apply(&pt, &mut res);
+            let tag_res = enc.finish();
+            assert!(ct == res, "vec #{}", n);
+            assert!(tag == tag_res, "vec #{}", n);
+
+            let mut dec = GcmDecrypt::new(algo, &key);
+
+            dec.start(&dummy[..12], None, &dummy[..16]);
+            dec.apply(&dummy, &mut dummy_res);
+            let _ = dec.finish();
+
+            if aad.len() > 0 {
+                dec.start(&iv, Some(&aad), &tag);
+            }
+            else {
+                dec.start(&iv, None, &tag);
+            }
+            dec.apply(&ct, &mut res);
+            let auth = dec.finish();
+            assert!(pt == res, "vec #{}", n);
+            assert!(auth.is_ok(), "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_gcm_auth_fail() {
+        let garbage = b"This is dummy invalid input";
+        let mut n = 0;
+        for item in GCM_VEC.iter() {
+            let (algo, key, iv, aad, pt, _, tag) = unpack6(item);
+            let buf_len = max(pt.len(), garbage.len());
+            let mut res: Vec<u8> = repeat(0).take(buf_len).collect();
+
+            let mut dec = GcmDecrypt::new(algo, &key);
+            if aad.len() > 0 {
+                dec.start(&iv, None, &tag);
+            }
+            else {
+                dec.start(&iv, Some(garbage), &tag);
+            }
+            dec.apply(&pt, &mut res);
+            let auth = dec.finish();
+            assert!(auth == Err(Error::AuthFailed), "vec #{}", n);
+
+            let mut dec = GcmDecrypt::new(algo, &key);
+            if aad.len() > 0 {
+                dec.start(&iv, Some(&aad), &tag);
+            }
+            else {
+                dec.start(&iv, None, &tag);
+            }
+            dec.apply(&garbage, &mut res);
+            let auth = dec.finish();
+            assert!(auth == Err(Error::AuthFailed), "vec #{}", n);
+
+            n += 1;
+        }
+    }
+
+    #[test]
+    fn test_gcm_var_tag_len() {
+        let test_lens = vec![4, 8, 12, 13, 14, 15, 16];
+        let mut n = 0;
+        for item in GCM_VEC.iter() {
+            let (algo, key, iv, aad, pt, ct, tag) = unpack6(item);
+            let mut res: Vec<u8> = repeat(0).take(pt.len()).collect();
+            let mut enc = GcmEncrypt::new(algo, &key);
+            let mut dec = GcmDecrypt::new(algo, &key);
+
+            for tag_len in test_lens.iter() {
+                let range = ..*tag_len;
+                if aad.len() > 0 {
+                    enc.start(&iv, Some(&aad));
+                    dec.start(&iv, Some(&aad), &tag[range]);
+                }
+                else {
+                    enc.start(&iv, None);
+                    dec.start(&iv, None, &tag[range]);
+                }
+                enc.apply(&pt, &mut res);
+                dec.apply(&ct, &mut res);
+
+                let tag_res = enc.finish();
+                let auth = dec.finish();
+                assert!(tag[range] == tag_res[range], "vec #{}, len {}", n, tag_len);
+                assert!(auth.is_ok(), "vec #{}, len {}", n, tag_len);
+            }
 
             n += 1;
         }


### PR DESCRIPTION
This is a prototype `symm` module rewrite that takes some inspiration from `hash` refactoring.
It's difficult to come up with a clean general API because each mode's API is slightly incompatible with every other one.
This version provides a `Writer` adapter for composability and an `apply` method that writes to `&mut [u8]`.
Because the static check model I tried out with `hash` and `hmac` wasn't settled on, call order requirements are checked dynamically and panic in case of errors.
Padding/alignment and authentication errors are handled with `Result`s, more "impossible" errors are checked with asserts.