### PR TITLE
Use raw keys and certs in SslContext 

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -435,6 +435,9 @@ extern "C" {
 
     pub fn PEM_read_bio_X509(bio: *mut BIO, out: *mut *mut X509, callback: Option<PasswordCallback>,
                              user_data: *mut c_void) -> *mut X509;
+    pub fn PEM_read_bio_PrivateKey(bio: *mut BIO, out: *mut *mut EVP_PKEY, callback: Option<PasswordCallback>,
+                             user_data: *mut c_void) -> *mut X509;
+
     pub fn PEM_write_bio_PrivateKey(bio: *mut BIO, pkey: *mut EVP_PKEY, cipher: *const EVP_CIPHER,
                                     kstr: *mut c_char, klen: c_int,
                                     callback: Option<PasswordCallback>,
@@ -510,7 +513,10 @@ extern "C" {
     pub fn SSL_CTX_get_ex_data(ctx: *mut SSL_CTX, idx: c_int) -> *mut c_void;
 
     pub fn SSL_CTX_use_certificate_file(ctx: *mut SSL_CTX, cert_file: *const c_char, file_type: c_int) -> c_int;
+    pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, cert_file: *mut X509) -> c_int;
     pub fn SSL_CTX_use_PrivateKey_file(ctx: *mut SSL_CTX, key_file: *const c_char, file_type: c_int) -> c_int;
+    pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, key: *mut EVP_PKEY) -> c_int;
+    pub fn SSL_CTX_check_private_key(ctx: *mut SSL_CTX) -> c_int;
 
     pub fn SSL_CTX_set_cipher_list(ssl: *mut SSL_CTX, s: *const c_char) -> c_int;
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -132,6 +132,8 @@ pub const SSL_CTRL_OPTIONS: c_int = 32;
 pub const SSL_CTRL_CLEAR_OPTIONS: c_int = 77;
 
 pub const SSL_CTRL_SET_TLSEXT_HOSTNAME: c_int = 55;
+pub const SSL_CTRL_EXTRA_CHAIN_CERT: c_int = 14;
+
 pub const SSL_ERROR_NONE: c_int = 0;
 pub const SSL_ERROR_SSL: c_int = 1;
 pub const SSL_ERROR_SYSCALL: c_int = 5;
@@ -275,6 +277,11 @@ pub unsafe fn SSL_CTX_get_options(ssl: *mut SSL_CTX) -> c_long {
 pub unsafe fn SSL_CTX_clear_options(ssl: *mut SSL_CTX, op: c_long) -> c_long {
     SSL_CTX_ctrl(ssl, SSL_CTRL_CLEAR_OPTIONS, (op), ptr::null_mut())
 }
+
+pub unsafe fn SSL_CTX_add_extra_chain_cert(ssl: *mut SSL_CTX, cert: *mut X509) -> c_long {
+    SSL_CTX_ctrl(ssl, SSL_CTRL_EXTRA_CHAIN_CERT, 0, cert)
+}
+
 
 // True functions
 extern "C" {
@@ -513,7 +520,8 @@ extern "C" {
     pub fn SSL_CTX_get_ex_data(ctx: *mut SSL_CTX, idx: c_int) -> *mut c_void;
 
     pub fn SSL_CTX_use_certificate_file(ctx: *mut SSL_CTX, cert_file: *const c_char, file_type: c_int) -> c_int;
-    pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, cert_file: *mut X509) -> c_int;
+    pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, cert: *mut X509) -> c_int;
+
     pub fn SSL_CTX_use_PrivateKey_file(ctx: *mut SSL_CTX, key_file: *const c_char, file_type: c_int) -> c_int;
     pub fn SSL_CTX_use_PrivateKey(ctx: *mut SSL_CTX, key: *mut EVP_PKEY) -> c_int;
     pub fn SSL_CTX_check_private_key(ctx: *mut SSL_CTX) -> c_int;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -143,6 +143,7 @@ pub const SSL_ERROR_WANT_X509_LOOKUP: c_int = 4;
 pub const SSL_ERROR_ZERO_RETURN: c_int = 6;
 pub const SSL_VERIFY_NONE: c_int = 0;
 pub const SSL_VERIFY_PEER: c_int = 1;
+pub const SSL_VERIFY_FAIL_IF_NO_PEER_CERT: c_int = 2;
 
 pub const TLSEXT_NAMETYPE_host_name: c_long = 0;
 

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -352,7 +352,6 @@ impl Drop for PKey {
 
 #[cfg(test)]
 mod tests {
-    use std::io;
     use std::path::Path;
     use std::fs::File;
     use crypto::hash::Type::{MD5, SHA1};

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -1,4 +1,5 @@
 use libc::{c_int, c_uint, c_ulong};
+use std::io;
 use std::io::prelude::*;
 use std::iter::repeat;
 use std::mem;
@@ -66,6 +67,22 @@ impl PKey {
                 evp: ffi::EVP_PKEY_new(),
                 parts: Parts::Neither,
             }
+        }
+    }
+
+    /// Reads private key from PEM, takes ownership of handle
+    pub fn private_key_from_pem<R>(reader: &mut R) -> Result<PKey, SslError> where R: Read {
+        let mut mem_bio = try!(MemBio::new());
+        try!(io::copy(reader, &mut mem_bio).map_err(StreamError));
+
+        unsafe {
+            let evp = try_ssl_null!(ffi::PEM_read_bio_PrivateKey(mem_bio.get_handle(),
+                                                                 ptr::null_mut(),
+                                                                 None, ptr::null_mut()));
+            Ok(PKey {
+                evp:   evp,
+                parts: Parts::Both,
+            })
         }
     }
 
@@ -335,6 +352,9 @@ impl Drop for PKey {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::path::Path;
+    use std::fs::File;
     use crypto::hash::Type::{MD5, SHA1};
 
     #[test]
@@ -371,6 +391,16 @@ mod tests {
         assert!(k1.can(super::Role::Decrypt));
         assert!(k1.can(super::Role::Verify));
         assert!(k1.can(super::Role::Sign));
+    }
+
+    #[test]
+    fn test_private_key_from_pem() {
+        let key_path = Path::new("test/key.pem");
+        let mut file = File::open(&key_path)
+            .ok()
+            .expect("Failed to open `test/key.pem`");
+
+        super::PKey::private_key_from_pem(&mut file).unwrap();
     }
 
     #[test]

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -22,6 +22,7 @@ use bio::{MemBio};
 use ffi;
 use ssl::error::{SslError, SslSessionClosed, StreamError, OpenSslErrors};
 use x509::{X509StoreContext, X509FileType, X509};
+use crypto::pkey::PKey;
 
 pub mod error;
 #[cfg(test)]
@@ -400,6 +401,14 @@ impl SslContext {
             })
     }
 
+    /// Specifies the certificate
+    pub fn set_certificate(&mut self, cert: &X509) -> Option<SslError> {
+        wrap_ssl_result(
+            unsafe {
+                ffi::SSL_CTX_use_certificate(*self.ctx, cert.get_handle())
+            })
+    }
+
     /// Specifies the file that contains private key
     pub fn set_private_key_file(&mut self, file: &Path,
                                 file_type: X509FileType) -> Option<SslError> {
@@ -407,6 +416,22 @@ impl SslContext {
         wrap_ssl_result(
             unsafe {
                 ffi::SSL_CTX_use_PrivateKey_file(self.ctx, file.as_ptr(), file_type as c_int)
+            })
+    }
+
+    /// Specifies the private key
+    pub fn set_private_key(&mut self, key: &PKey) -> Option<SslError> {
+        wrap_ssl_result(
+            unsafe {
+                ffi::SSL_CTX_use_PrivateKey(*self.ctx, key.get_handle())
+            })
+    }
+
+    /// Check consistency of private key and certificate
+    pub fn check_private_key(&mut self) -> Option<SslError> {
+        wrap_ssl_result(
+            unsafe {
+                ffi::SSL_CTX_check_private_key(*self.ctx)
             })
     }
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -350,7 +350,7 @@ impl SslContext {
                                      mem::transmute(verify));
             let f: extern fn(c_int, *mut ffi::X509_STORE_CTX) -> c_int =
                                 raw_verify;
-            ffi::SSL_CTX_set_verify(*self.ctx, mode.bits as c_int, Some(f));
+            ffi::SSL_CTX_set_verify(self.ctx, mode.bits as c_int, Some(f));
         }
     }
 
