### PR TITLE
Added support for building on Windows with MinGW

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ rust-openssl to a separate installation.
 
 ### Windows
 
-Install OpenSSL from [here][1]. Cargo will not be able to find OpenSSL if it's
+On Windows, consider building with [mingw-w64](http://mingw-w64.org/).
+Build script will try to find mingw in `PATH` environment variable to provide
+Cargo with location where openssl libs from mingw-w64 package may be found.
+If you followed guide [Building on Windows](https://github.com/rust-lang/rust#building-on-windows)
+from rust repo, then you should have [MSYS2](http://msys2.github.io/) with
+`mingw-w64-openssl` installed as part of `mingw-w64-x86_64-toolchain`
+(or `mingw-w64-i686-toolchain`) package.
+
+Alternatively, install OpenSSL from [here][1]. Cargo will not be able to find OpenSSL if it's
 installed to the default location. You can either copy the `include/openssl`
 directory, `libssl32.dll`, and `libeay32.dll` to locations that Cargo can find
 or pass the location to Cargo via environment variables:


### PR DESCRIPTION
Currently, linking against openssl libraries fails on windows, unless you hint build script with proper [environment variables](https://github.com/sfackler/rust-openssl#windows), or by copying openssl libs in one of the default paths supplied to rustc by cargo. This PR should enable proper linking against openssl while using one of the MinGW distributions (tested with MSYS2).

Somewhat related issue - #177 
I think issue there is same - linking fails because gcc couldn't find libs in paths provided (not because of .dll suffix, gcc bundled with rust and msys is able to link against both .dll & .a)