### PR TITLE
Expose ssl::init

### DIFF
--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -30,7 +30,9 @@ mod tests;
 
 static mut VERIFY_IDX: c_int = -1;
 
-fn init() {
+/// Manually initialize SSL.
+/// It is optional to call this function and safe to do so more than once.
+pub fn init() {
     static mut INIT: Once = ONCE_INIT;
 
     unsafe {


### PR DESCRIPTION
Allow other crates (e.g. ones that wrap a C library which requires openssl) to easily initialize openssl