### PR TITLE
Swap order of linking ssl/crypto

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -36,12 +36,12 @@ fn main() {
         Some(ref v) => v.split(":").collect(),
         None => if target.contains("windows") {
             if get_mingw_in_path().is_some() && lib_dir.is_none() && include_dir.is_none() {
-                vec!("eay32", "ssleay32")
+                vec!["ssleay32", "eay32"]
             } else {
-                vec!("eay32", "ssl32")
+                vec!["ssl32", "eay32"]
             }
         } else {
-            vec!("crypto", "ssl")
+            vec!["ssl", "crypto"]
         }
     };
 


### PR DESCRIPTION
GNU linkers will sometimes aggressively try to strip objects and archives from a
linker command line in a left-to-right fashion. When a linker hits an object
file that doesn't satisfy any unresolved symbols, it will discard the object and
not re-visit it. This means that currently if symbols are depended upon in
libssl then some of the dependencies of libssl (in libcrypto) may have already
been stripped, causing a link error.

By swapping the order of what's linked it reflects the natural flow of
dependencies and the linker should figure everything out for us.