### PR TITLE
Signature Generation/Verification Support

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -23,6 +23,7 @@ npn = []
 alpn = []
 rfc5114 = []
 pkcs5_pbkdf2_hmac = []
+signing = []
 
 [dependencies]
 libc = "0.2"

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -608,6 +608,16 @@ extern "C" {
     pub fn EVP_PKEY_set1_RSA(k: *mut EVP_PKEY, r: *mut RSA) -> c_int;
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> c_int;
 
+    pub fn EVP_DigestSignInit(ctx: *mut EVP_MD_CTX, pctx: *mut *mut EVP_PKEY_CTX,
+                              typ: *const EVP_MD, e: *const ENGINE, pkey: *mut EVP_PKEY) -> c_int;
+    pub fn EVP_DigestSignFinal(ctx: *mut EVP_MD_CTX, sig: *mut u8,
+                               siglen: *mut size_t) -> c_int;
+
+    pub fn EVP_DigestVerifyInit(ctx: *mut EVP_MD_CTX, pctx: *mut *mut EVP_PKEY_CTX,
+                                typ: *const EVP_MD, e: *mut ENGINE, pkey: *mut EVP_PKEY) -> c_int;
+    pub fn EVP_DigestVerifyFinal(ctx: *mut EVP_MD_CTX, sigret: *const c_uchar,
+                                 signlen: size_t) -> c_int;
+
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -608,13 +608,16 @@ extern "C" {
     pub fn EVP_PKEY_set1_RSA(k: *mut EVP_PKEY, r: *mut RSA) -> c_int;
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> c_int;
 
+    #[cfg(feature = "signing")]
     pub fn EVP_DigestSignInit(ctx: *mut EVP_MD_CTX, pctx: *mut *mut EVP_PKEY_CTX,
                               typ: *const EVP_MD, e: *const ENGINE, pkey: *mut EVP_PKEY) -> c_int;
+    #[cfg(feature = "signing")]
     pub fn EVP_DigestSignFinal(ctx: *mut EVP_MD_CTX, sig: *mut u8,
                                siglen: *mut size_t) -> c_int;
-
+    #[cfg(feature = "signing")]
     pub fn EVP_DigestVerifyInit(ctx: *mut EVP_MD_CTX, pctx: *mut *mut EVP_PKEY_CTX,
                                 typ: *const EVP_MD, e: *mut ENGINE, pkey: *mut EVP_PKEY) -> c_int;
+    #[cfg(feature = "signing")]
     pub fn EVP_DigestVerifyFinal(ctx: *mut EVP_MD_CTX, sigret: *const c_uchar,
                                  signlen: size_t) -> c_int;
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -539,6 +539,7 @@ extern "C" {
     pub fn ERR_lib_error_string(err: c_ulong) -> *const c_char;
     pub fn ERR_func_error_string(err: c_ulong) -> *const c_char;
     pub fn ERR_reason_error_string(err: c_ulong) -> *const c_char;
+    pub fn ERR_error_string(err: c_ulong, buf: *mut c_char) -> *const c_char;
 
     pub fn ERR_load_crypto_strings();
 

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -25,6 +25,7 @@ alpn = ["openssl-sys/alpn"]
 rfc5114 = ["openssl-sys/rfc5114"]
 ecdh_auto = ["openssl-sys-extras/ecdh_auto"]
 pkcs5_pbkdf2_hmac = ["openssl-sys/pkcs5_pbkdf2_hmac"]
+signing = ["openssl-sys/signing"]
 
 nightly = []
 catch_unwind = []

--- a/openssl/src/bio/mod.rs
+++ b/openssl/src/bio/mod.rs
@@ -1,7 +1,6 @@
 use libc::{c_void, c_int};
 use std::io;
 use std::io::prelude::*;
-use std::ptr;
 use std::cmp;
 
 use ffi;

--- a/openssl/src/crypto/mod.rs
+++ b/openssl/src/crypto/mod.rs
@@ -21,6 +21,7 @@ pub mod hmac;
 pub mod pkcs5;
 pub mod pkey;
 pub mod rand;
+pub mod signature;
 pub mod symm;
 pub mod memcmp;
 pub mod rsa;

--- a/openssl/src/crypto/mod.rs
+++ b/openssl/src/crypto/mod.rs
@@ -21,6 +21,7 @@ pub mod hmac;
 pub mod pkcs5;
 pub mod pkey;
 pub mod rand;
+#[cfg(feature = "signing")]
 pub mod signature;
 pub mod symm;
 pub mod memcmp;

--- a/openssl/src/crypto/signature.rs
+++ b/openssl/src/crypto/signature.rs
@@ -1,0 +1,261 @@
+// Copyright (c) 2016, The rust-openssl developers.
+
+//! Interface for computing/verifying message signatures
+//!
+//! The `Signer` allows for the computation of crytographic signatures
+//! of data given a private key.  The corresponding public key can then
+//! be used to verify the integrity and authenticity of signed messages
+//! using the `Verifier`.
+//!
+//! # Example
+//!
+//! ```rust
+//! use openssl::crypto::signature::{Signer, Verifier};
+//! use openssl::crypto::pkey::PKey;
+//! use openssl::crypto::hash;
+//!
+//! // Generate public/private keypairs
+//! let mut keypair = PKey::new();
+//! let mut privkey = PKey::new();
+//! let mut pubkey = PKey::new();
+//! keypair.gen(1024);
+//! privkey.load_priv(&keypair.save_priv()[..]);
+//! pubkey.load_pub(&keypair.save_pub()[..]);
+//!
+//! // generate some data
+//! let data1: Vec<u8> = (0..25).cycle().take(1024).collect();
+//! let data2: Vec<u8> = (100..150).cycle().take(1024 * 5).collect();
+//!
+//! // sign some content with private key
+//! let mut signer = Signer::new(hash::Type::SHA512, &privkey);
+//! signer.update(&data1[..]);
+//! signer.update(&data2[..]);
+//! let signature = signer.sign();
+//!
+//! // verify content using signature and public key
+//! let mut verifier = Verifier::new(hash::Type::SHA512, &pubkey);
+//! verifier.update(&data1[..]);
+//! verifier.update(&data2[..]);
+//! assert!(verifier.verify(&signature[..]));
+//! ```
+
+use std::ptr;
+use libc;
+
+use ffi;
+use crypto::pkey::PKey;
+use crypto::hash;
+
+/// Signature Generation Context
+pub struct Signer<'a> {
+    ctx: *mut ffi::EVP_MD_CTX,
+    pkey: &'a PKey,
+}
+
+/// Signature Verification Context
+pub struct Verifier<'a> {
+    ctx: *mut ffi::EVP_MD_CTX,
+    pkey: &'a PKey,
+}
+
+macro_rules! openssl_assert {
+    ($expression:expr, $msg:expr) => (
+        if ! $expression {
+            let error = ::ffi::ERR_get_error();
+            let bytes = ::std::ffi::CStr::from_ptr(::ffi::ERR_error_string(error, ::std::ptr::null_mut())).to_bytes();
+            panic!("{}: {}", $msg, ::std::str::from_utf8(bytes).unwrap());
+        }
+    )
+}
+
+impl<'a> Signer<'a> {
+    /// Create and initialize a new Signer
+    ///
+    /// The digest type specified will determine the final form  of the
+    /// signature returned by `finalize`.
+    ///
+    /// # Panics
+    ///
+    /// If the provided pkey does not contain a private key.
+    pub fn new(digest_type: hash::Type, pkey: &'a PKey) -> Signer {
+        ffi::init();
+
+        let ctx = unsafe {
+            let r = ffi::EVP_MD_CTX_create();
+            openssl_assert!(!r.is_null(), "EVP_MD_CTX_create failed");
+            r
+        };
+
+        let md = digest_type.evp_md();
+
+        let signer = Signer {
+            ctx: ctx,
+            pkey: pkey,
+        };
+
+        unsafe {
+            let r =
+                ffi::EVP_DigestSignInit(ctx, ptr::null_mut(), md, ptr::null(), signer.pkey.get_handle());
+            openssl_assert!(r == 1, "EVP_DigestSignInitFailed");
+        }
+
+        signer
+    }
+
+    /// Feed bytes to be added to the signature calculation
+    #[inline]
+    pub fn update(&mut self, data: &[u8]) {
+        unsafe {
+            let r = ffi::EVP_DigestUpdate(self.ctx, data.as_ptr(), data.len() as u32);
+            openssl_assert!(r == 1, "EVP_DigestSignUpdate failed");
+        }
+    }
+
+    /// Finalize the signature calculation and return the signature
+    ///
+    /// The signature form will be determined by the hashing type for this
+    /// Signer (e.g. `SHA512` will return a Vector with 64 bytes).
+    #[inline]
+    pub fn sign(&mut self) -> Vec<u8> {
+        let mut sigbuf = [0u8; 8 * 1024];
+        let mut siglen = sigbuf.len() as libc::size_t;
+        unsafe {
+            let r = ffi::EVP_DigestSignFinal(self.ctx, (&mut sigbuf[..]).as_mut_ptr(), &mut siglen);
+            openssl_assert!(r == 1, "EVP_DigestSignFinal failed");
+        }
+        Vec::from(&sigbuf[..siglen])
+    }
+}
+
+impl<'a> Drop for Signer<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::EVP_MD_CTX_destroy(self.ctx);
+        }
+    }
+}
+
+impl<'a> Verifier<'a> {
+    /// Create and initialize a new Verifier
+    ///
+    /// The digest type should match the form of the signature provided
+    /// during the final step of signature verification.
+    pub fn new(digest_type: hash::Type, pkey: &'a PKey) -> Verifier {
+        ffi::init();
+
+        let ctx = unsafe {
+            let r = ffi::EVP_MD_CTX_create();
+            openssl_assert!(!r.is_null(), "EVP_MD_CTX_create failed");
+            r
+        };
+
+        let md = digest_type.evp_md();
+
+        let verifier = Verifier {
+            ctx: ctx,
+            pkey: pkey,
+        };
+
+        unsafe {
+            let r =
+                ffi::EVP_DigestVerifyInit(ctx, ptr::null_mut(), md, ptr::null_mut(), verifier.pkey.get_handle());
+            openssl_assert!(r == 1, "EVP_DigestVerifyInit failed");
+        }
+
+        verifier
+    }
+
+    /// Feed bytes into the verification calculation
+    #[inline]
+    pub fn update(&mut self, data: &[u8]) {
+        unsafe {
+            let r = ffi::EVP_DigestUpdate(self.ctx, data.as_ptr(), data.len() as u32);
+            openssl_assert!(r == 1, "EVP_DigestVerifyUpdate failed");
+        }
+    }
+
+    /// Verify that the content feed into this Verifier is valid for the
+    /// given signature
+    #[inline]
+    pub fn verify(&self, signature: &[u8]) -> bool {
+        let r = unsafe {
+            ffi::EVP_DigestVerifyFinal(self.ctx,
+                                       signature.as_ptr(),
+                                       signature.len() as libc::size_t)
+        };
+        r == 1
+    }
+}
+
+impl<'a> Drop for Verifier<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::EVP_MD_CTX_destroy(self.ctx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crypto::hash;
+    use crypto::pkey::PKey;
+
+    #[test]
+    fn test_sign_verify() {
+        // Generate public/private keypairs
+        let mut keypair = PKey::new();
+        let mut privkey = PKey::new();
+        let mut pubkey = PKey::new();
+        keypair.gen(1024);
+        privkey.load_priv(&keypair.save_priv()[..]);
+        pubkey.load_pub(&keypair.save_pub()[..]);
+
+        // generate some data
+        let data1: Vec<u8> = (0..25).cycle().take(1024).collect();
+        let data2: Vec<u8> = (100..150).cycle().take(1024 * 5).collect();
+
+        // sign some content with private key
+        let mut signer = Signer::new(hash::Type::SHA224, &privkey);
+        signer.update(&data1[..]);
+        signer.update(&data2[..]);
+        let signature = signer.sign();
+
+        // verify content using signature and public key
+        let mut verifier = Verifier::new(hash::Type::SHA224, &pubkey);
+        verifier.update(&data1[..]);
+        verifier.update(&data2[..]);
+        assert!(verifier.verify(&signature[..]));
+    }
+
+    #[test]
+    fn test_sign_verify_fail() {
+        // Generate public/private keypairs
+        let mut keypair = PKey::new();
+        let mut privkey = PKey::new();
+        let mut pubkey = PKey::new();
+        keypair.gen(1024);
+        privkey.load_priv(&keypair.save_priv()[..]);
+        pubkey.load_pub(&keypair.save_pub()[..]);
+
+        // generate some data
+        let data1: Vec<u8> = (0..25).cycle().take(1024).collect();
+        let data2: Vec<u8> = (100..150).cycle().take(1024 * 5).collect();
+
+        // sign some content with private key
+        let mut signer = Signer::new(hash::Type::SHA224, &privkey);
+        signer.update(&data1[..]);
+        signer.update(&data2[..]);
+        let signature = signer.sign();
+
+        // verify content using signature and public key
+        let mut verifier = Verifier::new(hash::Type::SHA224, &pubkey);
+        verifier.update(&data1[..]);
+        verifier.update(&data2[..]);
+
+        // NOTE: here we inject a few extra bytes.  This should make the signature
+        // check fail (the contents have been tampered with)
+        verifier.update(&[1, 2, 3]);
+        assert!(!verifier.verify(&signature[..]));
+    }
+}

