### PR TITLE
Implement get_handle for X509Req

### DIFF
--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -611,6 +611,10 @@ impl X509Req {
         X509Req { handle: handle }
     }
 
+    pub fn get_handle(&self) -> *mut ffi::X509_REQ {
+        self.handle
+    }
+
     /// Reads CSR from PEM
     pub fn from_pem<R>(reader: &mut R) -> Result<X509Req, SslError>
         where R: Read


### PR DESCRIPTION
There is a `get_handle` function for X509.

This patch adds `get_handle` for X509, so I can implement my own #427 in my library.