### PR TITLE
Add ability to set session ID context on an SSL context

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -675,6 +675,7 @@ extern "C" {
     pub fn SSL_CTX_set_ex_data(ctx: *mut SSL_CTX, idx: c_int, data: *mut c_void)
                                -> c_int;
     pub fn SSL_CTX_get_ex_data(ctx: *mut SSL_CTX, idx: c_int) -> *mut c_void;
+    pub fn SSL_CTX_set_session_id_context(ssl: *mut SSL_CTX, sid_ctx: *const c_uchar, sid_ctx_len: c_uint) -> c_int;
 
     pub fn SSL_CTX_use_certificate_file(ctx: *mut SSL_CTX, cert_file: *const c_char, file_type: c_int) -> c_int;
     pub fn SSL_CTX_use_certificate_chain_file(ctx: *mut SSL_CTX, cert_chain_file: *const c_char, file_type: c_int) -> c_int;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -621,6 +621,20 @@ impl SslContext {
         })
     }
 
+    /// Set the context identifier for sessions
+    ///
+    /// This value identifies the server's session cache to a clients, telling them when they're
+    /// able to reuse sessions. Should be set to a unique value per server, unless multiple servers
+    /// share a session cache.
+    ///
+    /// This value should be set when using client certificates, or each request will fail
+    /// handshake and need to be restarted.
+    pub fn set_session_id_context(&mut self, sid_ctx: &[u8]) -> Result<(), SslError> {
+        wrap_ssl_result(unsafe {
+            ffi::SSL_CTX_set_session_id_context(self.ctx, sid_ctx.as_ptr(), sid_ctx.len() as u32)
+        })
+    }
+
     /// Specifies the file that contains certificate
     pub fn set_certificate_file<P: AsRef<Path>>(&mut self,
                                                 file: P,


### PR DESCRIPTION
This is necessary to make authentication with client certificates work
without session restarts.