### PR TITLE
Fix build on *BSD

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -27,6 +27,7 @@ fn main() {
         return;
     }
 
+    // pkg-config doesn't know of OpenSSL on FreeBSD 10.1 and OpenBSD uses LibreSSL
     if target.contains("bsd") {
         println!("cargo:rustc-flags=-l crypto -l ssl");
         // going to assume the base system includes a new version of openssl

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -27,6 +27,13 @@ fn main() {
         return;
     }
 
+    if target.contains("bsd") {
+        println!("cargo:rustc-flags=-l crypto -l ssl");
+        // going to assume the base system includes a new version of openssl
+        build_old_openssl_shim(false);
+        return;
+    }
+
     if pkg_config::Config::new().atleast_version("1.0.0").find("openssl").is_ok() {
         build_old_openssl_shim(false);
         return;


### PR DESCRIPTION
FreeBSD includes OpenSSL in the base system, and I believe OpenBSD includes their fork known as LibreSSL.