### PR TITLE
Added try_clone to SslStream for SslStream<TcpStream>.

### DIFF
--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(unsafe_destructor, core, io, std_misc, path, os, unique)]
+#![feature(unsafe_destructor, core, io, std_misc, net, path, os, unique)]
 #![cfg_attr(test, feature(net, fs))]
 #![doc(html_root_url="https://sfackler.github.io/rust-openssl/doc/openssl")]
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -5,6 +5,7 @@ use std::io;
 use std::io::prelude::*;
 use std::ffi::AsOsStr;
 use std::mem;
+use std::net;
 use std::num::FromPrimitive;
 use std::num::Int;
 use std::path::Path;
@@ -435,6 +436,17 @@ pub struct SslStream<S> {
     stream: S,
     ssl: Arc<Ssl>,
     buf: Vec<u8>
+}
+
+impl SslStream<net::TcpStream> {
+    /// Create a new independently owned handle to the underlying socket.
+    pub fn try_clone(&self) -> io::Result<SslStream<net::TcpStream>> {
+        Ok(SslStream { 
+            stream: try!(self.stream.try_clone()),
+            ssl: self.ssl.clone(),
+            buf: self.buf.clone(),
+        })
+    }
 }
 
 impl<S> fmt::Debug for SslStream<S> where S: fmt::Debug {


### PR DESCRIPTION
This serves the same purpose as adding the `#[derive(Clone)]` to SslStream did.