### PR TITLE
Allow setting of arbitrary X509 names

### DIFF
--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -209,6 +209,17 @@ impl X509Generator {
         self
     }
 
+    /// Add multiple attributes to the name of the certificate
+    ///
+    /// ```ignore
+    /// generator.add_names(vec![("CN".to_string(),"example.com".to_string())]);
+    /// ```
+    pub fn add_names<I>(mut self, attrs: I) -> X509Generator
+        where I: IntoIterator<Item=(String,String)> {
+        self.names.extend(attrs);
+        self
+    }
+
     /// (deprecated) Sets what for certificate could be used
     ///
     /// This function is deprecated, use `X509Generator.add_extension` instead.

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -201,8 +201,9 @@ impl X509Generator {
 
     /// Add attribute to the name of the certificate
     ///
-    /// ```ignore
-    /// generator.add_name("CN".to_string(),"example.com".to_string())
+    /// ```
+    /// # let generator = openssl::x509::X509Generator::new();
+    /// generator.add_name("CN".to_string(),"example.com".to_string());
     /// ```
     pub fn add_name(mut self, attr_type: String, attr_value: String) -> X509Generator {
         self.names.push((attr_type,attr_value));
@@ -211,7 +212,8 @@ impl X509Generator {
 
     /// Add multiple attributes to the name of the certificate
     ///
-    /// ```ignore
+    /// ```
+    /// # let generator = openssl::x509::X509Generator::new();
     /// generator.add_names(vec![("CN".to_string(),"example.com".to_string())]);
     /// ```
     pub fn add_names<I>(mut self, attrs: I) -> X509Generator

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -16,7 +16,7 @@ fn test_cert_gen() {
     let gen = X509Generator::new()
         .set_bitlength(2048)
         .set_valid_period(365*2)
-        .set_CN("test_me")
+        .add_name("CN".to_string(),"test_me".to_string())
         .set_sign_hash(SHA256)
         .add_extension(KeyUsage(vec![DigitalSignature, KeyEncipherment]))
         .add_extension(ExtKeyUsage(vec![ClientAuth, ServerAuth, ExtKeyUsageOption::Other("2.999.1".to_owned())]))


### PR DESCRIPTION
_Note added 2015-06-24: GitHub is usually pretty good in keeping obsolete commits in the PR history, but I guess not in this case. The original PR had `names` as a publicly-accessible field on the `X509Generator`._