### PR TITLE
Implement save_der for X509 and X509Req

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -841,6 +841,9 @@ extern "C" {
     pub fn X509_REQ_add_extensions(req: *mut X509_REQ, exts: *mut stack_st_X509_EXTENSION) -> c_int;
     pub fn X509_REQ_sign(x: *mut X509_REQ, pkey: *mut EVP_PKEY, md: *const EVP_MD) -> c_int;
 
+    pub fn i2d_X509_bio(b: *mut BIO, x: *mut X509) -> c_int;
+    pub fn i2d_X509_REQ_bio(b: *mut BIO, x: *mut X509_REQ) -> c_int;
+
     pub fn i2d_RSA_PUBKEY(k: *mut RSA, buf: *const *mut u8) -> c_int;
     pub fn d2i_RSA_PUBKEY(k: *const *mut RSA, buf: *const *const u8, len: c_uint) -> *mut RSA;
     pub fn i2d_RSAPrivateKey(k: *mut RSA, buf: *const *mut u8) -> c_int;

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -532,6 +532,17 @@ impl<'ctx> X509<'ctx> {
         }
         io::copy(&mut mem_bio, writer).map_err(StreamError).map(|_| ())
     }
+
+    /// Returns a DER serialized form of the certificate
+    pub fn save_der(&self) -> Result<Vec<u8>, SslError> {
+        let mut mem_bio = try!(MemBio::new());
+        unsafe {
+            ffi::i2d_X509_bio(mem_bio.get_handle(), self.handle);
+        }
+        let mut v = Vec::new();
+        try!(io::copy(&mut mem_bio, &mut v).map_err(StreamError));
+        Ok(v)
+    }
 }
 
 extern "C" {
@@ -636,6 +647,17 @@ impl X509Req {
             try_ssl!(ffi::PEM_write_bio_X509_REQ(mem_bio.get_handle(), self.handle));
         }
         io::copy(&mut mem_bio, writer).map_err(StreamError).map(|_| ())
+    }
+
+    /// Returns a DER serialized form of the CSR
+    pub fn save_der(&self) -> Result<Vec<u8>, SslError> {
+        let mut mem_bio = try!(MemBio::new());
+        unsafe {
+            ffi::i2d_X509_REQ_bio(mem_bio.get_handle(), self.handle);
+        }
+        let mut v = Vec::new();
+        try!(io::copy(&mut mem_bio, &mut v).map_err(StreamError));
+        Ok(v)
     }
 }
 

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -93,6 +93,19 @@ fn test_cert_loading() {
 }
 
 #[test]
+fn test_save_der() {
+    let cert_path = Path::new("test/cert.pem");
+    let mut file = File::open(&cert_path)
+                       .ok()
+                       .expect("Failed to open `test/cert.pem`");
+
+    let cert = X509::from_pem(&mut file).ok().expect("Failed to load PEM");
+
+    let der = cert.save_der().unwrap();
+    assert!(!der.is_empty());
+}
+
+#[test]
 fn test_subject_read_cn() {
     let cert_path = Path::new("test/cert.pem");
     let mut file = File::open(&cert_path)


### PR DESCRIPTION
Hi. I've been trying to write a letsencrypt client and I realized openssl crate doesn't support DER encoding for X509 and X509Req. I decided to implement this.

Test is a bit weak but save_der is working as intended.