### PR TITLE
Remove raw_pointer_derive lint

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -48,7 +48,6 @@ pub type bio_info_cb = Option<unsafe extern "C" fn(*mut BIO,
 
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[allow(raw_pointer_derive)]
 pub struct BIO_METHOD {
     pub type_: c_int,
     pub name: *const c_char,


### PR DESCRIPTION
This lint was removed in Rust 1.6 and now emits a warning:

```
openssl-sys-0.7.4/src/lib.rs:51:9: 51:27 warning: lint raw_pointer_derive has been removed: using derive with raw pointers is ok
openssl-sys-0.7.4/src/lib.rs:51 #[allow(raw_pointer_derive)]
                                        ^~~~~~~~~~~~~~~~~~
```