--- a/openssl/src/crypto/signature.rs
+++ b/openssl/src/crypto/signature.rs
@@ -126,8 +126,9 @@ impl<'a> Signer<'a> {
 
 impl<'a> Write for Signer<'a> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-        try!(self.update(data));
-        Ok(data.len())
+        let len = ::std::cmp::min(data.len(), u32::max_value() as usize);
+        try!(self.update(&data[..len]));
+        Ok(len)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -203,8 +204,9 @@ impl<'a> Verifier<'a> {
 
 impl<'a> Write for Verifier<'a> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-        try!(self.update(data));
-        Ok(data.len())
+        let len = ::std::cmp::min(data.len(), u32::max_value() as usize);
+        try!(self.update(&data[..len]));
+        Ok(len)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -4,7 +4,7 @@ macro_rules! try_ssl_stream {
     ($e:expr) => (
         match $e {
             Ok(ok) => ok,
-            Err(err) => return Err(StreamError(err))
+            Err(err) => return Err($crate::ssl::error::StreamError(err))
         }
     )
 }
@@ -13,7 +13,7 @@ macro_rules! try_ssl_stream {
 macro_rules! try_ssl_if {
     ($e:expr) => (
         if $e {
-            return Err(SslError::get())
+            return Err($crate::ssl::error::SslError::get())
         }
     )
 }
@@ -28,7 +28,7 @@ macro_rules! try_ssl{
 macro_rules! try_ssl_null{
     ($e:expr) => ({
         let t = $e;
-        try_ssl_if!(t == ptr::null_mut());
+        try_ssl_if!(t == ::std::ptr::null_mut());
         t
     })
 }
@@ -45,7 +45,7 @@ macro_rules! try_ssl_null{
 macro_rules! lift_ssl_if{
     ($e:expr) => ( {
         if $e {
-            Err(SslError::get())
+            Err($crate::ssl::error::SslError::get())
         } else {
             Ok(())
         }

--- a/openssl/src/ssl/error.rs
+++ b/openssl/src/ssl/error.rs
@@ -234,6 +234,13 @@ impl From<SslError> for NonblockingSslError {
     }
 }
 
+// useful when implementing Io traits
+impl From<SslError> for io::Error {
+    fn from(e: SslError) -> io::Error {
+        io::Error::new(io::ErrorKind::Other, e)
+    }
+}
+
 /// An error from the OpenSSL library
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpensslError {

--- a/openssl/test/run.sh
+++ b/openssl/test/run.sh
@@ -4,7 +4,7 @@ set -e
 MAIN_TARGETS=https://static.rust-lang.org/dist
 
 if [ "$TEST_FEATURES" == "true" ]; then
-    FEATURES="tlsv1_2 tlsv1_1 dtlsv1 dtlsv1_2 sslv3 aes_xts aes_ctr npn alpn rfc5114 ecdh_auto pkcs5_pbkdf2_hmac"
+    FEATURES="tlsv1_2 tlsv1_1 dtlsv1 dtlsv1_2 sslv3 aes_xts aes_ctr npn alpn rfc5114 ecdh_auto pkcs5_pbkdf2_hmac signing"
 fi
 
 if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then


### PR DESCRIPTION
Previously, there was basic support for signing and verifying signatures on buffers in PKey.  This change exposes two new structs, `Signer` and `Verifier`, that allow for signatures to be more easily generated/verified when performing streaming operations.

For my initial use case, I am performing signature verification of the entire filesystem of an embedded device which cannot fit into RAM.