### PR TITLE
Update gcc dependency version

### DIFF
--- a/openssl-sys-extras/Cargo.toml
+++ b/openssl-sys-extras/Cargo.toml
@@ -16,4 +16,4 @@ libc = "0.2"
 openssl-sys = { version = "0.7.5", path = "../openssl-sys" }
 
 [build-dependencies]
-gcc = "0.3"
+gcc = "0.3.22"


### PR DESCRIPTION
This is needed to pick up a recent update to gcc-rs that brings support for armv7 targets.