### PR TITLE
Fix documentation URL for openssl-sys.

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>",
 license = "MIT"
 description = "FFI bindings to OpenSSL"
 repository = "https://github.com/sfackler/rust-openssl"
-documentation = "https://sfackler.github.io/rust-openssl/doc/openssl-sys"
+documentation = "https://sfackler.github.io/rust-openssl/doc/openssl_sys"
 
 links = "openssl"
 build = "build.rs"


### PR DESCRIPTION
The [current link](https://sfackler.github.io/rust-openssl/doc/openssl-sys) leads to a 404. The [correct link](https://sfackler.github.io/rust-openssl/doc/openssl_sys) should have an underscore instead of a hyphen.