### PR TITLE
Add set_certificate_chain_file()

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -575,6 +575,7 @@ extern "C" {
     pub fn SSL_CTX_get_ex_data(ctx: *mut SSL_CTX, idx: c_int) -> *mut c_void;
 
     pub fn SSL_CTX_use_certificate_file(ctx: *mut SSL_CTX, cert_file: *const c_char, file_type: c_int) -> c_int;
+    pub fn SSL_CTX_use_certificate_chain_file(ctx: *mut SSL_CTX, cert_chain_file: *const c_char, file_type: c_int) -> c_int;
     pub fn SSL_CTX_use_certificate(ctx: *mut SSL_CTX, cert: *mut X509) -> c_int;
 
     pub fn SSL_CTX_use_PrivateKey_file(ctx: *mut SSL_CTX, key_file: *const c_char, file_type: c_int) -> c_int;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -523,6 +523,16 @@ impl SslContext {
             })
     }
 
+    /// Specifies the file that contains certificate chain
+    pub fn set_certificate_chain_file<P: AsRef<Path>>(&mut self, file: P, file_type: X509FileType)
+                                                -> Result<(),SslError> {
+        let file = CString::new(file.as_ref().as_os_str().to_str().expect("invalid utf8")).unwrap();
+        wrap_ssl_result(
+            unsafe {
+                ffi::SSL_CTX_use_certificate_chain_file(self.ctx, file.as_ptr(), file_type as c_int)
+            })
+    }
+
     /// Specifies the certificate
     pub fn set_certificate(&mut self, cert: &X509) -> Result<(),SslError> {
         wrap_ssl_result(


### PR DESCRIPTION
SSL_CTX_use_certificate_chain_file() is preferred over SSL_CTX_use_certificate_file().

It allows the use of complete certificate chains instead of loading only the first certificate in a PEM file.