### PR TITLE
Add TLS Next Protocol Negotiation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - FEATURES="tlsv1_1 tlsv1_2 aes_xts npn"
 before_script:
 - openssl s_server -accept 15418 -www -cert openssl/test/cert.pem -key openssl/test/key.pem >/dev/null 2>&1 &
+- openssl s_server -accept 15419 -www -cert openssl/test/cert.pem -key openssl/test/key.pem -nextprotoneg "http/1.1,spdy/3.1" >/dev/null 2>&1 &
 script:
 - (cd openssl && cargo test)
 - (test $TRAVIS_OS_NAME == "osx" || (cd openssl && cargo test --features "$FEATURES"))

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 env:
   global:
   - secure: J4i75AV4KMrU/UQrLIzzIh35Xix40Ki0uWjm8j05oxlXVl5aPU2zB30AemDne2QXYzkN4kRG/iRnNORE/8D0lF7YipQNSNxgfiBVoOEfj/NSogvI2BftYX9vlLZJUvt+s/nbE3xa/Pyge1IPv7itDYGO7SMe8RTSqitgqyfE2Eg=
-  - FEATURES="tlsv1_1 tlsv1_2 aes_xts"
+  - FEATURES="tlsv1_1 tlsv1_2 aes_xts npn"
 before_script:
 - openssl s_server -accept 15418 -www -cert openssl/test/cert.pem -key openssl/test/key.pem >/dev/null 2>&1 &
 script:

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -16,6 +16,7 @@ tlsv1_2 = []
 tlsv1_1 = []
 sslv2 = []
 aes_xts = []
+npn = []
 
 [dependencies]
 libc = "0.1"

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -134,6 +134,11 @@ pub const SSL_VERIFY_PEER: c_int = 1;
 
 pub const TLSEXT_NAMETYPE_host_name: c_long = 0;
 
+pub const SSL_TLSEXT_ERR_OK: c_int = 0;
+pub const SSL_TLSEXT_ERR_ALERT_WARNING: c_int = 1;
+pub const SSL_TLSEXT_ERR_ALERT_FATAL: c_int = 2;
+pub const SSL_TLSEXT_ERR_NOACK: c_int = 3;
+
 #[cfg(feature = "npn")]
 pub const OPENSSL_NPN_UNSUPPORTED: c_int = 0;
 #[cfg(feature = "npn")]

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -134,6 +134,13 @@ pub const SSL_VERIFY_PEER: c_int = 1;
 
 pub const TLSEXT_NAMETYPE_host_name: c_long = 0;
 
+#[cfg(feature = "npn")]
+pub const OPENSSL_NPN_UNSUPPORTED: c_int = 0;
+#[cfg(feature = "npn")]
+pub const OPENSSL_NPN_NEGOTIATED: c_int = 1;
+#[cfg(feature = "npn")]
+pub const OPENSSL_NPN_NO_OVERLAP: c_int = 2;
+
 pub const V_ASN1_GENERALIZEDTIME: c_int = 24;
 pub const V_ASN1_UTCTIME:         c_int = 23;
 
@@ -490,6 +497,28 @@ extern "C" {
     pub fn SSL_CTX_set_cipher_list(ssl: *mut SSL_CTX, s: *const c_char) -> c_int;
 
     pub fn SSL_CTX_ctrl(ssl: *mut SSL_CTX, cmd: c_int, larg: c_long, parg: *mut c_void) -> c_long;
+    #[cfg(feature = "npn")]
+    pub fn SSL_CTX_set_next_protos_advertised_cb(ssl: *mut SSL_CTX,
+                                                 cb: extern "C" fn(ssl: *mut SSL,
+                                                                   out: *mut *const c_uchar,
+                                                                   outlen: *mut c_uint,
+                                                                   arg: *mut c_void) -> c_int,
+                                                 arg: *mut c_void);
+    #[cfg(feature = "npn")]
+    pub fn SSL_CTX_set_next_proto_select_cb(ssl: *mut SSL_CTX,
+                                            cb: extern "C" fn(ssl: *mut SSL,
+                                                              out: *mut *mut c_uchar,
+                                                              outlen: *mut c_uchar,
+                                                              inbuf: *const c_uchar,
+                                                              inlen: c_uint,
+                                                              arg: *mut c_void) -> c_int,
+                                            arg: *mut c_void);
+    #[cfg(feature = "npn")]
+    pub fn SSL_select_next_proto(out: *mut *mut c_uchar, outlen: *mut c_uchar,
+                                 inbuf: *const c_uchar, inlen: c_uint,
+                                 client: *const c_uchar, client_len: c_uint) -> c_int;
+    #[cfg(feature = "npn")]
+    pub fn SSL_get0_next_proto_negotiated(s: *const SSL, data: *mut *const c_uchar, len: *mut c_uint);
 
     pub fn X509_add_ext(x: *mut X509, ext: *mut X509_EXTENSION, loc: c_int) -> c_int;
     pub fn X509_digest(x: *mut X509, digest: *const EVP_MD, buf: *mut c_char, len: *mut c_uint) -> c_int;

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -14,6 +14,7 @@ tlsv1_2 = ["openssl-sys/tlsv1_2"]
 tlsv1_1 = ["openssl-sys/tlsv1_1"]
 sslv2 = ["openssl-sys/sslv2"]
 aes_xts = ["openssl-sys/aes_xts"]
+npn = ["openssl-sys/npn"]
 
 [dependencies.openssl-sys]
 path = "../openssl-sys"


### PR DESCRIPTION
This pull request adds FFI bindings to OpenSSL's NPN-related functions to the `openssl-sys` crate. A new crate feature (`npn`) is also added and the functions are exposed only when it is set.

Additionally, the `openssl::ssl` module's API is augmented to provide Next Protocol Negotiation capabilities.

The following public methods were added:

- `SslContext::set_npn_protocols` - allows clients to set a list of protocols that should be used in NPN negotation. This applies to both server, as well as client sockets created using this `SslContext` instance.
- `Ssl::get_selected_npn_protocol` - returns an optional name of the protocol that was selected via NPN.
- `SslStream::get_selected_npn_protocol` - same as the previous method -- it actually delegates to the internal `Arc<Ssl>` instance.

These methods are also predicated on an `npn` feature being set in the `openssl` crate.

This API is very similar to what is found in Python's standard library.

Tests for the feature are included and properly integrated with the automated travis-ci test suite; an additional `openssl` process, with NPN enabled, is spawned before the tests are ran.