### PR TITLE
Set SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER flag

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -272,6 +272,7 @@ pub const SSL_CTRL_SET_TLSEXT_HOSTNAME: c_int = 55;
 pub const SSL_CTRL_EXTRA_CHAIN_CERT: c_int = 14;
 pub const SSL_CTRL_SET_READ_AHEAD: c_int = 41;
 
+pub const SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER: c_long = 2;
 pub const SSL_MODE_AUTO_RETRY: c_long = 4;
 
 pub const SSL_ERROR_NONE: c_int = 0;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -567,7 +567,7 @@ impl SslContext {
         let ctx = SslContext { ctx: ctx };
 
         // this is a bit dubious (?)
-        try!(ctx.set_mode(ffi::SSL_MODE_AUTO_RETRY));
+        try!(ctx.set_mode(ffi::SSL_MODE_AUTO_RETRY | ffi::SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER));
 
         if method.is_dtls() {
             ctx.set_read_ahead(1);


### PR DESCRIPTION
Hi,

Following on from https://github.com/hyperium/hyper/issues/872, this PR sets the [`SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER`](https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_mode.html) flag so that `SSL_write()` retries are accepted at a different pointer location (if the contents of the buffer are still the same).