### PR TITLE
Support for introspection of session cipher

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -31,6 +31,7 @@ pub type RSA = c_void;
 pub type SSL = c_void;
 pub type SSL_CTX = c_void;
 pub type SSL_METHOD = c_void;
+pub type SSL_CIPHER = c_void;
 pub type X509 = c_void;
 pub type X509_CRL = c_void;
 pub type X509_EXTENSION = c_void;
@@ -550,6 +551,12 @@ extern "C" {
     pub fn SSL_get_ssl_method(ssl: *mut SSL) -> *const SSL_METHOD;
     pub fn SSL_state_string(ssl: *mut SSL) -> *const c_char;
     pub fn SSL_state_string_long(ssl: *mut SSL) -> *const c_char;
+
+    pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
+    pub fn SSL_CIPHER_get_bits(c: *const SSL_CIPHER, bits: *mut c_int) -> c_int;
+    pub fn SSL_CIPHER_get_version(c: *const SSL_CIPHER) -> *mut c_char;
+    pub fn SSL_CIPHER_get_name(c: *const SSL_CIPHER) -> *const c_char;
+    pub fn SSL_CIPHER_description(c: *const SSL_CIPHER, buf: *mut c_char, sz: c_int) -> *mut c_char;
 
     pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const c_char;
 

--- a/openssl/src/ssl/tests.rs
+++ b/openssl/src/ssl/tests.rs
@@ -8,6 +8,7 @@ use std::net::TcpListener;
 use std::thread;
 use std::fs::File;
 
+
 use crypto::hash::Type::{SHA256};
 use ssl;
 use ssl::SslMethod;
@@ -47,6 +48,9 @@ macro_rules! run_test(
             use std::io;
             use std::io::prelude::*;
             use std::path::Path;
+            use std::fs::File;
+            use std::env;
+            use std::error::Error;
             use std::net::UdpSocket;
             use std::net::TcpStream;
             use ssl;
@@ -310,6 +314,28 @@ run_test!(clear_ctx_options, |method, _| {
     ctx.set_options(ssl::SSL_OP_ALL);
     let opts = ctx.clear_options(ssl::SSL_OP_ALL);
     assert!(!opts.contains(ssl::SSL_OP_ALL));
+});
+
+run_test!(get_current_cipher, |method, stream| {
+    //let ssl = Ssl::new(&SslContext::new(method).unwrap()).unwrap();
+    let ssl_stream = SslStream::connect_generic(&SslContext::new(method).unwrap(), stream).unwrap();
+    match ssl_stream.get_current_cipher() {
+        Some(cipher) => {
+            let mut path = env::temp_dir();
+            path.push("ciphers.txt");
+
+            let pathinfo = path.display();
+            let mut file = match File::create(&path){
+                Err(why) => panic!("couldn't create{}: {}", pathinfo, Error::description(&why)),
+                Ok(file) => file,
+            };
+            write!(file, "description: {}\n", cipher.description()).unwrap();
+            write!(file, "secret bits: {}\n", cipher.secret_bits()).unwrap();
+            write!(file, "version: {}\n", cipher.version()).unwrap();
+            write!(file, "name: {}\n", cipher.name()).unwrap();
+        },
+        None => panic!("unable to get cipher for current session")
+    }
 });
 
 #[test]


### PR DESCRIPTION
Adds support for the following OpenSSL native functions:

const char *SSL_CIPHER_get_name(const SSL_CIPHER *cipher);
int SSL_CIPHER_get_bits(const SSL_CIPHER *cipher, int *alg_bits);
char *SSL_CIPHER_get_version(const SSL_CIPHER *cipher);
char *SSL_CIPHER_description(const SSL_CIPHER *cipher, char *buf, int size);