### PR TITLE
Expose RSA_generate_key_ex

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -513,6 +513,7 @@ extern "C" {
     pub fn RAND_bytes(buf: *mut u8, num: c_int) -> c_int;
 
     pub fn RSA_generate_key(modsz: c_int, e: c_ulong, cb: *const c_void, cbarg: *const c_void) -> *mut RSA;
+    pub fn RSA_generate_key_ex(rsa: *mut RSA, bits: c_int, e: *mut BIGNUM, cb: *const c_void) -> c_int;
     pub fn RSA_private_decrypt(flen: c_int, from: *const u8, to: *mut u8, k: *mut RSA,
                                pad: c_int) -> c_int;
     pub fn RSA_public_encrypt(flen: c_int, from: *const u8, to: *mut u8, k: *mut RSA,


### PR DESCRIPTION
Exposes the function `RSA_generate_key_ex`, as `RSA_generate_key` is deprecated.

https://www.openssl.org/docs/man1.0.2/crypto/RSA_generate_key_ex.html