### PR TITLE
Update documentation about SSLv23

### DIFF
--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -106,7 +106,8 @@ pub enum SslMethod {
     #[cfg(feature = "sslv2")]
     /// Only support the SSLv2 protocol, requires the `sslv2` feature.
     Sslv2,
-    /// Support the SSLv2, SSLv3 and TLSv1 protocols.
+    /// Support the SSLv2, SSLv3, TLSv1, TLSv1.1, and TLSv1.2 protocols depending on what the
+    /// linked OpenSSL library supports.
     Sslv23,
     /// Only support the SSLv3 protocol.
     Sslv3,


### PR DESCRIPTION
In OpenSSL world, the SSLv23 option is a poorly name method [that will negotiate](http://stackoverflow.com/questions/23709664/openssl-let-the-server-and-client-negotiate-the-method) what version of TLS or SSL to use. It starts with the best version the library supports (which is TLS 1.2 on OpenSSL >= 1.0.1) and then precedes to keep trying all the way down to SSL 2.0.

The docs here were incorrect because they said it only supported SSLv2, SSLv3, and TLSv1.

It is generally recommended that you set additional options to explicitly disable SSL 2.0 and 3.0, but that seems outside the scope of a thin wrapper library.