### PR TITLE
Add SslStream.pending()

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -496,6 +496,7 @@ extern "C" {
     pub fn SSLv23_method() -> *const SSL_METHOD;
 
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
+    pub fn SSL_pending(ssl: *const SSL) -> c_int;
     pub fn SSL_free(ssl: *mut SSL);
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
     pub fn SSL_get_rbio(ssl: *mut SSL) -> *mut BIO;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -707,6 +707,13 @@ impl Ssl {
             }
         }
     }
+
+    /// pending() takes into account only bytes from the TLS/SSL record that is currently being processed (if any).
+    pub fn pending(&self) -> usize {
+        unsafe {
+            ffi::SSL_pending(self.ssl) as usize
+        }
+    }
 }
 
 macro_rules! make_LibSslError {
@@ -881,6 +888,11 @@ impl<S: Read+Write> SslStream<S> {
     #[cfg(feature = "npn")]
     pub fn get_selected_npn_protocol(&self) -> Option<&[u8]> {
         self.ssl.get_selected_npn_protocol()
+    }
+
+    /// pending() takes into account only bytes from the TLS/SSL record that is currently being processed (if any).
+    pub fn pending(&self) -> usize {
+        self.ssl.pending()
     }
 }
 


### PR DESCRIPTION
This does not differ strongly from the previous `pending` pull request.
I was just irritated by its behavior because so I added a comment, too:

    /// pending() takes into account only bytes from the TLS/SSL record that is currently being processed (if any).