### PR TITLE
Fix regression of c_char type mismatches on ARM

### DIFF
--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -951,7 +951,7 @@ impl Ssl {
             return None;
         }
 
-        unsafe { String::from_utf8(CStr::from_ptr(name).to_bytes().to_vec()).ok() }
+        unsafe { String::from_utf8(CStr::from_ptr(name as *const _).to_bytes().to_vec()).ok() }
     }
 
     /// change the context corresponding to the current connection


### PR DESCRIPTION
The problem with signed/unsigned c_char (issue #314) reappeared in the latest release. This patch fixes it.