### PR TITLE
Add metadata for the include dir of openssl

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -62,6 +62,7 @@ fn main() {
     let mut include_dirs = vec![];
 
     if let Some(include_dir) = include_dir {
+        println!("cargo:include={}", include_dir);
         include_dirs.push(PathBuf::from(&include_dir));
     }
 


### PR DESCRIPTION
If OpenSSL is installed at a nonstandard location dependencies on OpenSSL may
want to know where it was found to be installed at.