### PR TITLE
Change SslVerifyMode to bitflags and add SSL_VERIFY_FAIL_IF_NO_PEER_CERT

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -132,6 +132,7 @@ pub const SSL_ERROR_WANT_X509_LOOKUP: c_int = 4;
 pub const SSL_ERROR_ZERO_RETURN: c_int = 6;
 pub const SSL_VERIFY_NONE: c_int = 0;
 pub const SSL_VERIFY_PEER: c_int = 1;
+pub const SSL_VERIFY_FAIL_IF_NO_PEER_CERT: c_int = 2;
 
 pub const TLSEXT_NAMETYPE_host_name: c_long = 0;
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -111,13 +111,16 @@ impl SslMethod {
 }
 
 /// Determines the type of certificate verification used
-#[derive(Copy, Clone, Debug)]
-#[repr(i32)]
-pub enum SslVerifyMode {
-    /// Verify that the server's certificate is trusted
-    SslVerifyPeer = ffi::SSL_VERIFY_PEER,
-    /// Do not verify the server's certificate
-    SslVerifyNone = ffi::SSL_VERIFY_NONE
+bitflags! {
+    flags SslVerifyMode: i32 {
+        /// Verify that the server's certificate is trusted
+        const SSL_VERIFY_PEER = ffi::SSL_VERIFY_PEER,
+        /// Do not verify the server's certificate
+        const SSL_VERIFY_NONE = ffi::SSL_VERIFY_NONE,
+        /// Terminate handshake if client did not return a certificate.
+        /// Use together with SSL_VERIFY_PEER.
+        const SSL_VERIFY_FAIL_IF_NO_PEER_CERT = ffi::SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+    }
 }
 
 // Creates a static index for user data of type T
@@ -252,7 +255,7 @@ impl SslContext {
                                      mem::transmute(verify));
             let f: extern fn(c_int, *mut ffi::X509_STORE_CTX) -> c_int =
                                 raw_verify;
-            ffi::SSL_CTX_set_verify(*self.ctx, mode as c_int, Some(f));
+            ffi::SSL_CTX_set_verify(*self.ctx, mode.bits as c_int, Some(f));
         }
     }
 
@@ -271,7 +274,7 @@ impl SslContext {
                                      mem::transmute(data));
             let f: extern fn(c_int, *mut ffi::X509_STORE_CTX) -> c_int =
                                 raw_verify_with_data::<T>;
-            ffi::SSL_CTX_set_verify(*self.ctx, mode as c_int, Some(f));
+            ffi::SSL_CTX_set_verify(*self.ctx, mode.bits as c_int, Some(f));
         }
     }
 

--- a/openssl/src/ssl/tests.rs
+++ b/openssl/src/ssl/tests.rs
@@ -8,7 +8,7 @@ use crypto::hash::Type::{SHA256};
 use ssl;
 use ssl::SslMethod::Sslv23;
 use ssl::{SslContext, SslStream, VerifyCallback};
-use ssl::SslVerifyMode::SslVerifyPeer;
+use ssl::SSL_VERIFY_PEER;
 use x509::{X509StoreContext};
 
 #[test]
@@ -26,7 +26,7 @@ fn test_new_sslstream() {
 fn test_verify_untrusted() {
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, None);
+    ctx.set_verify(SSL_VERIFY_PEER, None);
     match SslStream::new(&ctx, stream) {
         Ok(_) => panic!("expected failure"),
         Err(err) => println!("error {:?}", err)
@@ -37,7 +37,7 @@ fn test_verify_untrusted() {
 fn test_verify_trusted() {
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, None);
+    ctx.set_verify(SSL_VERIFY_PEER, None);
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => panic!("Unexpected error {:?}", err)
@@ -55,7 +55,7 @@ fn test_verify_untrusted_callback_override_ok() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match SslStream::new(&ctx, stream) {
         Ok(_) => (),
         Err(err) => panic!("Expected success, got {:?}", err)
@@ -69,7 +69,7 @@ fn test_verify_untrusted_callback_override_bad() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     assert!(SslStream::new(&ctx, stream).is_err());
 }
 
@@ -80,7 +80,7 @@ fn test_verify_trusted_callback_override_ok() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => panic!("Unexpected error {:?}", err)
@@ -98,7 +98,7 @@ fn test_verify_trusted_callback_override_bad() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => panic!("Unexpected error {:?}", err)
@@ -114,7 +114,7 @@ fn test_verify_callback_load_certs() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     assert!(SslStream::new(&ctx, stream).is_ok());
 }
 
@@ -126,7 +126,7 @@ fn test_verify_trusted_get_error_ok() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => panic!("Unexpected error {:?}", err)
@@ -142,7 +142,7 @@ fn test_verify_trusted_get_error_err() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     assert!(SslStream::new(&ctx, stream).is_err());
 }
 
@@ -167,7 +167,7 @@ fn test_verify_callback_data() {
     // Please update if "test/cert.pem" will ever change
     let node_hash_str = "46e3f1a6d17a41ce70d0c66ef51cee2ab4ba67cac8940e23f10c1f944b49fb5c";
     let node_id = node_hash_str.from_hex().unwrap();
-    ctx.set_verify_with_data(SslVerifyPeer, callback, node_id);
+    ctx.set_verify_with_data(SSL_VERIFY_PEER, callback, node_id);
     ctx.set_verify_depth(1);
 
     match SslStream::new(&ctx, stream) {


### PR DESCRIPTION
SslVerifyMode was changed to bitflags to allow for bitwise operations
like (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT).