### PR TITLE
Add ability to redefine library list via OPENSSL_LIBS environment variable

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -23,7 +23,7 @@ fn main() {
     let libs_env = env::var("OPENSSL_LIBS").ok();
     let libs = match libs_env {
         Some(ref v) => v.split(":").collect(),
-        None => if target.contains("windows") && env::var_os("MSYSTEM").is_none() {
+        None => if target.contains("windows") {
             vec!("eay32", "ssl32")
         } else {
             vec!("crypto", "ssl")

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -20,10 +20,14 @@ fn main() {
         }
     }
 
-    let (libcrypto, libssl) = if target.contains("windows") {
-    	("eay32", "ssl32")
-    } else {
-    	("crypto", "ssl")
+    let libs_env = env::var("OPENSSL_LIBS").ok();
+    let libs = match libs_env {
+        Some(ref v) => v.split(":").collect(),
+        None => if target.contains("windows") && env::var_os("MSYSTEM").is_none() {
+            vec!("eay32", "ssl32")
+        } else {
+            vec!("crypto", "ssl")
+        }
     };
 
     let mode = if env::var_os("OPENSSL_STATIC").is_some() {
@@ -36,7 +40,8 @@ fn main() {
     	println!("cargo:rustc-flags=-L native={}", lib_dir);
     }
 
-    println!("cargo:rustc-flags=-l {0}={1} -l {0}={2}", mode, libcrypto, libssl);
+    let libs_arg = libs.iter().fold(String::new(), |args, lib| args + &format!(" -l {0}={1}", mode, lib));
+    println!("cargo:rustc-flags={0}", libs_arg);
 
     let mut include_dirs = vec![];
 


### PR DESCRIPTION
Add ability to redefine library list via OPENSSL_LIBS environment variable.

It's usefull for compiling with MinGW-w64 installed via MSYS2 (https://wiki.qt.io/MSYS2).

This MinGW-w64 uses **crypto** and **ssl** library names.