### PR TITLE
Revert "impl Clone for PKey and X509 by using their 'references' member"

### DIFF
--- a/openssl/src/c_helpers.c
+++ b/openssl/src/c_helpers.c
@@ -7,11 +7,3 @@ void rust_SSL_clone(SSL *ssl) {
 void rust_SSL_CTX_clone(SSL_CTX *ctx) {
     CRYPTO_add(&ctx->references,1,CRYPTO_LOCK_SSL_CTX);
 }
-
-void rust_EVP_PKEY_clone(EVP_PKEY *pkey) {
-    CRYPTO_add(&pkey->references,1,CRYPTO_LOCK_EVP_PKEY);
-}
-
-void rust_X509_clone(X509 *x509) {
-    CRYPTO_add(&x509->references,1,CRYPTO_LOCK_X509);
-}

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -52,10 +52,6 @@ fn openssl_hash_nid(hash: HashType) -> c_int {
     }
 }
 
-extern "C" {
-    fn rust_EVP_PKEY_clone(pkey: *mut ffi::EVP_PKEY);
-}
-
 pub struct PKey {
     evp: *mut ffi::EVP_PKEY,
     parts: Parts,
@@ -601,16 +597,6 @@ impl Drop for PKey {
         unsafe {
             ffi::EVP_PKEY_free(self.evp);
         }
-    }
-}
-
-impl Clone for PKey {
-    fn clone(&self) -> Self {
-        unsafe {
-            rust_EVP_PKEY_clone(self.evp);
-        }
-
-        PKey::from_handle(self.evp, self.parts)
     }
 }
 

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -509,20 +509,6 @@ impl<'ctx> X509<'ctx> {
     }
 }
 
-extern "C" {
-    fn rust_X509_clone(x509: *mut ffi::X509);
-}
-
-impl<'ctx> Clone for X509<'ctx> {
-    fn clone(&self) -> X509<'ctx> {
-        unsafe { rust_X509_clone(self.handle) }
-        /* FIXME: given that we now have refcounting control, 'owned' should be uneeded, the 'ctx
-         * is probably also uneeded. We can remove both to condense the x509 api quite a bit
-         */
-        X509::new(self.handle, true)
-    }
-}
-
 impl<'ctx> Drop for X509<'ctx> {
     fn drop(&mut self) {
         if self.owned {


### PR DESCRIPTION
Reverts sfackler/rust-openssl#336

OpenSSL 1.1 is making these types opaque.