### PR TITLE
(maint) Use wget with appveyor (to enable msvc testing)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,14 @@ environment:
   matrix:
   - TARGET: i686-pc-windows-gnu
     BITS: 32
-#  - TARGET: x86_64-pc-windows-msvc
-#    BITS: 64
+  - TARGET: x86_64-pc-windows-msvc
+    BITS: 64
 install:
   - ps: Start-FileDownload "http://slproweb.com/download/Win${env:BITS}OpenSSL-1_0_2h.exe"
-  - Win%BITS%OpenSSL-1_0_2h.exe /SILENT /VERYSILENT /SP- /DIR="C:\OpenSSL"
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.8.0-${env:TARGET}.exe"
-  - rust-1.8.0-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - ps: wget "http://slproweb.com/download/Win${env:BITS}OpenSSL-1_0_2h.exe" -OutFile "$pwd\OpenSSL.exe"
+  - OpenSSL.exe /SILENT /VERYSILENT /SP- /DIR="C:\OpenSSL"
+  - ps: wget "https://static.rust-lang.org/dist/rust-1.8.0-${env:TARGET}.exe" -OutFile "$pwd\Rust.exe"
+  - Rust.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V


### PR DESCRIPTION
This commit re-enables msvc testing by using wget with appveyor instead
of Start-FileDownload. This commit also fixes an issue where the version
of OpenSSL and Rust were specified twice in appveyor's config meaning
that it was possible to update one of the version for a release but not
the other.