### PR TITLE
x509: allow setting & getting validity times to use time::Tm and std::time::Duration

### DIFF
--- a/openssl-sys-extras/src/lib.rs
+++ b/openssl-sys-extras/src/lib.rs
@@ -5,7 +5,7 @@ extern crate openssl_sys;
 extern crate libc;
 
 use libc::{c_int, c_uint, c_long, c_char, c_void};
-use openssl_sys::{HMAC_CTX, EVP_MD, ENGINE, SSL_CTX, BIO, X509, stack_st_X509_EXTENSION, SSL, DH};
+use openssl_sys::{HMAC_CTX, EVP_MD, ENGINE, SSL_CTX, BIO, X509, stack_st_X509_EXTENSION, SSL, DH, ASN1_TIME};
 
 macro_rules! import_options {
     ( $( $name:ident $val:expr  )* ) => {
@@ -77,4 +77,9 @@ extern {
     pub fn SSL_CTX_set_tlsext_servername_callback(ssl: *mut SSL_CTX, callback: Option<extern fn()>);
     #[link_name = "SSL_CTX_set_tlsext_servername_arg_shim"]
     pub fn SSL_CTX_set_tlsext_servername_arg(ssl: *mut SSL_CTX, arg: *const c_void);
+
+    #[link_name = "X509_get_notBefore_shim"]
+    pub fn X509_get_notBefore(x: *mut X509) -> *mut ASN1_TIME;
+    #[link_name = "X509_get_notAfter_shim"]
+    pub fn X509_get_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }

--- a/openssl-sys-extras/src/openssl_shim.c
+++ b/openssl-sys-extras/src/openssl_shim.c
@@ -2,6 +2,7 @@
 #include <openssl/ssl.h>
 #include <openssl/dh.h>
 #include <openssl/bn.h>
+#include <openssl/x509.h>
 
 #if defined(__APPLE__) || defined(__linux)
 
@@ -163,4 +164,12 @@ long SSL_set_tlsext_host_name_shim(SSL *s, char *name) {
 
 STACK_OF(X509_EXTENSION) *X509_get_extensions_shim(X509 *x) {
     return x->cert_info ? x->cert_info->extensions : NULL;
+}
+
+ASN1_TIME *X509_get_notBefore_shim(X509 *x) {
+    return X509_get_notBefore(x);
+}
+
+ASN1_TIME *X509_get_notAfter_shim(X509 *x) {
+    return X509_get_notAfter(x);
 }

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -7,14 +7,12 @@ extern crate libc;
 #[cfg(target_os = "nacl")]
 extern crate libressl_pnacl_sys;
 
-use libc::{c_void, c_int, c_char, c_ulong, c_long, c_uint, c_uchar, size_t};
+use libc::{c_void, c_int, c_char, c_ulong, c_long, c_uint, c_uchar, size_t, time_t};
 use std::mem;
 use std::sync::{Mutex, MutexGuard};
 use std::sync::{Once, ONCE_INIT};
 
 pub type ASN1_INTEGER = c_void;
-pub type ASN1_STRING = c_void;
-pub type ASN1_TIME = c_void;
 pub type BN_CTX = c_void;
 pub type COMP_METHOD = c_void;
 pub type DH = c_void;
@@ -195,6 +193,16 @@ impl Copy for BIGNUM {}
 impl Clone for BIGNUM {
     fn clone(&self) -> BIGNUM { *self }
 }
+
+#[repr(C)]
+pub struct ASN1_STRING {
+    pub length: c_int,
+    pub typ: c_int,
+    pub data: *mut c_uchar,
+    pub flags: c_long
+}
+
+pub type ASN1_TIME = ASN1_STRING;
 
 pub type CRYPTO_EX_new = extern "C" fn(parent: *mut c_void, ptr: *mut c_void,
                                        ad: *const CRYPTO_EX_DATA, idx: c_int,
@@ -382,6 +390,8 @@ fn set_id_callback() {}
 extern "C" {
     pub fn ASN1_INTEGER_set(dest: *mut ASN1_INTEGER, value: c_long) -> c_int;
     pub fn ASN1_STRING_type_new(ty: c_int) -> *mut ASN1_STRING;
+    pub fn ASN1_TIME_set(tm: *mut ASN1_TIME, t: time_t) -> *mut ASN1_TIME;
+    pub fn ASN1_TIME_set_string(tm: *mut ASN1_TIME, t:  *const c_char) -> c_int;
     pub fn ASN1_TIME_free(tm: *mut ASN1_TIME);
 
     pub fn BIO_ctrl(b: *mut BIO, cmd: c_int, larg: c_long, parg: *mut c_void) -> c_long;

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -34,6 +34,7 @@ lazy_static = "0.1"
 libc = "0.2"
 openssl-sys = { version = "0.7.5", path = "../openssl-sys" }
 openssl-sys-extras = { version = "0.7.5", path = "../openssl-sys-extras" }
+time = "0.1"
 
 [build-dependencies]
 gcc = "0.3"

--- a/openssl/src/asn1/mod.rs
+++ b/openssl/src/asn1/mod.rs
@@ -1,9 +1,14 @@
-use libc::c_long;
+use libc::{c_long, time_t, c_char};
 use std::ptr;
 
+use time;
 use ffi;
 use ssl::error::SslError;
+use std::ffi::CString;
+use std::slice;
 
+#[cfg(test)]
+mod tests;
 
 pub struct Asn1Time {
     handle: *mut ffi::ASN1_TIME,
@@ -17,6 +22,33 @@ impl Asn1Time {
             handle: handle,
             owned: true,
         }
+    }
+
+    /// Create a new Asn1Time from a given time_t.
+    fn from_time_t(t: time_t) -> Asn1Time {
+        let v = unsafe { ffi::ASN1_TIME_set(ptr::null_mut(), t) };
+        /* failures here are only due to allocation issues, so panicing is appropriate */
+        assert!(!v.is_null());
+
+        Asn1Time {
+            handle: v,
+            owned: true,
+        }
+    }
+
+    /// Create a new Asn1Time from an absolute timespec
+    pub fn from_tm(t: time::Tm) -> Result<Asn1Time, SslError> {
+        let t = tm_to_asn1_string(t);
+        let v = Asn1Time::from_time_t(0);
+        try_ssl!(unsafe {
+            ffi::ASN1_TIME_set_string(
+                v.get_handle(),
+                /* unwraping is OK because we know tm_to_asn1_string() does not generate embedded
+                 * nulls */
+                CString::new(t).unwrap().as_ptr() as *const c_char
+            )
+        });
+        Ok(v)
     }
 
     fn new_with_period(period: u64) -> Result<Asn1Time, SslError> {
@@ -37,6 +69,31 @@ impl Asn1Time {
     pub unsafe fn get_handle(&self) -> *mut ffi::ASN1_TIME {
         return self.handle;
     }
+
+    pub fn as_bytes<'a>(&'a self) -> &'a [u8] {
+        unsafe {
+            let v : &ffi::ASN1_TIME = &*(self.handle);
+            slice::from_raw_parts(v.data, v.length as usize)
+        }
+    }
+
+    pub fn as_tm(&self) -> Result<time::Tm, String> {
+        let typ = unsafe {
+            let v: &ffi::ASN1_TIME = &*(self.handle);
+            v.typ
+        };
+        match typ {
+            ffi::V_ASN1_GENERALIZEDTIME => {
+                asn1_string_to_tm(self.as_bytes(), 4)
+            },
+            ffi::V_ASN1_UTCTIME => {
+                asn1_string_to_tm(self.as_bytes(), 2)
+            },
+            _ => {
+                Err(format!("Unknown type {}", typ))
+            }
+        }
+    }
 }
 
 impl Drop for Asn1Time {
@@ -45,4 +102,144 @@ impl Drop for Asn1Time {
             unsafe { ffi::ASN1_TIME_free(self.handle) };
         }
     }
+}
+
+/// Given a timespec, generate an ASN.1 string suitible for passing to openssl.
+///
+/// Note that this does lose the seconds offset from the timezone, but note that most (all?)
+/// timezone's lack a seconds offset in any case.
+pub fn tm_to_asn1_string(t: time::Tm) -> String
+{
+    let tz_hours = t.tm_utcoff / 60 / 60;
+    let tz_min = (t.tm_utcoff).abs() / 60 % 60;
+    /* Note that strftime is undesirable as it lacks support for nanoseconds */
+    /* YYYYMMDDHHMMSS.nsZ */
+    /*       YYYY MM   DD   HH   MM   SS   .ns   Z */
+    format!("{:04}{:02}{:02}{:02}{:02}{:02}.{:09}{:+03}{:02}",
+            t.tm_year + 1900,
+            t.tm_mon + 1,
+            t.tm_mday,
+            t.tm_hour,
+            t.tm_min,
+            t.tm_sec,
+            t.tm_nsec,
+            tz_hours,
+            tz_min)
+}
+
+fn parse_n_digit<I>(b: &mut I, ct: usize, name: &str) -> Result<i32, String>
+    where I: Iterator<Item = u8>
+{
+    let mut res: u32 = 0;
+
+    for i in 0..ct {
+        res *= 10;
+        let c = try!(b.next().ok_or(format!("Digit {} out of {} in {} not found", i, ct, name))) as char;
+        res += try!(c.to_digit(10).ok_or(format!("Digit {} out of {} in {} is not convertable: {}",
+                                                 i, ct, name, c)));
+    }
+
+    Ok(res as i32)
+}
+
+/// Read digits until we get a non-digit character, then correct the value to be as if we parsed
+/// @n values.
+///
+/// If digits exist after @ct, eat them without changing result
+fn parse_decimal<I>(b: &mut I, ct: usize) -> Result<(i32, u8), String>
+    where I: Iterator<Item = u8>
+{
+    let mut res: u32 = 0;
+    for i in 0..ct {
+        let v = try!(b.next().ok_or(format!("Digit or character {} in decimal not found", i)));
+        let c = v as char;
+        if c.is_numeric() {
+            res *= 10;
+            res += try!(c.to_digit(10).ok_or(format!("Digit {} out of {} in decimal is not convertable: {}",
+                                                     i, ct, c)));
+        } else {
+            res *= 10u32.pow((ct - i) as u32);
+            return Ok((res as i32, v))
+        }
+    }
+
+    /* We've got all the data we need, but there might be digits left */
+    loop {
+        let v = try!(b.next().ok_or(format!("Digit or character trailing decimal not found")));
+        if !(v as char).is_numeric() {
+            return Ok((res as i32, v))
+        }
+    }
+}
+
+/// Given an ASN.1 formated time, generate a timespec
+///
+/// If @short_year is true, assumes the year is 2 digits and applies a heuristic to guess the real
+/// year.
+///
+/// Note that the returned Tm does not fill out tm_wday, tm_yday, or tm_isdst (they are -1, 0, and
+/// 0 respectively), so users of the result should be cautious that they don't rely on those
+/// fields.
+pub fn asn1_string_to_tm(s: &[u8], year_len: usize) -> Result<time::Tm, String>
+{
+    let mut b = s.iter().cloned();
+
+    let mut y = try!(parse_n_digit(&mut b, year_len, "year"));
+    let year = if year_len < 4 {
+        if y < 70 {
+            y += 100;
+        }
+        y
+    } else {
+        y - 1900
+    };
+
+    let month = try!(parse_n_digit(&mut b, 2, "month"));
+    let day = try!(parse_n_digit(&mut b, 2, "day"));
+    let hour = try!(parse_n_digit(&mut b, 2, "hour"));
+    let minute = try!(parse_n_digit(&mut b, 2, "minute"));
+    let second = try!(parse_n_digit(&mut b, 2, "second"));
+
+    let c = try!(b.next().ok_or("Character after seconds missing"));
+    let (nano, c) = if (c as char) == '.' {
+        /* parse nano seconds */
+        try!(parse_decimal(&mut b, 9))
+    } else {
+        (0, c)
+    };
+
+    /* use the extra char 'c' and the reset of iterator to get the timezone */
+    let tz_sec = match c as char {
+        'Z' => {
+            0
+        },
+        '+' | '-' => {
+            let tz_hours = try!(parse_n_digit(&mut b, 2, "tz hours"));
+            let tz_min = try!(parse_n_digit(&mut b, 2, "tz minutes"));
+            let neg = if c as char == '+' {
+                1
+            } else {
+                -1
+            };
+            neg * ((tz_hours * 60) + tz_min) * 60
+        },
+        _ => {
+            return Err(format!("Unexpected character {} in timezone", c));
+        }
+    };
+
+    Ok(time::Tm {
+        tm_sec: second,
+        tm_min: minute,
+        tm_hour: hour,
+        tm_mday: day,
+        tm_mon: month - 1,
+        tm_year: year,
+        tm_nsec: nano,
+        tm_utcoff: tz_sec,
+
+        tm_isdst: -1,
+        tm_wday: 0,
+        tm_yday: 0,
+    })
 }

--- a/openssl/src/asn1/tests/mod.rs
+++ b/openssl/src/asn1/tests/mod.rs
@@ -1,0 +1,183 @@
+use time;
+
+fn check_convert(s: &str, t: time::Tm, ylen: usize)
+{
+    use super::{asn1_string_to_tm,tm_to_asn1_string};
+
+    let g_t = asn1_string_to_tm(s.as_bytes(), ylen).expect("asn1 time decode failed");
+    assert_eq!(g_t, t);
+
+    let g_s = tm_to_asn1_string(t);
+
+    println!("> {} ", g_s);
+
+    assert_eq!(asn1_string_to_tm(g_s.as_bytes(), 4).expect("generate asn1 time decode failed"), t);
+}
+
+#[test]
+fn asn1_time_str_convert() {
+    //       YYYYMMddHHmmSSZ
+    let s = "21340103020508Z";
+    let t = time::Tm {
+        tm_sec: 8,
+        tm_min: 5,
+        tm_hour: 2,
+        tm_mday: 3,
+        tm_mon: 0,
+        tm_year: 2134 - 1900,
+
+        tm_nsec: 0,
+        tm_utcoff: 0,
+
+        tm_isdst: -1,
+        tm_wday: 0,
+        tm_yday: 0
+    };
+
+    check_convert(s, t, 4);
+
+    //             YYMMddHHmmSS+HHmm
+    check_convert("990102030405+0706", time::Tm {
+        tm_sec:5,
+        tm_min:4,
+        tm_hour: 3,
+        tm_mday: 2,
+        tm_mon: 0,
+        tm_year: 1999 - 1900,
+
+        tm_nsec: 0,
+        tm_utcoff: ((7 * 60) + 6) * 60,
+
+        tm_isdst: -1,
+        tm_wday: 0,
+        tm_yday: 0
+    }, 2);
+
+    //             YYYYMMddHHmmSS.ns-HHmm
+    check_convert("19891131535455.23452-1011", time::Tm {
+        tm_sec: 55,
+        tm_min: 54,
+        tm_hour: 53,
+        tm_mday: 31,
+        tm_mon: 10,
+        tm_year: 1989 - 1900,
+
+        //       123456789
+        tm_nsec: 234520000,
+
+        tm_utcoff: -((10 * 60) + 11) * 60,
+
+        tm_isdst: -1,
+        tm_wday: 0,
+        tm_yday: 0
+    }, 4);
+
+    //             YYYYMMddHHmmSS.ns-HHmm
+    check_convert("19891131535455.1234567898-1011", time::Tm {
+        tm_sec: 55,
+        tm_min: 54,
+        tm_hour: 53,
+        tm_mday: 31,
+        tm_mon: 10,
+        tm_year: 1989 - 1900,
+
+        tm_nsec: 123456789,
+
+        tm_utcoff: -((10 * 60) + 11) * 60,
+
+        tm_isdst: -1,
+        tm_wday: 0,
+        tm_yday: 0
+    }, 4);
+
+    //             YYYYMMddHHmmSS.ns-HHmm
+    check_convert("19891131535455.123456789-1011", time::Tm {
+        tm_sec: 55,
+        tm_min: 54,
+        tm_hour: 53,
+        tm_mday: 31,
+        tm_mon: 10,
+        tm_year: 1989 - 1900,
+
+        tm_nsec: 123456789,
+
+        tm_utcoff: -((10 * 60) + 11) * 60,
+
+        tm_isdst: -1,
+        tm_wday: 0,
+        tm_yday: 0
+    }, 4);
+}
+
+fn asn1_time_roundtrip(t: time::Tm) {
+    use super::Asn1Time;
+    use super::tm_to_asn1_string;
+    println!("> {} ", tm_to_asn1_string(t));
+    assert_eq!(Asn1Time::from_tm(t).expect("could not create Asn1Time from Tm")
+               .as_tm().expect("could not get Tm from Asn1Time"), t);
+}
+
+#[test]
+fn asn1_time_tm() {
+    /* check that we can round trip a Tm through Asn1Time */
+
+    asn1_time_roundtrip(time::Tm {
+        tm_sec: 55,
+        tm_min: 54,
+        tm_hour: 23,
+        tm_mday: 31,
+        tm_mon: 11,
+        tm_year: 1989 - 1900,
+
+        tm_nsec: 123456789,
+
+        tm_utcoff: -((10 * 60) + 11) * 60,
+
+        tm_isdst: -1,
+        tm_wday: 0,
+        tm_yday: 0
+    });
+
+    asn1_time_roundtrip(time::Tm {
+        tm_sec: 0,
+        tm_min: 0,
+        tm_hour: 23,
+        tm_mday: 31,
+        tm_mon: 11,
+        tm_year: 1950 - 1900,
+
+        tm_nsec: 1239,
+
+        tm_utcoff: 0,
+
+        tm_isdst: -1,
+        tm_wday: 0,
+        tm_yday: 0
+    });
+
+    asn1_time_roundtrip(time::Tm {
+        tm_sec: 0,
+        tm_min: 0,
+        tm_hour: 23,
+        tm_mday: 31,
+        tm_mon: 11,
+        tm_year: 2040 - 1900,
+
+        tm_nsec: 0,
+
+        tm_utcoff: 0,
+
+        tm_isdst: -1,
+        tm_wday: 0,
+        tm_yday: 0
+    });
+}
+
+#[test]
+fn asn1time_new() {
+    use super::Asn1Time;
+    let _ = Asn1Time::from_tm(time::Tm {
+        tm_sec: 17, tm_min: 22, tm_hour: 15, tm_mday: 26, tm_mon: 0, tm_year: 116, tm_wday: 2,
+        tm_yday: 25, tm_isdst: 0, tm_utcoff: 0, tm_nsec: 94275379
+    }).expect("could not create asn1time");
+}

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -8,6 +8,7 @@ extern crate libc;
 extern crate lazy_static;
 extern crate openssl_sys as ffi;
 extern crate openssl_sys_extras as ffi_extras;
+extern crate time;
 
 #[cfg(test)]
 extern crate rustc_serialize as serialize;

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -16,6 +16,7 @@ extern crate rustc_serialize as serialize;
 #[cfg(test)]
 extern crate net2;
 
+
 mod macros;
 
 pub mod asn1;


### PR DESCRIPTION
To support this, `Asn1Time` grows the ability to be constructed from a `time::Tm` and converted to a `time::Tm`.

Additionally, a few extra methods were added to `X509Generator` and the way it tracks validity prior to cert signing was adjusted.

For the `Asn1Time` <=> `time::Tm` conversion, I had to add a parser for ASN.1 formatted times.
I don't really like this, but the API the openssl exposes doesn't appear provide another way to do this (without precision & 32bit hazards via `time_t`).

Note that I am mixing `time::Tm` and `std::time::Duration` here. Ideally I'd use all `std` data-structures, but there isn't anything comparable to `time::Tm` (yet, anyhow) so I've stuck with using `std` where possible but falling back to the `time` crate.

