### PR TITLE
Add function to advertise accepted CA list for clients

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -36,6 +36,7 @@ pub type X509_REQ = c_void;
 pub type X509_STORE_CTX = c_void;
 pub type stack_st_X509_EXTENSION = c_void;
 pub type stack_st_void = c_void;
+pub type stack_of_X509_NAME = c_void;
 pub type bio_st = c_void;
 
 pub type bio_info_cb = Option<unsafe extern "C" fn(*mut BIO,
@@ -686,6 +687,8 @@ extern "C" {
 
     pub fn SSL_CTX_set_cipher_list(ssl: *mut SSL_CTX, s: *const c_char) -> c_int;
 
+    pub fn SSL_CTX_set_client_CA_list(ssl: *mut SSL_CTX, s: *const stack_of_X509_NAME) -> c_int;
+
     #[cfg(feature = "npn")]
     pub fn SSL_CTX_set_next_protos_advertised_cb(ssl: *mut SSL_CTX,
                                                  cb: extern "C" fn(ssl: *mut SSL,
@@ -726,6 +729,8 @@ extern "C" {
                                             arg: *mut c_void);
     #[cfg(feature = "alpn")]
     pub fn SSL_get0_alpn_selected(s: *const SSL, data: *mut *const c_uchar, len: *mut c_uint);
+
+    pub fn SSL_load_client_CA_file(file: *const c_char) -> *mut stack_of_X509_NAME;
 
     pub fn X509_add_ext(x: *mut X509, ext: *mut X509_EXTENSION, loc: c_int) -> c_int;
     pub fn X509_digest(x: *mut X509, digest: *const EVP_MD, buf: *mut c_char, len: *mut c_uint) -> c_int;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -687,7 +687,7 @@ extern "C" {
 
     pub fn SSL_CTX_set_cipher_list(ssl: *mut SSL_CTX, s: *const c_char) -> c_int;
 
-    pub fn SSL_CTX_set_client_CA_list(ssl: *mut SSL_CTX, s: *const stack_of_X509_NAME) -> c_int;
+    pub fn SSL_CTX_set_client_CA_list(ssl: *mut SSL_CTX, s: *const stack_of_X509_NAME);
 
     #[cfg(feature = "npn")]
     pub fn SSL_CTX_set_next_protos_advertised_cb(ssl: *mut SSL_CTX,

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -613,6 +613,19 @@ impl SslContext {
     }
 
     #[allow(non_snake_case)]
+    /// Advertise the CAs from a file as being accepted for client certificates.
+    ///
+    /// This does not actually make the certificates trusted. You'll still need to call set_CA_file
+    /// for that.
+    pub fn advertise_client_CA_list<P: AsRef<Path>>(&mut self, file: P) -> Result<(), SslError> {
+        let file = CString::new(file.as_ref().as_os_str().to_str().expect("invalid utf8")).unwrap();
+        wrap_ssl_result(unsafe {
+            let names = ffi::SSL_load_client_CA_file(file.as_ptr() as *const _);
+            ffi::SSL_CTX_set_client_CA_list(self.ctx, names)
+        })
+    }
+
+    #[allow(non_snake_case)]
     /// Specifies the file that contains trusted CA certificates.
     pub fn set_CA_file<P: AsRef<Path>>(&mut self, file: P) -> Result<(), SslError> {
         let file = CString::new(file.as_ref().as_os_str().to_str().expect("invalid utf8")).unwrap();

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -621,7 +621,8 @@ impl SslContext {
         let file = CString::new(file.as_ref().as_os_str().to_str().expect("invalid utf8")).unwrap();
         wrap_ssl_result(unsafe {
             let names = ffi::SSL_load_client_CA_file(file.as_ptr() as *const _);
-            ffi::SSL_CTX_set_client_CA_list(self.ctx, names)
+            // For some reason a 0 return value here indicates failure instead of success
+            1 - ffi::SSL_CTX_set_client_CA_list(self.ctx, names)
         })
     }
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -621,8 +621,7 @@ impl SslContext {
         let file = CString::new(file.as_ref().as_os_str().to_str().expect("invalid utf8")).unwrap();
         wrap_ssl_result(unsafe {
             let names = ffi::SSL_load_client_CA_file(file.as_ptr() as *const _);
-            // For some reason a 0 return value here indicates failure instead of success
-            1 - ffi::SSL_CTX_set_client_CA_list(self.ctx, names)
+            ffi::SSL_CTX_set_client_CA_list(self.ctx, names)
         })
     }
 


### PR DESCRIPTION
Advertising the CA list properly will restrict the list of client certificates
that a browser will show to the user only to ones that will provide successful
authentication.
