### PR TITLE
Add an OPENSSL_EXTRA_DYLIBS var to build.rs

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -59,6 +59,12 @@ fn main() {
         println!("cargo:rustc-link-lib={}={}", mode, lib);
     }
 
+    if let Ok(s) = env::var("OPENSSL_EXTRA_DYLIBS") {
+        for lib in s.split(":") {
+            println!("cargo:rustc-link-lib={}", lib);
+        }
+    }
+
     let mut include_dirs = vec![];
 
     if let Some(include_dir) = include_dir {


### PR DESCRIPTION
When linking OpenSSL statically there are often a few libraries which need to be
pulled in which OpenSSL itself depends on. For example on Linux it normally
depends on `libdl` and on Windows it depends on `libgdi32` and/or `libuser32`.
Typically these sort of dependency relations are expressed via a
`[dependencies]` annotation + an `extern crate` directive, but as these aren't
always required it may not always be the best solution in this case.

For now this adds an extra environment variable which adds a location to throw
in these extra dylibs to the build when linking OpenSSL statically.