### PR TITLE
change PKey::clone to use EVP_PKEY_copy_parameters

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -548,6 +548,7 @@ extern "C" {
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
     pub fn EVP_PKEY_free(k: *mut EVP_PKEY);
     pub fn EVP_PKEY_assign(pkey: *mut EVP_PKEY, typ: c_int, key: *const c_void) -> c_int;
+    pub fn EVP_PKEY_copy_parameters(to: *mut EVP_PKEY, from: *const EVP_PKEY) -> c_int;
     pub fn EVP_PKEY_get1_RSA(k: *mut EVP_PKEY) -> *mut RSA;
     pub fn EVP_PKEY_set1_RSA(k: *mut EVP_PKEY, r: *mut RSA) -> c_int;
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> c_int;

--- a/openssl/src/c_helpers.c
+++ b/openssl/src/c_helpers.c
@@ -8,10 +8,6 @@ void rust_SSL_CTX_clone(SSL_CTX *ctx) {
     CRYPTO_add(&ctx->references,1,CRYPTO_LOCK_SSL_CTX);
 }
 
-void rust_EVP_PKEY_clone(EVP_PKEY *pkey) {
-    CRYPTO_add(&pkey->references,1,CRYPTO_LOCK_EVP_PKEY);
-}
-
 void rust_X509_clone(X509 *x509) {
     CRYPTO_add(&x509->references,1,CRYPTO_LOCK_X509);
 }


### PR DESCRIPTION
Right now PKey::clone just increments the reference count, falsely giving full ownership of the same struct to two owners. Code that simply `clone`s and repeatedly calls `gen` from multiple threads will segfault.

Here is a branch with just the test showing that it fails: https://github.com/kcking/rust-openssl/tree/kcking-pkey-clone-does-not-copy

(I didn't get a chance to take a look at other Clone impls since my current project only uses PKey)