### PR TITLE
Add SSL::set_ecdh_auto()

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -22,6 +22,7 @@ aes_ctr = []
 npn = []
 alpn = []
 rfc5114 = []
+ecdh_auto = []
 
 [dependencies]
 libc = "0.1"

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -675,6 +675,9 @@ extern "C" {
     pub fn SSL_CTX_add_extra_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> c_long;
     #[link_name = "SSL_CTX_set_read_ahead_shim"]
     pub fn SSL_CTX_set_read_ahead(ctx: *mut SSL_CTX, m: c_long) -> c_long;
+    #[cfg(feature = "ecdh_auto")]
+    #[link_name = "SSL_CTX_set_ecdh_auto_shim"]
+    pub fn SSL_CTX_set_ecdh_auto(ssl: *mut SSL_CTX, onoff: c_int) -> c_int;
     #[link_name = "SSL_set_tlsext_host_name_shim"]
     pub fn SSL_set_tlsext_host_name(s: *mut SSL, name: *const c_char) -> c_long;
     #[link_name = "SSL_CTX_set_tmp_dh_shim"]

--- a/openssl-sys/src/openssl_shim.c
+++ b/openssl-sys/src/openssl_shim.c
@@ -85,6 +85,12 @@ long SSL_CTX_set_tmp_dh_shim(SSL_CTX *ctx, DH *dh) {
     return SSL_CTX_set_tmp_dh(ctx, dh);
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x1000200L
+int SSL_CTX_set_ecdh_auto_shim(SSL_CTX *ctx, int onoff) {
+    return SSL_CTX_set_ecdh_auto(ctx, onoff);
+}
+#endif
+
 DH *DH_new_from_params(BIGNUM *p, BIGNUM *g, BIGNUM *q) {
     DH *dh;
 

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -20,6 +20,7 @@ aes_ctr = ["openssl-sys/aes_ctr"]
 npn = ["openssl-sys/npn"]
 alpn = ["openssl-sys/alpn"]
 rfc5114 = ["openssl-sys/rfc5114"]
+ecdh_auto = ["openssl-sys/ecdh_auto"]
 
 [dependencies.openssl-sys]
 path = "../openssl-sys"

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -570,6 +570,14 @@ impl SslContext {
             })
     }
 
+    #[cfg(feature = "ecdh_auto")]
+    pub fn set_ecdh_auto(&mut self, onoff: bool) -> Result<(),SslError> {
+        wrap_ssl_result(
+            unsafe {
+                ffi::SSL_CTX_set_ecdh_auto(self.ctx, onoff as c_int)
+            })
+    }
+
     pub fn set_options(&mut self, option: SslContextOptions) -> SslContextOptions {
         let raw_bits = option.bits();
         let ret = unsafe {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -570,6 +570,10 @@ impl SslContext {
             })
     }
 
+    /// If `onoff` is set to `true`, enable ECDHE for key exchange with compatible
+    /// clients, and automatically select an appropriate elliptic curve.
+    ///
+    /// This method requires OpenSSL >= 1.2.0 or LibreSSL and the `ecdh_auto` feature.
     #[cfg(feature = "ecdh_auto")]
     pub fn set_ecdh_auto(&mut self, onoff: bool) -> Result<(),SslError> {
         wrap_ssl_result(


### PR DESCRIPTION
This sets automatic curve selection and enables ECDH support.
Requires LibreSSL or OpenSSL >= 1.0.2, so behind a feature gate.