### PR TITLE
adding functionality to directly get and set RSA public key material

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -588,6 +588,7 @@ extern "C" {
 
     pub fn RAND_bytes(buf: *mut u8, num: c_int) -> c_int;
 
+    pub fn RSA_new() -> *mut RSA;
     pub fn RSA_free(rsa: *mut RSA);
     pub fn RSA_generate_key(modsz: c_int, e: c_ulong, cb: *const c_void, cbarg: *const c_void) -> *mut RSA;
     pub fn RSA_generate_key_ex(rsa: *mut RSA, bits: c_int, e: *mut BIGNUM, cb: *const c_void) -> c_int;

--- a/openssl/src/bn/mod.rs
+++ b/openssl/src/bn/mod.rs
@@ -473,6 +473,11 @@ impl BigNum {
         n
     }
 
+    pub unsafe fn into_raw(self) -> *mut ffi::BIGNUM {
+        let mut me = self;
+        ptr::replace(&mut me.0, ptr::null_mut())
+    }
+
     pub fn to_vec(&self) -> Vec<u8> {
         let size = self.num_bytes() as usize;
         let mut v = Vec::with_capacity(size);

--- a/openssl/src/bn/mod.rs
+++ b/openssl/src/bn/mod.rs
@@ -1,7 +1,7 @@
 use libc::{c_int, c_ulong, c_void};
 use std::ffi::{CStr, CString};
 use std::cmp::Ordering;
-use std::{fmt, ptr};
+use std::{fmt, ptr, mem};
 
 use ffi;
 use ssl::error::SslError;
@@ -473,9 +473,9 @@ impl BigNum {
         n
     }
 
-    pub unsafe fn into_raw(self) -> *mut ffi::BIGNUM {
+    pub fn into_raw(self) -> *mut ffi::BIGNUM {
         let mut me = self;
-        ptr::replace(&mut me.0, ptr::null_mut())
+        mem::replace(&mut me.0, ptr::null_mut())
     }
 
     pub fn to_vec(&self) -> Vec<u8> {

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -205,6 +205,30 @@ impl PKey {
         }
     }
 
+    /// pass ownership of the RSA key to this
+    pub fn set_rsa(&mut self, rsa: RSA) {
+        unsafe {
+            // TODO: should we do something like panic if null? this will fail silently right now
+            let rsa_ptr = rsa.as_ptr();
+            if !rsa_ptr.is_null() {
+                if ffi::EVP_PKEY_set1_RSA(self.evp, rsa_ptr) == 1 {
+                    if rsa.has_e() && rsa.has_n() {
+                        self.parts = Parts::Public;
+                    }
+                }
+            }
+        }
+    }
+
+    /// get a reference to the interal RSA key for direct access to the key components
+    pub fn get_rsa(&self) -> RSA {
+        unsafe {
+            let evp_pkey: *mut ffi::EVP_PKEY = self.evp;
+            // this is safe as the ffi increments a reference counter to the internal key
+            RSA(ffi::EVP_PKEY_get1_RSA(evp_pkey))
+        }
+    }
+
     /**
      * Returns a DER serialized form of the public key, suitable for load_pub().
      */

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -208,13 +208,10 @@ impl PKey {
     /// pass ownership of the RSA key to this
     pub fn set_rsa(&mut self, rsa: RSA) {
         unsafe {
-            // TODO: should we do something like panic if null? this will fail silently right now
             let rsa_ptr = rsa.as_ptr();
-            if !rsa_ptr.is_null() {
-                if ffi::EVP_PKEY_set1_RSA(self.evp, rsa_ptr) == 1 {
-                    if rsa.has_e() && rsa.has_n() {
-                        self.parts = Parts::Public;
-                    }
+            if ffi::EVP_PKEY_set1_RSA(self.evp, rsa_ptr) == 1 {
+                if rsa.has_e() && rsa.has_n() {
+                    self.parts = Parts::Public;
                 }
             }
         }
@@ -225,7 +222,7 @@ impl PKey {
         unsafe {
             let evp_pkey: *mut ffi::EVP_PKEY = self.evp;
             // this is safe as the ffi increments a reference counter to the internal key
-            RSA(ffi::EVP_PKEY_get1_RSA(evp_pkey))
+            RSA::with_raw(ffi::EVP_PKEY_get1_RSA(evp_pkey))
         }
     }
 

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -205,9 +205,10 @@ impl PKey {
         }
     }
 
-    /// pass ownership of the RSA key to this
-    pub fn set_rsa(&mut self, rsa: RSA) {
+    /// assign RSA key to this pkey
+    pub fn set_rsa(&mut self, rsa: &RSA) {
         unsafe {
+            // this needs to be a reference as the set1_RSA ups the reference count
             let rsa_ptr = rsa.as_ptr();
             if ffi::EVP_PKEY_set1_RSA(self.evp, rsa_ptr) == 1 {
                 if rsa.has_e() && rsa.has_n() {
@@ -222,7 +223,7 @@ impl PKey {
         unsafe {
             let evp_pkey: *mut ffi::EVP_PKEY = self.evp;
             // this is safe as the ffi increments a reference counter to the internal key
-            RSA::with_raw(ffi::EVP_PKEY_get1_RSA(evp_pkey))
+            RSA::from_raw(ffi::EVP_PKEY_get1_RSA(evp_pkey))
         }
     }
 
@@ -625,6 +626,7 @@ mod tests {
     use std::path::Path;
     use std::fs::File;
     use crypto::hash::Type::{MD5, SHA1};
+    use crypto::rsa::RSA;
 
     #[test]
     fn test_gen_pub() {
@@ -809,6 +811,28 @@ mod tests {
         // the `PRIVATE KEY` or `PUBLIC KEY` strings.
         assert!(priv_key.windows(11).any(|s| s == b"PRIVATE KEY"));
         assert!(pub_key.windows(10).any(|s| s == b"PUBLIC KEY"));
+    }
+
+    #[test]
+    fn test_public_key_from_raw() {
+        let mut k0 = super::PKey::new();
+        let mut k1 = super::PKey::new();
+        let msg = vec![0xdeu8, 0xadu8, 0xd0u8, 0x0du8];
+
+        k0.gen(512);
+        let sig = k0.sign(&msg);
+
+        let r0 = k0.get_rsa();
+        let r1 = RSA::from_public_components(r0.n().expect("n"), r0.e().expect("e")).expect("r1");
+        k1.set_rsa(&r1);
+
+        assert!(k1.can(super::Role::Encrypt));
+        assert!(!k1.can(super::Role::Decrypt));
+        assert!(k1.can(super::Role::Verify));
+        assert!(!k1.can(super::Role::Sign));
+
+        let rv = k1.verify(&msg, &sig);
+        assert!(rv == true);
     }
 
     #[test]

--- a/openssl/src/crypto/rsa.rs
+++ b/openssl/src/crypto/rsa.rs
@@ -29,7 +29,8 @@ impl RSA {
         }
     }
 
-    pub fn from_raw(rsa: *mut ffi::RSA) -> RSA {
+    /// the caller should assert that the rsa pointer is valid.
+    pub unsafe fn from_raw(rsa: *mut ffi::RSA) -> RSA {
         RSA(rsa)
     }
 

--- a/openssl/src/crypto/rsa.rs
+++ b/openssl/src/crypto/rsa.rs
@@ -7,7 +7,7 @@ use std::io::{self, Read};
 use bn::BigNum;
 use bio::MemBio;
 
-pub struct RSA(pub *mut ffi::RSA);
+pub struct RSA(*mut ffi::RSA);
 
 impl Drop for RSA {
     fn drop(&mut self) {
@@ -25,6 +25,10 @@ impl RSA {
             let rsa = try_ssl_null!(ffi::RSA_new());
             Ok(RSA(rsa))
         }
+    }
+
+    pub fn with_raw(rsa: *mut ffi::RSA) -> RSA {
+        RSA(rsa)
     }
 
     /// Reads an RSA private key from PEM formatted data.

--- a/openssl/src/crypto/rsa.rs
+++ b/openssl/src/crypto/rsa.rs
@@ -20,14 +20,16 @@ impl Drop for RSA {
 impl RSA {
     /// only useful for associating the key material directly with the key, it's safer to use
     /// the supplied load and save methods for DER formatted keys.
-    pub fn new() -> Result<RSA, SslError> {
+    pub fn from_public_components(n: BigNum, e: BigNum) -> Result<RSA, SslError> {
         unsafe {
             let rsa = try_ssl_null!(ffi::RSA_new());
+            (*rsa).n = n.into_raw();
+            (*rsa).e = e.into_raw();
             Ok(RSA(rsa))
         }
     }
 
-    pub fn with_raw(rsa: *mut ffi::RSA) -> RSA {
+    pub fn from_raw(rsa: *mut ffi::RSA) -> RSA {
         RSA(rsa)
     }
 
@@ -74,13 +76,6 @@ impl RSA {
         }
     }
 
-    /// set the key modulus
-    pub fn set_n(&mut self, n: BigNum) {
-        unsafe {
-            (*self.0).n = n.into_raw();
-        }
-    }
-
     pub fn has_n(&self) -> bool {
         unsafe {
             !(*self.0).n.is_null()
@@ -96,13 +91,6 @@ impl RSA {
     pub fn e(&self) -> Result<BigNum, SslError> {
         unsafe {
             BigNum::new_from_ffi((*self.0).e)
-        }
-    }
-
-    /// set the exponent
-    pub fn set_e(&mut self, e: BigNum) {
-        unsafe {
-            (*self.0).e = e.into_raw();
         }
     }
 


### PR DESCRIPTION
I'm currently working on DNSSec and needed the ability to both directly access and set the RSA public key material. Please note that this is the first unsafe Rust code that I've needed to write, so please double check my unsafe sections.