### PR TITLE
Add support for ALPN ("successor" to NPN)

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -19,6 +19,7 @@ dtlsv1_2 = []
 sslv2 = []
 aes_xts = []
 npn = []
+alpn = []
 
 [dependencies]
 libc = "0.1"

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -547,12 +547,30 @@ extern "C" {
                                                               inlen: c_uint,
                                                               arg: *mut c_void) -> c_int,
                                             arg: *mut c_void);
-    #[cfg(feature = "npn")]
+    #[cfg(any(feature = "alpn", feature = "npn"))]
     pub fn SSL_select_next_proto(out: *mut *mut c_uchar, outlen: *mut c_uchar,
                                  inbuf: *const c_uchar, inlen: c_uint,
                                  client: *const c_uchar, client_len: c_uint) -> c_int;
     #[cfg(feature = "npn")]
     pub fn SSL_get0_next_proto_negotiated(s: *const SSL, data: *mut *const c_uchar, len: *mut c_uint);
+
+    #[cfg(feature = "alpn")]
+    pub fn SSL_CTX_set_alpn_protos(s: *mut SSL_CTX, data: *const c_uchar, len: c_uint) -> c_int;
+
+    #[cfg(feature = "alpn")]
+    pub fn SSL_set_alpn_protos(s: *mut SSL, data: *const c_uchar, len: c_uint) -> c_int;
+
+    #[cfg(feature = "alpn")]
+    pub fn SSL_CTX_set_alpn_select_cb(ssl: *mut SSL_CTX,
+                                            cb: extern "C" fn(ssl: *mut SSL,
+                                                              out: *mut *mut c_uchar,
+                                                              outlen: *mut c_uchar,
+                                                              inbuf: *const c_uchar,
+                                                              inlen: c_uint,
+                                                              arg: *mut c_void) -> c_int,
+                                            arg: *mut c_void);
+    #[cfg(feature = "alpn")]
+    pub fn SSL_get0_alpn_selected(s: *const SSL, data: *mut *const c_uchar, len: *mut c_uint);
 
     pub fn X509_add_ext(x: *mut X509, ext: *mut X509_EXTENSION, loc: c_int) -> c_int;
     pub fn X509_digest(x: *mut X509, digest: *const EVP_MD, buf: *mut c_char, len: *mut c_uint) -> c_int;

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -17,6 +17,7 @@ dtlsv1_2 = ["openssl-sys/dtlsv1_2"]
 sslv2 = ["openssl-sys/sslv2"]
 aes_xts = ["openssl-sys/aes_xts"]
 npn = ["openssl-sys/npn"]
+alpn = ["openssl-sys/alpn"]
 
 [dependencies.openssl-sys]
 path = "../openssl-sys"

