### PR TITLE
Add support for DHE for forward secrecy

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -21,6 +21,7 @@ aes_xts = []
 aes_ctr = []
 npn = []
 alpn = []
+rfc5114 = []
 
 [dependencies]
 libc = "0.1"

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -20,6 +20,7 @@ pub type BIO_METHOD = c_void;
 pub type BN_CTX = c_void;
 pub type COMP_METHOD = c_void;
 pub type CRYPTO_EX_DATA = c_void;
+pub type DH = c_void;
 pub type ENGINE = c_void;
 pub type EVP_CIPHER = c_void;
 pub type EVP_CIPHER_CTX = c_void;
@@ -380,6 +381,17 @@ extern "C" {
     pub fn CRYPTO_memcmp(a: *const c_void, b: *const c_void,
                          len: size_t) -> c_int;
 
+    pub fn DH_free(dh: *mut DH);
+
+    #[cfg(feature = "rfc5114")]
+    pub fn DH_get_1024_160() -> *mut DH;
+    #[cfg(feature = "rfc5114")]
+    pub fn DH_get_2048_224() -> *mut DH;
+    #[cfg(feature = "rfc5114")]
+    pub fn DH_get_2048_256() -> *mut DH;
+
+    pub fn DH_new_from_params(p: *mut BIGNUM, g: *mut BIGNUM, q: *mut BIGNUM) -> *mut DH;
+
     pub fn ERR_get_error() -> c_ulong;
 
     pub fn ERR_lib_error_string(err: c_ulong) -> *const c_char;
@@ -664,6 +676,8 @@ extern "C" {
     pub fn SSL_CTX_set_read_ahead(ctx: *mut SSL_CTX, m: c_long) -> c_long;
     #[link_name = "SSL_set_tlsext_host_name_shim"]
     pub fn SSL_set_tlsext_host_name(s: *mut SSL, name: *const c_char) -> c_long;
+    #[link_name = "SSL_CTX_set_tmp_dh_shim"]
+    pub fn SSL_CTX_set_tmp_dh(s: *mut SSL, dh: *const DH) -> c_long;
     #[link_name = "X509_get_extensions_shim"]
     pub fn X509_get_extensions(x: *mut X509) -> *mut stack_st_X509_EXTENSION;
 }

--- a/openssl-sys/src/openssl_shim.c
+++ b/openssl-sys/src/openssl_shim.c
@@ -1,5 +1,7 @@
 #include <openssl/hmac.h>
 #include <openssl/ssl.h>
+#include <openssl/dh.h>
+#include <openssl/bn.h>
 
 #if OPENSSL_VERSION_NUMBER < 0x1000000L
 // Copied from openssl crypto/hmac/hmac.c
@@ -77,6 +79,22 @@ long SSL_CTX_add_extra_chain_cert_shim(SSL_CTX *ctx, X509 *x509) {
 
 long SSL_CTX_set_read_ahead_shim(SSL_CTX *ctx, long m) {
     return SSL_CTX_set_read_ahead(ctx, m);
+}
+
+long SSL_CTX_set_tmp_dh_shim(SSL_CTX *ctx, DH *dh) {
+    return SSL_CTX_set_tmp_dh(ctx, dh);
+}
+
+DH *DH_new_from_params(BIGNUM *p, BIGNUM *g, BIGNUM *q) {
+    DH *dh;
+
+    if ((dh = DH_new()) == NULL) {
+        return NULL;
+    }
+    dh->p = p;
+    dh->g = g;
+    dh->q = q;
+    return dh;
 }
 
 long SSL_set_tlsext_host_name_shim(SSL *s, char *name) {

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -19,6 +19,7 @@ aes_xts = ["openssl-sys/aes_xts"]
 aes_ctr = ["openssl-sys/aes_ctr"]
 npn = ["openssl-sys/npn"]
 alpn = ["openssl-sys/alpn"]
+rfc5114 = ["openssl-sys/rfc5114"]
 
 [dependencies.openssl-sys]
 path = "../openssl-sys"

--- a/openssl/src/bn/mod.rs
+++ b/openssl/src/bn/mod.rs
@@ -397,12 +397,12 @@ impl BigNum {
         (self.num_bits() + 7) / 8
     }
 
-    unsafe fn raw(&self) -> *mut ffi::BIGNUM {
+    pub unsafe fn raw(&self) -> *mut ffi::BIGNUM {
         let BigNum(n) = *self;
         n
     }
 
-    unsafe fn raw_ptr(&self) -> *const *mut ffi::BIGNUM {
+    pub unsafe fn raw_ptr(&self) -> *const *mut ffi::BIGNUM {
         let BigNum(ref n) = *self;
         n
     }

--- a/openssl/src/dh/mod.rs
+++ b/openssl/src/dh/mod.rs
@@ -1,0 +1,97 @@
+use ffi;
+use ssl::error::SslError;
+use bn::BigNum;
+use std::mem;
+use std::ptr;
+
+pub struct DH(*mut ffi::DH);
+
+impl DH {
+    pub fn from_params(p: BigNum, g: BigNum, q: BigNum) -> Result<DH, SslError> {
+        let dh = unsafe { ffi::DH_new_from_params(p.raw(), g.raw(), q.raw()) };
+        if dh == ptr::null_mut() {
+            return Err(SslError::get());
+        }
+        mem::forget(p);
+        mem::forget(g);
+        mem::forget(q);
+        Ok(DH(dh))
+    }
+
+    #[cfg(feature = "rfc5114")]
+    pub fn get_1024_160() -> Result<DH, SslError> {
+        let dh = unsafe { ffi::DH_get_1024_160() };
+        if dh == ptr::null_mut() {
+            return Err(SslError::get());
+        }
+        Ok(DH(dh))
+    }
+
+    #[cfg(feature = "rfc5114")]
+    pub fn get_2048_224() -> Result<DH, SslError> {
+        let dh = unsafe { ffi::DH_get_2048_224() };
+        if dh == ptr::null_mut() {
+            return Err(SslError::get());
+        }
+        Ok(DH(dh))
+    }
+
+    #[cfg(feature = "rfc5114")]
+    pub fn get_2048_256() -> Result<DH, SslError> {
+        let dh = unsafe { ffi::DH_get_2048_256() };
+        if dh == ptr::null_mut() {
+            return Err(SslError::get());
+        }
+        Ok(DH(dh))
+    }
+
+    pub unsafe fn raw(&self) -> *mut ffi::DH {
+        let DH(n) = *self;
+        n
+    }
+
+    pub unsafe fn raw_ptr(&self) -> *const *mut ffi::DH {
+        let DH(ref n) = *self;
+        n
+    }
+}
+
+impl Drop for DH {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.raw().is_null() {
+                ffi::DH_free(self.raw())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DH;
+    use bn::BigNum;
+    use ssl::SslContext;
+    use ssl::SslMethod::Sslv23;
+
+    #[test]
+    #[cfg(feature = "rfc5114")]
+    fn test_dh_rfc5114() {
+        let ctx = SslContext::new(Sslv23).unwrap();
+        let dh1 = DH::get_1024_160().unwrap();
+        ctx.set_tmp_dh(dh1).unwrap();
+        let dh2 = DH::get_2048_224().unwrap();
+        ctx.set_tmp_dh(dh2).unwrap();
+        let dh3 = DH::get_2048_256().unwrap();
+        ctx.set_tmp_dh(dh3).unwrap();
+    }
+
+    #[test]
+    fn test_dh() {
+        let ctx = SslContext::new(Sslv23).unwrap();
+        let p = BigNum::from_hex_str("87A8E61DB4B6663CFFBBD19C651959998CEEF608660DD0F25D2CEED4435E3B00E00DF8F1D61957D4FAF7DF4561B2AA3016C3D91134096FAA3BF4296D830E9A7C209E0C6497517ABD5A8A9D306BCF67ED91F9E6725B4758C022E0B1EF4275BF7B6C5BFC11D45F9088B941F54EB1E59BB8BC39A0BF12307F5C4FDB70C581B23F76B63ACAE1CAA6B7902D52526735488A0EF13C6D9A51BFA4AB3AD8347796524D8EF6A167B5A41825D967E144E5140564251CCACB83E6B486F6B3CA3F7971506026C0B857F689962856DED4010ABD0BE621C3A3960A54E710C375F26375D7014103A4B54330C198AF126116D2276E11715F693877FAD7EF09CADB094AE91E1A1597").unwrap();
+        let g = BigNum::from_hex_str("3FB32C9B73134D0B2E77506660EDBD484CA7B18F21EF205407F4793A1A0BA12510DBC15077BE463FFF4FED4AAC0BB555BE3A6C1B0C6B47B1BC3773BF7E8C6F62901228F8C28CBB18A55AE31341000A650196F931C77A57F2DDF463E5E9EC144B777DE62AAAB8A8628AC376D282D6ED3864E67982428EBC831D14348F6F2F9193B5045AF2767164E1DFC967C1FB3F2E55A4BD1BFFE83B9C80D052B985D182EA0ADB2A3B7313D3FE14C8484B1E052588B9B7D2BBD2DF016199ECD06E1557CD0915B3353BBB64E0EC377FD028370DF92B52C7891428CDC67EB6184B523D1DB246C32F63078490F00EF8D647D148D47954515E2327CFEF98C582664B4C0F6CC41659").unwrap();
+        let q = BigNum::from_hex_str("8CF83642A709A097B447997640129DA299B1A47D1EB3750BA308B0FE64F5FBD3").unwrap();
+        let dh = DH::from_params(p, g, q).unwrap();
+        ctx.set_tmp_dh(dh).unwrap();
+    }
+}

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -20,6 +20,7 @@ pub mod asn1;
 pub mod bn;
 pub mod bio;
 pub mod crypto;
+pub mod dh;
 pub mod ssl;
 pub mod x509;
 pub mod nid;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -21,6 +21,7 @@ use std::slice;
 
 use bio::{MemBio};
 use ffi;
+use dh::DH;
 use ssl::error::{SslError, SslSessionClosed, StreamError, OpenSslErrors};
 use x509::{X509StoreContext, X509FileType, X509};
 use crypto::pkey::PKey;
@@ -490,6 +491,12 @@ impl SslContext {
         unsafe {
             ffi::SSL_CTX_set_read_ahead(self.ctx, m as c_long);
         }
+    }
+
+    pub fn set_tmp_dh(&self, dh: DH) -> Result<(),SslError> {
+        wrap_ssl_result(unsafe {
+            ffi::SSL_CTX_set_tmp_dh(self.ctx, dh.raw()) as i32
+        })
     }
 
     #[allow(non_snake_case)]


### PR DESCRIPTION
Add support for `set_tmp_dh()` and RFC5114 DH parameters for forward secrecy.

rust-openssl didn't support forward secrecy at all.

This adds support for DHE, by exposing set_tmp_dh() as well as the RFC5114 parameters, which are conveniently exposed since OpenSSL 1.0.2.

With OpenSSL >= 1.0.2, and the rfc5114 feature gate, enabling DHE is as simple as (here for 2048-bit MODP group with 256-bit prime order subgroup):

        use openssl::dh::DH;
        let dh = DH::get_2048_256().unwrap();
        ctx.set_tmp_dh(dh).unwrap();

With OpenSSL < 1.0.2, DH::from_params() can be used to manually specify the DH parameters (here for 2048-bit MODP group with 256-bit prime order subgroup):

        use openssl::bn::BigNum;
        use openssl::dh::DH;
        let p = BigNum::from_hex_str("87A8E61DB4B6663CFFBBD19C651959998CEEF608660DD0F25D2CEED4435E3B00E00DF8F1D61957D4FAF7DF4561B2AA3016C3D91134096FAA3BF4296D830E9A7C209E0C6497517ABD5A8A9D306BCF67ED91F9E6725B4758C022E0B1EF4275BF7B6C5BFC11D45F9088B941F54EB1E59BB8BC39A0BF12307F5C4FDB70C581B23F76B63ACAE1CAA6B7902D52526735488A0EF13C6D9A51BFA4AB3AD8347796524D8EF6A167B5A41825D967E144E5140564251CCACB83E6B486F6B3CA3F7971506026C0B857F689962856DED4010ABD0BE621C3A3960A54E710C375F26375D7014103A4B54330C198AF126116D2276E11715F693877FAD7EF09CADB094AE91E1A1597").unwrap();
        let g = BigNum::from_hex_str("3FB32C9B73134D0B2E77506660EDBD484CA7B18F21EF205407F4793A1A0BA12510DBC15077BE463FFF4FED4AAC0BB555BE3A6C1B0C6B47B1BC3773BF7E8C6F62901228F8C28CBB18A55AE31341000A650196F931C77A57F2DDF463E5E9EC144B777DE62AAAB8A8628AC376D282D6ED3864E67982428EBC831D14348F6F2F9193B5045AF2767164E1DFC967C1FB3F2E55A4BD1BFFE83B9C80D052B985D182EA0ADB2A3B7313D3FE14C8484B1E052588B9B7D2BBD2DF016199ECD06E1557CD0915B3353BBB64E0EC377FD028370DF92B52C7891428CDC67EB6184B523D1DB246C32F63078490F00EF8D647D148D47954515E2327CFEF98C582664B4C0F6CC41659").unwrap();
        let q = BigNum::from_hex_str("8CF83642A709A097B447997640129DA299B1A47D1EB3750BA308B0FE64F5FBD3").unwrap();
        let dh = DH::from_params(p, g, q).unwrap();
        ctx.set_tmp_dh(dh).unwrap();