### PR TITLE
Specify minor version of pkg-config (0.3.1)

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -21,7 +21,7 @@ aes_xts = []
 libc = "0.1"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.1"
 gcc = "0.3"
 
 [target.le32-unknown-nacl.dependencies]


### PR DESCRIPTION
Depending on opensaml in my project seems to pull down 0.3.0 of pkg-config which doesn't compile against the latest rust nightly builds.

Here's a build for example: https://travis-ci.org/davbo/matasano/builds/54021798