--- a/openssl/src/ssl/tests.rs
+++ b/openssl/src/ssl/tests.rs
@@ -393,6 +393,28 @@ fn test_pending() {
 /// Tests that connecting with the client using NPN, but the server not does not
 /// break the existing connection behavior.
 #[test]
+#[cfg(feature = "alpn")]
+fn test_connect_with_unilateral_alpn() {
+    let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
+    let mut ctx = SslContext::new(Sslv23).unwrap();
+    ctx.set_verify(SSL_VERIFY_PEER, None);
+    ctx.set_alpn_protocols(&[b"http/1.1", b"spdy/3.1"]);
+    match ctx.set_CA_file(&Path::new("test/cert.pem")) {
+        Ok(_) => {}
+        Err(err) => panic!("Unexpected error {:?}", err)
+    }
+    let stream = match SslStream::new(&ctx, stream) {
+        Ok(stream) => stream,
+        Err(err) => panic!("Expected success, got {:?}", err)
+    };
+    // Since the socket to which we connected is not configured to use NPN,
+    // there should be no selected protocol...
+    assert!(stream.get_selected_alpn_protocol().is_none());
+}
+
+/// Tests that connecting with the client using NPN, but the server not does not
+/// break the existing connection behavior.
+#[test]
 #[cfg(feature = "npn")]
 fn test_connect_with_unilateral_npn() {
     let stream = TcpStream::connect("127.0.0.1:15418").unwrap();
@@ -410,6 +432,30 @@ fn test_connect_with_unilateral_npn() {
     // Since the socket to which we connected is not configured to use NPN,
     // there should be no selected protocol...
     assert!(stream.get_selected_npn_protocol().is_none());
+}
+
+/// Tests that when both the client as well as the server use ALPN and their
+/// lists of supported protocols have an overlap, the correct protocol is chosen.
+#[test]
+#[cfg(feature = "alpn")]
+fn test_connect_with_alpn_successful_multiple_matching() {
+    // A different port than the other tests: an `openssl` process that has
+    // NPN enabled.
+    let stream = TcpStream::connect("127.0.0.1:15419").unwrap();
+    let mut ctx = SslContext::new(Sslv23).unwrap();
+    ctx.set_verify(SSL_VERIFY_PEER, None);
+    ctx.set_alpn_protocols(&[b"spdy/3.1", b"http/1.1"]);
+    match ctx.set_CA_file(&Path::new("test/cert.pem")) {
+        Ok(_) => {}
+        Err(err) => panic!("Unexpected error {:?}", err)
+    }
+    let stream = match SslStream::new(&ctx, stream) {
+        Ok(stream) => stream,
+        Err(err) => panic!("Expected success, got {:?}", err)
+    };
+    // The server prefers "http/1.1", so that is chosen, even though the client
+    // would prefer "spdy/3.1"
+    assert_eq!(b"http/1.1", stream.get_selected_alpn_protocol().unwrap());
 }
 
 /// Tests that when both the client as well as the server use NPN and their
@@ -435,6 +481,32 @@ fn test_connect_with_npn_successful_multiple_matching() {
     // would prefer "spdy/3.1"
     assert_eq!(b"http/1.1", stream.get_selected_npn_protocol().unwrap());
 }
+
+/// Tests that when both the client as well as the server use ALPN and their
+/// lists of supported protocols have an overlap -- with only ONE protocol
+/// being valid for both.
+#[test]
+#[cfg(feature = "alpn")]
+fn test_connect_with_alpn_successful_single_match() {
+    // A different port than the other tests: an `openssl` process that has
+    // ALPN enabled.
+    let stream = TcpStream::connect("127.0.0.1:15419").unwrap();
+    let mut ctx = SslContext::new(Sslv23).unwrap();
+    ctx.set_verify(SSL_VERIFY_PEER, None);
+    ctx.set_alpn_protocols(&[b"spdy/3.1"]);
+    match ctx.set_CA_file(&Path::new("test/cert.pem")) {
+        Ok(_) => {}
+        Err(err) => panic!("Unexpected error {:?}", err)
+    }
+    let stream = match SslStream::new(&ctx, stream) {
+        Ok(stream) => stream,
+        Err(err) => panic!("Expected success, got {:?}", err)
+    };
+    // The client now only supports one of the server's protocols, so that one
+    // is used.
+    assert_eq!(b"spdy/3.1", stream.get_selected_alpn_protocol().unwrap());
+}
+
 
 /// Tests that when both the client as well as the server use NPN and their
 /// lists of supported protocols have an overlap -- with only ONE protocol
@@ -500,6 +572,47 @@ fn test_npn_server_advertise_multiple() {
     };
     // SPDY is selected since that's the only thing the client supports.
     assert_eq!(b"spdy/3.1", stream.get_selected_npn_protocol().unwrap());
+}
+
+/// Tests that when the `SslStream` is created as a server stream, the protocols
+/// are correctly advertised to the client.
+#[test]
+#[cfg(feature = "alpn")]
+fn test_alpn_server_advertise_multiple() {
+    let localhost = "127.0.0.1:15420";
+    let listener = TcpListener::bind(localhost).unwrap();
+    // We create a different context instance for the server...
+    let listener_ctx = {
+        let mut ctx = SslContext::new(Sslv23).unwrap();
+        ctx.set_verify(SSL_VERIFY_PEER, None);
+        ctx.set_alpn_protocols(&[b"http/1.1", b"spdy/3.1"]);
+        assert!(ctx.set_certificate_file(
+                &Path::new("test/cert.pem"), X509FileType::PEM).is_ok());
+        ctx.set_private_key_file(
+                &Path::new("test/key.pem"), X509FileType::PEM).unwrap();
+        ctx
+    };
+    // Have the listener wait on the connection in a different thread.
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let _ = SslStream::new_server(&listener_ctx, stream).unwrap();
+    });
+
+    let mut ctx = SslContext::new(Sslv23).unwrap();
+    ctx.set_verify(SSL_VERIFY_PEER, None);
+    ctx.set_alpn_protocols(&[b"spdy/3.1"]);
+    match ctx.set_CA_file(&Path::new("test/cert.pem")) {
+        Ok(_) => {}
+        Err(err) => panic!("Unexpected error {:?}", err)
+    }
+    // Now connect to the socket and make sure the protocol negotiation works...
+    let stream = TcpStream::connect(localhost).unwrap();
+    let stream = match SslStream::new(&ctx, stream) {
+        Ok(stream) => stream,
+        Err(err) => panic!("Expected success, got {:?}", err)
+    };
+    // SPDY is selected since that's the only thing the client supports.
+    assert_eq!(b"spdy/3.1", stream.get_selected_alpn_protocol().unwrap());
 }
 
 #[cfg(feature="dtlsv1")]

--- a/openssl/test/test.sh
+++ b/openssl/test/test.sh
@@ -4,7 +4,7 @@ cd $(dirname $0)
 
 openssl s_server -accept 15418 -www -cert cert.pem -key key.pem >/dev/null 2>&1 &
 openssl s_server -accept 15419 -www -cert cert.pem -key key.pem \
-    -nextprotoneg "http/1.1,spdy/3.1" >/dev/null 2>&1 &
+    -nextprotoneg "http/1.1,spdy/3.1" -alpn "http/1.1,spdy/3.1" >/dev/null 2>&1 &
 openssl s_server -no_ssl2 -accept 15420 -www -cert cert.pem -key key.pem >/dev/null 2>&1 &
 
 if test "$TRAVIS_OS_NAME" == "osx"; then


### PR DESCRIPTION
Implementation and interface is very similar, tests I've created are identical.
It's possible we might be able to reduce duplication between the NPN and ALPN code & tests at some point.