### PR TITLE
docs(README.md): remove extra `\` character

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ rust-openssl directory. Then run one of the following commands:
 
 * Windows: `openssl s_server -accept 15418 -www -cert test/cert.pem -key
   test/key.pem > NUL`
-* Linux: `openssl s_server -accept 15418 -www -cert test/cert.pem -key \
+* Linux: `openssl s_server -accept 15418 -www -cert test/cert.pem -key
   test/key.pem >/dev/null`
 
 Then in the original terminal, run `cargo test`. If everything is set up


### PR DESCRIPTION
The original intention might have been to cause a line-break in
the markdown document. However, it was taken literally.

Those who would just copy-paste the `openssl` server line on linux would
be greeted with a `file not found` error.

Without the `\` character, it works as expected.