### PR TITLE
Fix probelms with DTLS when no packets are pending.

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -525,6 +525,7 @@ extern "C" {
     pub fn SSL_get_SSL_CTX(ssl: *mut SSL) -> *mut SSL_CTX;
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
     pub fn SSL_get_peer_certificate(ssl: *mut SSL) -> *mut X509;
+    pub fn SSL_get_ssl_method(ssl: *mut SSL) -> *const SSL_METHOD;
 
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const c_char;
 

--- a/openssl/src/ssl/tests.rs
+++ b/openssl/src/ssl/tests.rs
@@ -51,7 +51,7 @@ macro_rules! run_test(
             use std::net::TcpStream;
             use ssl;
             use ssl::SslMethod;
-            use ssl::{SslContext, SslStream, VerifyCallback};
+            use ssl::{SslContext, Ssl, SslStream, VerifyCallback};
             use ssl::SSL_VERIFY_PEER;
             use crypto::hash::Type::SHA256;
             use x509::X509StoreContext;
@@ -84,6 +84,11 @@ run_test!(new_ctx, |method, _| {
 
 run_test!(new_sslstream, |method, stream| {
     SslStream::connect_generic(&SslContext::new(method).unwrap(), stream).unwrap();
+});
+
+run_test!(get_ssl_method, |method, _| {
+    let ssl = Ssl::new(&SslContext::new(method).unwrap()).unwrap();
+    assert_eq!(ssl.get_ssl_method(), Some(method));
 });
 
 run_test!(verify_untrusted, |method, stream| {


### PR DESCRIPTION
When using DTLS you might run into the situation where no packets
are pending, so SSL_read returns len=0. On a TLS connection this
means that the connection was closed, but on DTLS it does not
(a DTLS connection cannot be closed in the usual sense).
This commit fixes a bug introduced by c8d23f3.
