### PR TITLE
Cut down on unstable features in openssl-sys

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -1,4 +1,4 @@
-#![feature(env, path)]
+#![feature(path)]
 
 extern crate "pkg-config" as pkg_config;
 extern crate gcc;


### PR DESCRIPTION
* Move from `old_path` to `path` (leveraging the `fs` feature as well)
* Move from `StaticMutex` to `Mutex<()>` as they're dynamically initialized