### PR TITLE
Add 1DES symm ciphers (des-cbc, des-ecb, des-cfb, des-ofb)

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -529,8 +529,6 @@ extern "C" {
 
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
-    pub fn EVP_des_cfb() -> *const EVP_CIPHER;
-    pub fn EVP_des_ofb() -> *const EVP_CIPHER;
 
     pub fn EVP_BytesToKey(typ: *const EVP_CIPHER, md: *const EVP_MD,
                           salt: *const u8, data: *const u8, datalen: c_int,

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -527,6 +527,11 @@ extern "C" {
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 
+    pub fn EVP_des_cbc() -> *const EVP_CIPHER;
+    pub fn EVP_des_ecb() -> *const EVP_CIPHER;
+    pub fn EVP_des_cfb() -> *const EVP_CIPHER;
+    pub fn EVP_des_ofb() -> *const EVP_CIPHER;
+
     pub fn EVP_BytesToKey(typ: *const EVP_CIPHER, md: *const EVP_MD,
                           salt: *const u8, data: *const u8, datalen: c_int,
                           count: c_int, key: *mut u8, iv: *mut u8) -> c_int;

--- a/openssl/src/crypto/symm.rs
+++ b/openssl/src/crypto/symm.rs
@@ -37,6 +37,11 @@ pub enum Type {
     AES_256_CFB128,
     AES_256_CFB8,
 
+    DES_CBC,
+    DES_ECB,
+    DES_CFB,
+    DES_OFB,
+
     RC4_128,
 }
 
@@ -361,5 +366,49 @@ mod tests {
         let iv = "000102030405060708090a0b0c0d0e0f";
 
         cipher_test(super::Type::AES_256_CFB8, pt, ct, key, iv);
+    }
+
+    #[test]
+    fn test_des_cbc() {
+
+        let pt = "54686973206973206120746573742e";
+        let ct = "6f2867cfefda048a4046ef7e556c7132";
+        let key = "7cb66337f3d3c0fe";
+        let iv = "0001020304050607";
+
+        cipher_test(super::Type::DES_CBC, pt, ct, key, iv);
+    }
+
+    #[test]
+    fn test_des_ecb() {
+
+        let pt = "54686973206973206120746573742e";
+        let ct = "0050ab8aecec758843fe157b4dde938c";
+        let key = "7cb66337f3d3c0fe";
+        let iv = "0001020304050607";
+
+        cipher_test(super::Type::DES_ECB, pt, ct, key, iv);
+    }
+
+    #[test]
+    fn test_des_cfb() {
+
+        let pt = "54686973206973206120746573742e";
+        let ct = "10577dc484ebfe7679121dff761797";
+        let key = "7cb66337f3d3c0fe";
+        let iv = "0001020304050607";
+
+        cipher_test(super::Type::DES_CFB, pt, ct, key, iv);
+    }
+
+    #[test]
+    fn test_des_ofb() {
+
+        let pt = "54686973206973206120746573742e";
+        let ct = "10577dc484ebfe76be391c7b8a6b9d";
+        let key = "7cb66337f3d3c0fe";
+        let iv = "0001020304050607";
+
+        cipher_test(super::Type::DES_OFB, pt, ct, key, iv);
     }
 }

--- a/openssl/src/crypto/symm.rs
+++ b/openssl/src/crypto/symm.rs
@@ -39,8 +39,6 @@ pub enum Type {
 
     DES_CBC,
     DES_ECB,
-    DES_CFB,
-    DES_OFB,
 
     RC4_128,
 }
@@ -388,27 +386,5 @@ mod tests {
         let iv = "0001020304050607";
 
         cipher_test(super::Type::DES_ECB, pt, ct, key, iv);
-    }
-
-    #[test]
-    fn test_des_cfb() {
-
-        let pt = "54686973206973206120746573742e";
-        let ct = "10577dc484ebfe7679121dff761797";
-        let key = "7cb66337f3d3c0fe";
-        let iv = "0001020304050607";
-
-        cipher_test(super::Type::DES_CFB, pt, ct, key, iv);
-    }
-
-    #[test]
-    fn test_des_ofb() {
-
-        let pt = "54686973206973206120746573742e";
-        let ct = "10577dc484ebfe76be391c7b8a6b9d";
-        let key = "7cb66337f3d3c0fe";
-        let iv = "0001020304050607";
-
-        cipher_test(super::Type::DES_OFB, pt, ct, key, iv);
     }
 }

--- a/openssl/src/crypto/symm_internal.rs
+++ b/openssl/src/crypto/symm_internal.rs
@@ -26,6 +26,11 @@ pub fn evpc(t: symm::Type) -> (*const ffi::EVP_CIPHER, u32, u32) {
             symm::Type::AES_256_CFB128 => (ffi::EVP_aes_256_cfb128(), 32, 16),
             symm::Type::AES_256_CFB8 => (ffi::EVP_aes_256_cfb8(), 32, 16),
 
+            symm::Type::DES_CBC => (ffi::EVP_des_cbc(), 8, 8),
+            symm::Type::DES_ECB => (ffi::EVP_des_ecb(), 8, 8),
+            symm::Type::DES_CFB => (ffi::EVP_des_cfb(), 8, 8),
+            symm::Type::DES_OFB => (ffi::EVP_des_ofb(), 8, 8),
+
             symm::Type::RC4_128 => (ffi::EVP_rc4(), 16, 0),
         }
     }

--- a/openssl/src/crypto/symm_internal.rs
+++ b/openssl/src/crypto/symm_internal.rs
@@ -28,8 +28,6 @@ pub fn evpc(t: symm::Type) -> (*const ffi::EVP_CIPHER, u32, u32) {
 
             symm::Type::DES_CBC => (ffi::EVP_des_cbc(), 8, 8),
             symm::Type::DES_ECB => (ffi::EVP_des_ecb(), 8, 8),
-            symm::Type::DES_CFB => (ffi::EVP_des_cfb(), 8, 8),
-            symm::Type::DES_OFB => (ffi::EVP_des_ofb(), 8, 8),
 
             symm::Type::RC4_128 => (ffi::EVP_rc4(), 16, 0),
         }


### PR DESCRIPTION
1DES is well and truly dead for actual sensitive information, (its
keysize is too small for modern purposes), but it can still find use in
backwards compatiblity or educational applications.