### PR TITLE
Fix a leak when using `EVP_PKEY_get1_RSA`.

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -482,6 +482,7 @@ extern "C" {
 
     pub fn RAND_bytes(buf: *mut u8, num: c_int) -> c_int;
 
+    pub fn RSA_free(rsa: *mut RSA);
     pub fn RSA_generate_key(modsz: c_int, e: c_ulong, cb: *const c_void, cbarg: *const c_void) -> *mut RSA;
     pub fn RSA_generate_key_ex(rsa: *mut RSA, bits: c_int, e: *mut BIGNUM, cb: *const c_void) -> c_int;
     pub fn RSA_private_decrypt(flen: c_int, from: *const u8, to: *mut u8, k: *mut RSA,

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -120,6 +120,7 @@ impl PKey {
             let mut s = repeat(0u8).take(len as usize).collect::<Vec<_>>();
 
             let r = f(rsa, &s.as_mut_ptr());
+            ffi::RSA_free(rsa);
 
             s.truncate(r as usize);
             s


### PR DESCRIPTION
`EVP_PKEY_get1_RSA` returns a RSA structure with its reference count
increased by 1 and therefore we need to call `RSA_free` after finishing
using that value.

- [EVP_PKEY_get1_RSA's source](http://osxr.org/openssl/source/crypto/evp/p_lib.c#0285)
- [Valgrind logs before and after the patch](http://pastebin.com/By0gH22Y)