@@ -370,7 +370,7 @@ impl SslContext {
                                      mem::transmute(data));
             let f: extern fn(c_int, *mut ffi::X509_STORE_CTX) -> c_int =
                                 raw_verify_with_data::<T>;
-            ffi::SSL_CTX_set_verify(*self.ctx, mode.bits as c_int, Some(f));
+            ffi::SSL_CTX_set_verify(self.ctx, mode.bits as c_int, Some(f));
         }
     }
 
@@ -405,7 +405,7 @@ impl SslContext {
     pub fn set_certificate(&mut self, cert: &X509) -> Result<(),SslError> {
         wrap_ssl_result(
             unsafe {
-                ffi::SSL_CTX_use_certificate(*self.ctx, cert.get_handle())
+                ffi::SSL_CTX_use_certificate(self.ctx, cert.get_handle())
             })
     }
 
@@ -414,7 +414,7 @@ impl SslContext {
     pub fn add_extra_chain_cert(&mut self, cert: &X509) -> Result<(),SslError> {
         wrap_ssl_result(
             unsafe {
-                ffi::SSL_CTX_add_extra_chain_cert(*self.ctx, cert.get_handle()) as c_int
+                ffi::SSL_CTX_add_extra_chain_cert(self.ctx, cert.get_handle()) as c_int
             })
     }
 
@@ -432,7 +432,7 @@ impl SslContext {
     pub fn set_private_key(&mut self, key: &PKey) -> Result<(),SslError> {
         wrap_ssl_result(
             unsafe {
-                ffi::SSL_CTX_use_PrivateKey(*self.ctx, key.get_handle())
+                ffi::SSL_CTX_use_PrivateKey(self.ctx, key.get_handle())
             })
     }
 
@@ -440,7 +440,7 @@ impl SslContext {
     pub fn check_private_key(&mut self) -> Result<(),SslError> {
         wrap_ssl_result(
             unsafe {
-                ffi::SSL_CTX_check_private_key(*self.ctx)
+                ffi::SSL_CTX_check_private_key(self.ctx)
             })
     }
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -115,13 +115,16 @@ impl SslMethod {
 }
 
 /// Determines the type of certificate verification used
-#[derive(Copy, Clone, Debug)]
-#[repr(i32)]
-pub enum SslVerifyMode {
-    /// Verify that the server's certificate is trusted
-    SslVerifyPeer = ffi::SSL_VERIFY_PEER,
-    /// Do not verify the server's certificate
-    SslVerifyNone = ffi::SSL_VERIFY_NONE
+bitflags! {
+    flags SslVerifyMode: i32 {
+        /// Verify that the server's certificate is trusted
+        const SSL_VERIFY_PEER = ffi::SSL_VERIFY_PEER,
+        /// Do not verify the server's certificate
+        const SSL_VERIFY_NONE = ffi::SSL_VERIFY_NONE,
+        /// Terminate handshake if client did not return a certificate.
+        /// Use together with SSL_VERIFY_PEER.
+        const SSL_VERIFY_FAIL_IF_NO_PEER_CERT = ffi::SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+    }
 }
 
 lazy_static! {
@@ -346,7 +349,7 @@ impl SslContext {
                                      mem::transmute(verify));
             let f: extern fn(c_int, *mut ffi::X509_STORE_CTX) -> c_int =
                                 raw_verify;
-            ffi::SSL_CTX_set_verify(self.ctx, mode as c_int, Some(f));
+            ffi::SSL_CTX_set_verify(*self.ctx, mode.bits as c_int, Some(f));
         }
     }
 
@@ -366,7 +369,7 @@ impl SslContext {
                                      mem::transmute(data));
             let f: extern fn(c_int, *mut ffi::X509_STORE_CTX) -> c_int =
                                 raw_verify_with_data::<T>;
-            ffi::SSL_CTX_set_verify(self.ctx, mode as c_int, Some(f));
+            ffi::SSL_CTX_set_verify(*self.ctx, mode.bits as c_int, Some(f));
         }
     }
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -300,11 +300,11 @@ pub type VerifyCallbackData<T> = fn(preverify_ok: bool,
 
 // FIXME: macro may be instead of inlining?
 #[inline]
-fn wrap_ssl_result(res: c_int) -> Option<SslError> {
+fn wrap_ssl_result(res: c_int) -> Result<(),SslError> {
     if res == 0 {
-        Some(SslError::get())
+        Err(SslError::get())
     } else {
-        None
+        Ok(())
     }
 }
 
@@ -383,7 +383,7 @@ impl SslContext {
 
     #[allow(non_snake_case)]
     /// Specifies the file that contains trusted CA certificates.
-    pub fn set_CA_file(&mut self, file: &Path) -> Option<SslError> {
+    pub fn set_CA_file(&mut self, file: &Path) -> Result<(),SslError> {
         let file = CString::new(file.as_os_str().to_str().expect("invalid utf8")).unwrap();
         wrap_ssl_result(
             unsafe {
@@ -393,7 +393,7 @@ impl SslContext {
 
     /// Specifies the file that contains certificate
     pub fn set_certificate_file(&mut self, file: &Path,
-                                file_type: X509FileType) -> Option<SslError> {
+                                file_type: X509FileType) -> Result<(),SslError> {
         let file = CString::new(file.as_os_str().to_str().expect("invalid utf8")).unwrap();
         wrap_ssl_result(
             unsafe {
@@ -402,7 +402,7 @@ impl SslContext {
     }
 
     /// Specifies the certificate
-    pub fn set_certificate(&mut self, cert: &X509) -> Option<SslError> {
+    pub fn set_certificate(&mut self, cert: &X509) -> Result<(),SslError> {
         wrap_ssl_result(
             unsafe {
                 ffi::SSL_CTX_use_certificate(*self.ctx, cert.get_handle())
@@ -411,7 +411,7 @@ impl SslContext {
 
     /// Adds a certificate to the certificate chain presented together with the
     /// certificate specified using set_certificate()
-    pub fn add_extra_chain_cert(&mut self, cert: &X509) -> Option<SslError> {
+    pub fn add_extra_chain_cert(&mut self, cert: &X509) -> Result<(),SslError> {
         wrap_ssl_result(
             unsafe {
                 ffi::SSL_CTX_add_extra_chain_cert(*self.ctx, cert.get_handle()) as c_int
@@ -420,7 +420,7 @@ impl SslContext {
 
     /// Specifies the file that contains private key
     pub fn set_private_key_file(&mut self, file: &Path,
-                                file_type: X509FileType) -> Option<SslError> {
+                                file_type: X509FileType) -> Result<(),SslError> {
         let file = CString::new(file.as_os_str().to_str().expect("invalid utf8")).unwrap();
         wrap_ssl_result(
             unsafe {
@@ -429,7 +429,7 @@ impl SslContext {
     }
 
     /// Specifies the private key
-    pub fn set_private_key(&mut self, key: &PKey) -> Option<SslError> {
+    pub fn set_private_key(&mut self, key: &PKey) -> Result<(),SslError> {
         wrap_ssl_result(
             unsafe {
                 ffi::SSL_CTX_use_PrivateKey(*self.ctx, key.get_handle())
@@ -437,14 +437,14 @@ impl SslContext {
     }
 
     /// Check consistency of private key and certificate
-    pub fn check_private_key(&mut self) -> Option<SslError> {
+    pub fn check_private_key(&mut self) -> Result<(),SslError> {
         wrap_ssl_result(
             unsafe {
                 ffi::SSL_CTX_check_private_key(*self.ctx)
             })
     }
 
-    pub fn set_cipher_list(&mut self, cipher_list: &str) -> Option<SslError> {
+    pub fn set_cipher_list(&mut self, cipher_list: &str) -> Result<(),SslError> {
         wrap_ssl_result(
             unsafe {
                 let cipher_list = CString::new(cipher_list.as_bytes()).unwrap();

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -409,6 +409,15 @@ impl SslContext {
             })
     }
 
+    /// Adds a certificate to the certificate chain presented together with the
+    /// certificate specified using set_certificate()
+    pub fn add_extra_chain_cert(&mut self, cert: &X509) -> Option<SslError> {
+        wrap_ssl_result(
+            unsafe {
+                ffi::SSL_CTX_add_extra_chain_cert(*self.ctx, cert.get_handle()) as c_int
+            })
+    }
+
     /// Specifies the file that contains private key
     pub fn set_private_key_file(&mut self, file: &Path,
                                 file_type: X509FileType) -> Option<SslError> {

--- a/openssl/src/ssl/tests.rs
+++ b/openssl/src/ssl/tests.rs
@@ -48,8 +48,8 @@ fn test_verify_trusted() {
     let mut ctx = SslContext::new(Sslv23).unwrap();
     ctx.set_verify(SSL_VERIFY_PEER, None);
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
-        None => {}
-        Some(err) => panic!("Unexpected error {:?}", err)
+        Ok(_) => {}
+        Err(err) => panic!("Unexpected error {:?}", err)
     }
     match SslStream::new(&ctx, stream) {
         Ok(_) => (),
@@ -91,8 +91,8 @@ fn test_verify_trusted_callback_override_ok() {
     let mut ctx = SslContext::new(Sslv23).unwrap();
     ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
-        None => {}
-        Some(err) => panic!("Unexpected error {:?}", err)
+        Ok(_) => {}
+        Err(err) => panic!("Unexpected error {:?}", err)
     }
     match SslStream::new(&ctx, stream) {
         Ok(_) => (),
@@ -109,8 +109,8 @@ fn test_verify_trusted_callback_override_bad() {
     let mut ctx = SslContext::new(Sslv23).unwrap();
     ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
-        None => {}
-        Some(err) => panic!("Unexpected error {:?}", err)
+        Ok(_) => {}
+        Err(err) => panic!("Unexpected error {:?}", err)
     }
     assert!(SslStream::new(&ctx, stream).is_err());
 }
@@ -137,8 +137,8 @@ fn test_verify_trusted_get_error_ok() {
     let mut ctx = SslContext::new(Sslv23).unwrap();
     ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
-        None => {}
-        Some(err) => panic!("Unexpected error {:?}", err)
+        Ok(_) => {}
+        Err(err) => panic!("Unexpected error {:?}", err)
     }
     assert!(SslStream::new(&ctx, stream).is_ok());
 }
@@ -200,10 +200,10 @@ fn test_set_certificate_and_private_key() {
     let cert = X509::from_pem(&mut cert_file).unwrap();
 
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_private_key(&key);
-    ctx.set_certificate(&cert);
+    ctx.set_private_key(&key).unwrap();
+    ctx.set_certificate(&cert).unwrap();
 
-    assert!(ctx.check_private_key().is_none());
+    assert!(ctx.check_private_key().is_ok());
 }
 
 #[test]

--- a/openssl/src/ssl/tests.rs
+++ b/openssl/src/ssl/tests.rs
@@ -258,11 +258,11 @@ fn test_read() {
 fn test_connect_with_unilateral_npn() {
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, None);
+    ctx.set_verify(SSL_VERIFY_PEER, None);
     ctx.set_npn_protocols(&[b"http/1.1", b"spdy/3.1"]);
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
-        None => {}
-        Some(err) => panic!("Unexpected error {:?}", err)
+        Ok(_)=> {}
+        Err(err) => panic!("Unexpected error {:?}", err)
     }
     let stream = match SslStream::new(&ctx, stream) {
         Ok(stream) => stream,
@@ -282,11 +282,11 @@ fn test_connect_with_npn_successful_multiple_matching() {
     // NPN enabled.
     let stream = TcpStream::connect("127.0.0.1:15419").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, None);
+    ctx.set_verify(SSL_VERIFY_PEER, None);
     ctx.set_npn_protocols(&[b"spdy/3.1", b"http/1.1"]);
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
-        None => {}
-        Some(err) => panic!("Unexpected error {:?}", err)
+        Ok(_)=> {}
+        Err(err) => panic!("Unexpected error {:?}", err)
     }
     let stream = match SslStream::new(&ctx, stream) {
         Ok(stream) => stream,
@@ -307,11 +307,11 @@ fn test_connect_with_npn_successful_single_match() {
     // NPN enabled.
     let stream = TcpStream::connect("127.0.0.1:15419").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, None);
+    ctx.set_verify(SSL_VERIFY_PEER, None);
     ctx.set_npn_protocols(&[b"spdy/3.1"]);
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
-        None => {}
-        Some(err) => panic!("Unexpected error {:?}", err)
+        Ok(_)=> {}
+        Err(err) => panic!("Unexpected error {:?}", err)
     }
     let stream = match SslStream::new(&ctx, stream) {
         Ok(stream) => stream,
@@ -332,12 +332,12 @@ fn test_npn_server_advertise_multiple() {
     // We create a different context instance for the server...
     let listener_ctx = {
         let mut ctx = SslContext::new(Sslv23).unwrap();
-        ctx.set_verify(SslVerifyPeer, None);
+        ctx.set_verify(SSL_VERIFY_PEER, None);
         ctx.set_npn_protocols(&[b"http/1.1", b"spdy/3.1"]);
-        ctx.set_certificate_file(
-                &Path::new("test/cert.pem"), X509FileType::PEM);
+        assert!(ctx.set_certificate_file(
+                &Path::new("test/cert.pem"), X509FileType::PEM).is_ok());
         ctx.set_private_key_file(
-                &Path::new("test/key.pem"), X509FileType::PEM);
+                &Path::new("test/key.pem"), X509FileType::PEM).unwrap();
         ctx
     };
     // Have the listener wait on the connection in a different thread.
@@ -347,11 +347,11 @@ fn test_npn_server_advertise_multiple() {
     });
 
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, None);
+    ctx.set_verify(SSL_VERIFY_PEER, None);
     ctx.set_npn_protocols(&[b"spdy/3.1"]);
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
-        None => {}
-        Some(err) => panic!("Unexpected error {:?}", err)
+        Ok(_)=> {}
+        Err(err) => panic!("Unexpected error {:?}", err)
     }
     // Now connect to the socket and make sure the protocol negotiation works...
     let stream = TcpStream::connect(localhost).unwrap();

--- a/openssl/src/ssl/tests.rs
+++ b/openssl/src/ssl/tests.rs
@@ -12,10 +12,11 @@ use crypto::hash::Type::{SHA256};
 use ssl;
 use ssl::SslMethod::Sslv23;
 use ssl::{SslContext, SslStream, VerifyCallback};
-use ssl::SslVerifyMode::SslVerifyPeer;
+use ssl::SSL_VERIFY_PEER;
 use x509::X509StoreContext;
 #[cfg(feature = "npn")]
 use x509::X509FileType;
+use x509::{X509StoreContext};
 
 #[test]
 fn test_new_ctx() {
@@ -32,7 +33,7 @@ fn test_new_sslstream() {
 fn test_verify_untrusted() {
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, None);
+    ctx.set_verify(SSL_VERIFY_PEER, None);
     match SslStream::new(&ctx, stream) {
         Ok(_) => panic!("expected failure"),
         Err(err) => println!("error {:?}", err)
@@ -43,7 +44,7 @@ fn test_verify_untrusted() {
 fn test_verify_trusted() {
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, None);
+    ctx.set_verify(SSL_VERIFY_PEER, None);
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => panic!("Unexpected error {:?}", err)
@@ -61,7 +62,7 @@ fn test_verify_untrusted_callback_override_ok() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match SslStream::new(&ctx, stream) {
         Ok(_) => (),
         Err(err) => panic!("Expected success, got {:?}", err)
@@ -75,7 +76,7 @@ fn test_verify_untrusted_callback_override_bad() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     assert!(SslStream::new(&ctx, stream).is_err());
 }
 
@@ -86,7 +87,7 @@ fn test_verify_trusted_callback_override_ok() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => panic!("Unexpected error {:?}", err)
@@ -104,7 +105,7 @@ fn test_verify_trusted_callback_override_bad() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => panic!("Unexpected error {:?}", err)
@@ -120,7 +121,7 @@ fn test_verify_callback_load_certs() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     assert!(SslStream::new(&ctx, stream).is_ok());
 }
 
@@ -132,7 +133,7 @@ fn test_verify_trusted_get_error_ok() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     match ctx.set_CA_file(&Path::new("test/cert.pem")) {
         None => {}
         Some(err) => panic!("Unexpected error {:?}", err)
@@ -148,7 +149,7 @@ fn test_verify_trusted_get_error_err() {
     }
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
     let mut ctx = SslContext::new(Sslv23).unwrap();
-    ctx.set_verify(SslVerifyPeer, Some(callback as VerifyCallback));
+    ctx.set_verify(SSL_VERIFY_PEER, Some(callback as VerifyCallback));
     assert!(SslStream::new(&ctx, stream).is_err());
 }
 
@@ -173,7 +174,7 @@ fn test_verify_callback_data() {
     // Please update if "test/cert.pem" will ever change
     let node_hash_str = "46e3f1a6d17a41ce70d0c66ef51cee2ab4ba67cac8940e23f10c1f944b49fb5c";
     let node_id = node_hash_str.from_hex().unwrap();
-    ctx.set_verify_with_data(SslVerifyPeer, callback, node_id);
+    ctx.set_verify_with_data(SSL_VERIFY_PEER, callback, node_id);
     ctx.set_verify_depth(1);
 
     match SslStream::new(&ctx, stream) {

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -393,6 +393,10 @@ impl<'ctx> X509<'ctx> {
         }
     }
 
+    pub fn get_handle(&self) -> *mut ffi::X509 {
+        self.handle
+    }
+
     pub fn subject_name<'a>(&'a self) -> X509Name<'a> {
         let name = unsafe { ffi::X509_get_subject_name(self.handle) };
         X509Name { x509: self, name: name }


### PR DESCRIPTION
Add `SslContext::set_private_key(&PKey)` and `SslContext::set_certificate(&X509)` to use 'raw' private keys and certificates for SSL connections.
Additionally, this pull requests adds `PKey::private_key_from_pem(...)` which is needed for testing but might come in handy for some people.