### PR TITLE
Explicitly depend on gdi32 and user32 on Windows

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -39,3 +39,15 @@ libressl-pnacl-sys = "2.1.0"
 libressl-pnacl-sys = "2.1.0"
 [target.arm-unknown-nacl.dependencies]
 libressl-pnacl-sys = "2.1.0"
+[target.i686-pc-windows-gnu]
+user32-sys = "*"
+gdi32-sys = "*"
+[target.x86_64-pc-windows-gnu]
+user32-sys = "*"
+gdi32-sys = "*"
+[target.i686-pc-windows-msvc]
+user32-sys = "*"
+gdi32-sys = "*"
+[target.x86_64-pc-windows-msvc]
+user32-sys = "*"
+gdi32-sys = "*"


### PR DESCRIPTION
Since when statically linking openssl, it ends up depending on functions from these system libraries, depend on -sys crates that provide these system libraries. This would prevent the errors [here](https://github.com/sfackler/rust-openssl/issues/293#issuecomment-150899376).