### PR TITLE
Mark PKey as `Send` and `Sync`

### DIFF
--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -57,6 +57,9 @@ pub struct PKey {
     parts: Parts,
 }
 
+unsafe impl Send for PKey {}
+unsafe impl Sync for PKey {}
+
 /// Represents a public key, optionally with a private key attached.
 impl PKey {
     pub fn new() -> PKey {


### PR DESCRIPTION
Given that the `locking_function` is always set, it is my understanding that the underlying `ffi::EVP_KEY` type should be safe to use across threads.