### PR TITLE
Add accessor for peer_certificate

### DIFF
--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -822,6 +822,11 @@ impl<S: Read+Write> SslStream<S> {
         &self.stream
     }
 
+    /// Return the certificate of the peer
+    pub fn get_peer_certificate(&self) -> Option<X509> {
+        self.ssl.get_peer_certificate()
+    }
+
     /// Returns a mutable reference to the underlying stream.
     ///
     /// ## Warning

--- a/openssl/src/ssl/tests.rs
+++ b/openssl/src/ssl/tests.rs
@@ -315,6 +315,16 @@ fn test_write() {
     stream.flush().unwrap();
 }
 
+run_test!(get_peer_certificate, |method, stream| {
+    //let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
+    let stream = SslStream::new(&SslContext::new(method).unwrap(), stream).unwrap();
+    let cert = stream.get_peer_certificate().unwrap();
+    let fingerprint = cert.fingerprint(SHA256).unwrap();
+    let node_hash_str = "46e3f1a6d17a41ce70d0c66ef51cee2ab4ba67cac8940e23f10c1f944b49    fb5c";
+    let node_id = node_hash_str.from_hex().unwrap();
+    assert_eq!(node_id, fingerprint)
+});
+
 #[test]
 #[cfg(feature = "dtlsv1")]
 fn test_write_dtlsv1() {


### PR DESCRIPTION
This is useful for authenticating peers.

Is there a better way to do this?