### PR TITLE
Check if public/private RSA key is properly loaded

### DIFF
--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -351,10 +351,10 @@ impl PKey {
     pub fn sign_with_hash(&self, s: &[u8], hash: hash::Type) -> Vec<u8> {
         unsafe {
             let rsa = ffi::EVP_PKEY_get1_RSA(self.evp);
-            let len = ffi::RSA_size(rsa);
             if rsa.is_null() {
                 panic!("Could not get RSA key for signing");
             }
+            let len = ffi::RSA_size(rsa);
             let mut r = repeat(0u8).take(len as usize + 1).collect::<Vec<_>>();
 
             let mut len = 0;

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -560,4 +560,36 @@ mod tests {
         assert!(priv_key.windows(11).any(|s| s == b"PRIVATE KEY"));
         assert!(pub_key.windows(10).any(|s| s == b"PUBLIC KEY"));
     }
+
+    #[test]
+    #[should_panic(expected = "Could not get RSA key for encryption")]
+    fn test_nokey_encrypt() {
+        let mut pkey = super::PKey::new();
+        pkey.load_pub(&[]);
+        pkey.encrypt(&[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Could not get RSA key for decryption")]
+    fn test_nokey_decrypt() {
+        let mut pkey = super::PKey::new();
+        pkey.load_priv(&[]);
+        pkey.decrypt(&[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Could not get RSA key for signing")]
+    fn test_nokey_sign() {
+        let mut pkey = super::PKey::new();
+        pkey.load_priv(&[]);
+        pkey.sign(&[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Could not get RSA key for verification")]
+    fn test_nokey_verify() {
+        let mut pkey = super::PKey::new();
+        pkey.load_pub(&[]);
+        pkey.verify(&[], &[]);
+    }
 }


### PR DESCRIPTION
This fixes #43.

The panics do not break any API since they now just prevent a segmentation fault.