### PR TITLE
Add a interface to RSA structs

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -65,9 +65,9 @@ unsafe impl Sync for BIO_METHOD {}
 
 #[repr(C)]
 pub struct RSA {
-    pad: c_int,
-    version: c_long,
-    meth: *const c_void,
+    pub pad: c_int,
+    pub version: c_long,
+    pub meth: *const c_void,
 
     pub engine: *mut c_void,
     pub n: *mut BIGNUM,
@@ -79,17 +79,17 @@ pub struct RSA {
     pub dmq1: *mut BIGNUM,
     pub iqmp: *mut BIGNUM,
 
-    ex_data: *mut c_void,
-    references: c_int,
-    flags: c_int,
+    pub ex_data: *mut c_void,
+    pub references: c_int,
+    pub flags: c_int,
 
-    _method_mod_n: *mut c_void,
-    _method_mod_p: *mut c_void,
-    _method_mod_q: *mut c_void,
+    pub _method_mod_n: *mut c_void,
+    pub _method_mod_p: *mut c_void,
+    pub _method_mod_q: *mut c_void,
 
-    bignum_data: *mut c_char,
-    blinding: *mut c_void,
-    mt_blinding: *mut c_void,
+    pub bignum_data: *mut c_char,
+    pub blinding: *mut c_void,
+    pub mt_blinding: *mut c_void,
 }
 
 #[repr(C)]
@@ -98,10 +98,10 @@ pub struct EVP_PKEY {
     pub save_type: c_int,
     pub references: c_int,
     pub ameth: *const c_void,
-    engine: *mut ENGINE,
+    pub engine: *mut ENGINE,
     pub pkey: *mut c_void,
-    save_parameters: c_int,
-    attributes: *mut c_void,
+    pub save_parameters: c_int,
+    pub attributes: *mut c_void,
 }
 
 #[repr(C)]

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -22,9 +22,7 @@ pub type ENGINE = c_void;
 pub type EVP_CIPHER = c_void;
 pub type EVP_CIPHER_CTX = c_void;
 pub type EVP_MD = c_void;
-pub type EVP_PKEY = c_void;
 pub type EVP_PKEY_CTX = c_void;
-pub type RSA = c_void;
 pub type SSL = c_void;
 pub type SSL_CTX = c_void;
 pub type SSL_METHOD = c_void;
@@ -64,6 +62,47 @@ pub struct BIO_METHOD {
 
 // so we can create static BIO_METHODs
 unsafe impl Sync for BIO_METHOD {}
+
+#[repr(C)]
+pub struct RSA {
+    pad: c_int,
+    version: c_long,
+    meth: *const c_void,
+
+    pub engine: *mut c_void,
+    pub n: *mut BIGNUM,
+    pub e: *mut BIGNUM,
+    pub d: *mut BIGNUM,
+    pub p: *mut BIGNUM,
+    pub q: *mut BIGNUM,
+    pub dmp1: *mut BIGNUM,
+    pub dmq1: *mut BIGNUM,
+    pub iqmp: *mut BIGNUM,
+
+    ex_data: *mut c_void,
+    references: c_int,
+    flags: c_int,
+
+    _method_mod_n: *mut c_void,
+    _method_mod_p: *mut c_void,
+    _method_mod_q: *mut c_void,
+
+    bignum_data: *mut c_char,
+    blinding: *mut c_void,
+    mt_blinding: *mut c_void,
+}
+
+#[repr(C)]
+pub struct EVP_PKEY {
+    pub type_: c_int,
+    pub save_type: c_int,
+    pub references: c_int,
+    pub ameth: *const c_void,
+    engine: *mut ENGINE,
+    pub pkey: *mut c_void,
+    save_parameters: c_int,
+    attributes: *mut c_void,
+}
 
 #[repr(C)]
 pub struct BIO {

--- a/openssl/src/bn/mod.rs
+++ b/openssl/src/bn/mod.rs
@@ -108,7 +108,7 @@ impl BigNum {
         }
         let r = ffi::BN_dup(orig);
         if r.is_null() {
-            panic!("Unexpected null pointer from BN_dup(..)")
+            Err(SslError::get())
         } else {
             Ok(BigNum(r))
         }

--- a/openssl/src/bn/mod.rs
+++ b/openssl/src/bn/mod.rs
@@ -102,6 +102,20 @@ impl BigNum {
         })
     }
 
+    pub fn new_from_ffi(orig: *mut ffi::BIGNUM) -> Result<BigNum, SslError> {
+        if orig.is_null() {
+            panic!("Null Pointer was supplied to BigNum::new_from_ffi");
+        }
+        unsafe {
+            let r = ffi::BN_dup(orig);
+            if r.is_null() {
+                panic!("Unexpected null pointer from BN_dup(..)")
+            } else {
+                Ok(BigNum(r))
+            }
+        }
+    }
+
     pub fn new_from_slice(n: &[u8]) -> Result<BigNum, SslError> {
         BigNum::new().and_then(|v| unsafe {
             try_ssl_null!(ffi::BN_bin2bn(n.as_ptr(), n.len() as c_int, v.raw()));

--- a/openssl/src/bn/mod.rs
+++ b/openssl/src/bn/mod.rs
@@ -102,17 +102,15 @@ impl BigNum {
         })
     }
 
-    pub fn new_from_ffi(orig: *mut ffi::BIGNUM) -> Result<BigNum, SslError> {
+    pub unsafe fn new_from_ffi(orig: *mut ffi::BIGNUM) -> Result<BigNum, SslError> {
         if orig.is_null() {
             panic!("Null Pointer was supplied to BigNum::new_from_ffi");
         }
-        unsafe {
-            let r = ffi::BN_dup(orig);
-            if r.is_null() {
-                panic!("Unexpected null pointer from BN_dup(..)")
-            } else {
-                Ok(BigNum(r))
-            }
+        let r = ffi::BN_dup(orig);
+        if r.is_null() {
+            panic!("Unexpected null pointer from BN_dup(..)")
+        } else {
+            Ok(BigNum(r))
         }
     }
 

--- a/openssl/src/crypto/mod.rs
+++ b/openssl/src/crypto/mod.rs
@@ -21,5 +21,6 @@ pub mod pkey;
 pub mod rand;
 pub mod symm;
 pub mod memcmp;
+pub mod rsa;
 
 mod symm_internal;

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -93,7 +93,7 @@ impl PKey {
                                                                  None,
                                                                  ptr::null_mut()));
             Ok(PKey {
-                evp: evp,
+                evp: evp as *mut ffi::EVP_PKEY,
                 parts: Parts::Both,
             })
         }
@@ -112,7 +112,7 @@ impl PKey {
                                                              None,
                                                              ptr::null_mut()));
             Ok(PKey {
-                evp: evp,
+                evp: evp as *mut ffi::EVP_PKEY,
                 parts: Parts::Public,
             })
         }

