### PR TITLE
Local Certificate & PKey accessors for SslContext

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -677,6 +677,9 @@ extern "C" {
 
     pub fn SSL_CTX_set_cipher_list(ssl: *mut SSL_CTX, s: *const c_char) -> c_int;
 
+    pub fn SSL_CTX_get0_certificate(ctx: *mut SSL_CTX) -> *mut X509;
+    pub fn SSL_CTX_get0_privatekey(ctx: *mut SSL_CTX) -> *mut EVP_PKEY;
+
     #[cfg(feature = "npn")]
     pub fn SSL_CTX_set_next_protos_advertised_cb(ssl: *mut SSL_CTX,
                                                  cb: extern "C" fn(ssl: *mut SSL,

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -642,6 +642,7 @@ extern "C" {
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
     pub fn SSL_get_peer_certificate(ssl: *mut SSL) -> *mut X509;
     pub fn SSL_get_certificate(ssl: *mut SSL) -> *mut X509;
+    pub fn SSL_get_privatekey(ssl: *mut SSL) -> *mut EVP_PKEY;
     pub fn SSL_get_ssl_method(ssl: *mut SSL) -> *const SSL_METHOD;
     pub fn SSL_state_string(ssl: *mut SSL) -> *const c_char;
     pub fn SSL_state_string_long(ssl: *mut SSL) -> *const c_char;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -641,6 +641,7 @@ extern "C" {
     pub fn SSL_set_SSL_CTX(ssl: *mut SSL, ctx: *mut SSL_CTX) -> *mut SSL_CTX;
     pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
     pub fn SSL_get_peer_certificate(ssl: *mut SSL) -> *mut X509;
+    pub fn SSL_get_certificate(ssl: *mut SSL) -> *mut X509;
     pub fn SSL_get_ssl_method(ssl: *mut SSL) -> *const SSL_METHOD;
     pub fn SSL_state_string(ssl: *mut SSL) -> *const c_char;
     pub fn SSL_state_string_long(ssl: *mut SSL) -> *const c_char;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -893,7 +893,7 @@ impl Ssl {
     }
 
     /// Returns the certificate of the peer, if present.
-    pub fn peer_certificate(&self) -> Option<X509> {
+    pub fn peer_certificate(&self) -> Option<X509<'static>> {
         unsafe {
             let ptr = ffi::SSL_get_peer_certificate(self.ssl);
             if ptr.is_null() {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -29,6 +29,7 @@ use dh::DH;
 use ssl::error::{NonblockingSslError, SslError, OpenSslError, OpensslError};
 use x509::{X509StoreContext, X509FileType, X509};
 use crypto::pkey::PKey;
+use crypto::pkey::Parts;
 
 pub mod error;
 mod bio;
@@ -889,6 +890,18 @@ impl Ssl {
                 None
             } else {
                 Some(X509::from_ref(ptr))
+            }
+        }
+    }
+
+    /// Return our local private key, if present.
+    pub fn private_key(&self) -> Option<PKey> {
+        unsafe {
+            let ptr = ffi::SSL_get_privatekey(self.ssl);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(PKey::from_ref(ptr, Parts::Both))
             }
         }
     }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -881,6 +881,18 @@ impl Ssl {
         }
     }
 
+    /// Return our local certificate, if present.
+    pub fn certificate(&self) -> Option<X509<'static>> {
+        unsafe {
+            let ptr = ffi::SSL_get_certificate(self.ssl);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(X509::from_ref(ptr))
+            }
+        }
+    }
+
     /// Returns the protocol selected by performing Next Protocol Negotiation, if any.
     ///
     /// The protocol's name is returned is an opaque sequence of bytes. It is up to the client

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -687,6 +687,28 @@ impl SslContext {
         })
     }
 
+    pub fn private_key(&self) -> Option<PKey> {
+        unsafe {
+            let ptr = ffi::SSL_CTX_get0_privatekey(self.ctx);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(PKey::from_ref(ptr, Parts::Both))
+            }
+        }
+    }
+
+    pub fn certificate(&self) -> Option<X509<'static>> {
+        unsafe {
+            let ptr = ffi::SSL_CTX_get0_certificate(self.ctx);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(X509::from_ref(ptr))
+            }
+        }
+    }
+
     /// If `onoff` is set to `true`, enable ECDHE for key exchange with compatible
     /// clients, and automatically select an appropriate elliptic curve.
     ///

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -415,6 +415,19 @@ pub struct X509<'ctx> {
 }
 
 impl<'ctx> X509<'ctx> {
+    /// Create new from a handle, and incriment the internal X509 refounting appropriately.
+    ///
+    /// Generally used to transform returned `*mut ffi::X509`'s from ffi functions that don't
+    /// incriment refcount into static X509 handles.
+    pub fn from_ref(handle: *mut ffi::X509) -> X509<'ctx> {
+        assert!(!handle.is_null());
+        unsafe { rust_X509_clone(handle) }
+        /* FIXME: given that we now have refcounting control, 'owned' should be uneeded, the 'ctx
+         * is probably also uneeded. We can remove both to condense the x509 api quite a bit
+         */
+        X509::new(handle, true)
+    }
+
     /// Creates new from handle with desired ownership.
     pub fn new(handle: *mut ffi::X509, owned: bool) -> X509<'ctx> {
         X509 {
@@ -513,11 +526,7 @@ extern "C" {
 
 impl<'ctx> Clone for X509<'ctx> {
     fn clone(&self) -> X509<'ctx> {
-        unsafe { rust_X509_clone(self.handle) }
-        /* FIXME: given that we now have refcounting control, 'owned' should be uneeded, the 'ctx
-         * is probably also uneeded. We can remove both to condense the x509 api quite a bit
-         */
-        X509::new(self.handle, true)
+        X509::from_ref(self.handle)
     }
 }
 


### PR DESCRIPTION
Allow retrieval of the local private key and local certificate from an SslContext. This uses reference counting machinery added previously for `.clone()`.

Also adjust the existing `peer_certificate()`'s lifetime (extend to 'static) to avoid strange lifetime inference issue. I'm pretty sure this should be a non-breaking change (because the lifetime is just being expanded).
