### PR TITLE
Unpin the bitflags version.

### DIFF
--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -24,7 +24,7 @@ path = "../openssl-sys"
 version = "0.6.3"
 
 [dependencies]
-bitflags = "0.2"
+bitflags = ">= 0.2, < 0.4"
 lazy_static = "0.1"
 libc = "0.1"
 


### PR DESCRIPTION
This dependency causes Servo to depend on multiple versions of the bitflags
crate.