### PR TITLE
(maint) Update appveyor link to the OpenSSL download

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
     BITS: 64
 install:
-  - ps: Start-FileDownload "http://slproweb.com/download/Win${env:BITS}OpenSSL-1_0_2d.exe"
-  - Win%BITS%OpenSSL-1_0_2d.exe /SILENT /VERYSILENT /SP- /DIR="C:\OpenSSL"
+  - ps: Start-FileDownload "http://slproweb.com/download/Win${env:BITS}OpenSSL-1_0_2e.exe"
+  - Win%BITS%OpenSSL-1_0_2e.exe /SILENT /VERYSILENT /SP- /DIR="C:\OpenSSL"
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin


### PR DESCRIPTION
This PR updates the link in appveyor to the OpenSSL download to fix
Windows PR testing.