--- a/openssl/src/crypto/rsa.rs
+++ b/openssl/src/crypto/rsa.rs
@@ -1,0 +1,39 @@
+use ffi;
+use bn::BigNum;
+use std::fmt;
+
+pub struct RSA {
+    pub rsa_obj : ffi::RSA
+}
+
+impl RSA {
+    pub unsafe fn get_n(&self) -> BigNum {
+        BigNum::new_from_ffi(self.rsa_obj.n).unwrap()
+    }
+
+    pub unsafe fn get_d(&self) -> BigNum {
+        BigNum::new_from_ffi(self.rsa_obj.d).unwrap()
+    }
+
+    pub unsafe fn get_e(&self) -> BigNum {
+        BigNum::new_from_ffi(self.rsa_obj.e).unwrap()
+    }
+
+    pub unsafe fn get_p(&self) -> BigNum {
+        BigNum::new_from_ffi(self.rsa_obj.p).unwrap()
+    }
+
+    pub unsafe fn get_q(&self) -> BigNum {
+        BigNum::new_from_ffi(self.rsa_obj.q).unwrap()
+    }
+
+    pub fn get_type(&self) -> &str {
+        "rsa"
+    }
+}
+
+impl fmt::Debug for RSA {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Currently no debug output. Sorry :(")
+    }
+}

