### PR TITLE
Fix the target for windows

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -15,12 +15,10 @@ fn main() {
                      (instructions in the README) and provide their location through \
                      $OPENSSL_PATH.");
         println!("cargo:rustc-flags=-L native={} -l crypto:static -l ssl:static", path);
-        // going to assume the user built a new version of openssl
-        build_old_openssl_shim(false);
         return;
     }
 
-    if target.contains("win32") || target.contains("win64") {
+    if target.contains("win32") || target.contains("win64") || target.contains("i386-pc-windows-gnu") || target.contains("x86_64-pc-windows-gnu") {
         println!("cargo:rustc-flags=-l crypto -l ssl -l gdi32 -l wsock32");
         // going to assume the user has a new version of openssl
         build_old_openssl_shim(false);
@@ -41,14 +39,15 @@ fn main() {
 }
 
 fn build_old_openssl_shim(is_old: bool) {
-        let mut config: gcc::Config = Default::default();
-        if is_old {
-            config.definitions.push(("OLD_OPENSSL".to_string(), None));
-        }
+    let mut config: gcc::Config = Default::default();
+    if is_old {
+        config.definitions.push(("OLD_OPENSSL".to_string(), None));
 
         gcc::compile_library("libold_openssl_shim.a",
-                             &config,
-                             &["src/old_openssl_shim.c"]);
+            &config,
+            &["src/old_openssl_shim.c"]);
+
         let out_dir = env::var_string("OUT_DIR").unwrap();
         println!("cargo:rustc-flags=-L native={} -l old_openssl_shim:static", out_dir);
+    }
 }

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -42,12 +42,12 @@ fn build_old_openssl_shim(is_old: bool) {
     let mut config: gcc::Config = Default::default();
     if is_old {
         config.definitions.push(("OLD_OPENSSL".to_string(), None));
+    }
 
-        gcc::compile_library("libold_openssl_shim.a",
+    gcc::compile_library("libold_openssl_shim.a",
             &config,
             &["src/old_openssl_shim.c"]);
 
-        let out_dir = env::var_string("OUT_DIR").unwrap();
-        println!("cargo:rustc-flags=-L native={} -l old_openssl_shim:static", out_dir);
-    }
+    let out_dir = env::var_string("OUT_DIR").unwrap();
+    println!("cargo:rustc-flags=-L native={} -l old_openssl_shim:static", out_dir);
 }


### PR DESCRIPTION
As a windows user on x86_64 plateform, this fix allowed me to compile. 

I'm not sure that the targets `win32` and `win64` are still relevant. And the gcc should not compile the `libold_openssl_shim.a`  with a  value of `false` as argument.