--- a/openssl/src/crypto/rsa.rs
+++ b/openssl/src/crypto/rsa.rs
@@ -41,6 +41,6 @@ impl RSA {
 
 impl fmt::Debug for RSA {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Currently no debug output. Sorry :(")
+        write!(f, "RSA")
     }
 }

--- a/openssl/src/crypto/rsa.rs
+++ b/openssl/src/crypto/rsa.rs
@@ -3,32 +3,28 @@ use bn::BigNum;
 use std::fmt;
 
 pub struct RSA {
-    pub rsa_obj : ffi::RSA
+    rsa_obj : ffi::RSA
 }
 
 impl RSA {
-    pub unsafe fn get_n(&self) -> BigNum {
+    pub unsafe fn n(&self) -> BigNum {
         BigNum::new_from_ffi(self.rsa_obj.n).unwrap()
     }
 
-    pub unsafe fn get_d(&self) -> BigNum {
+    pub unsafe fn d(&self) -> BigNum {
         BigNum::new_from_ffi(self.rsa_obj.d).unwrap()
     }
 
-    pub unsafe fn get_e(&self) -> BigNum {
+    pub unsafe fn e(&self) -> BigNum {
         BigNum::new_from_ffi(self.rsa_obj.e).unwrap()
     }
 
-    pub unsafe fn get_p(&self) -> BigNum {
+    pub unsafe fn p(&self) -> BigNum {
         BigNum::new_from_ffi(self.rsa_obj.p).unwrap()
     }
 
-    pub unsafe fn get_q(&self) -> BigNum {
+    pub unsafe fn q(&self) -> BigNum {
         BigNum::new_from_ffi(self.rsa_obj.q).unwrap()
-    }
-
-    pub fn get_type(&self) -> &str {
-        "rsa"
     }
 }
 

--- a/openssl/src/crypto/rsa.rs
+++ b/openssl/src/crypto/rsa.rs
@@ -7,24 +7,35 @@ pub struct RSA {
 }
 
 impl RSA {
-    pub unsafe fn n(&self) -> BigNum {
-        BigNum::new_from_ffi(self.rsa_obj.n).unwrap()
+    // The following getters are unsafe, since BigNum::new_from_ffi fails upon null pointers
+    pub fn n(&self) -> BigNum {
+        unsafe {
+            BigNum::new_from_ffi(self.rsa_obj.n).unwrap()
+        }
     }
 
-    pub unsafe fn d(&self) -> BigNum {
-        BigNum::new_from_ffi(self.rsa_obj.d).unwrap()
+    pub fn d(&self) -> BigNum {
+        unsafe {
+            BigNum::new_from_ffi(self.rsa_obj.d).unwrap()
+        }
     }
 
-    pub unsafe fn e(&self) -> BigNum {
-        BigNum::new_from_ffi(self.rsa_obj.e).unwrap()
+    pub fn e(&self) -> BigNum {
+        unsafe {
+            BigNum::new_from_ffi(self.rsa_obj.e).unwrap()
+        }
     }
 
-    pub unsafe fn p(&self) -> BigNum {
-        BigNum::new_from_ffi(self.rsa_obj.p).unwrap()
+    pub fn p(&self) -> BigNum {
+        unsafe {
+            BigNum::new_from_ffi(self.rsa_obj.p).unwrap()
+        }
     }
 
-    pub unsafe fn q(&self) -> BigNum {
-        BigNum::new_from_ffi(self.rsa_obj.q).unwrap()
+    pub fn q(&self) -> BigNum {
+        unsafe {
+            BigNum::new_from_ffi(self.rsa_obj.q).unwrap()
+        }
     }
 }
 


### PR DESCRIPTION
This is my take at making the PKey / RSA struct available in the binding and making the BigNums of keys accessible.
This will be used in a crate to support JWK (JSON Web Keys).

It is currently used by casting the pointer returned by `PKey::get_handle`:

```rust
let gen = X509Generator::new();

let (cert, pkey) = gen.generate().unwrap();

unsafe {
    let evppkey = pkey.get_handle();
    let rsa = (*evppkey).pkey as *mut RSA;
    let n : BigNum = (*rsa).get_n();
    println!("n == {:?}", n);
}
```

I would also like to hide the `BigNum::new_from_ffi` function, because it does not need to be exported publicly.