### PR TITLE
Add more support for non-blocking DTLS sockets.

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -295,6 +295,9 @@ pub const SSL_CTRL_SET_TLSEXT_HOSTNAME: c_int = 55;
 pub const SSL_CTRL_EXTRA_CHAIN_CERT: c_int = 14;
 pub const SSL_CTRL_SET_READ_AHEAD: c_int = 41;
 
+pub const DTLS_CTRL_GET_TIMEOUT: c_int = 73;
+pub const DTLS_CTRL_HANDLE_TIMEOUT: c_int = 74;
+
 pub const SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER: c_long = 2;
 pub const SSL_MODE_AUTO_RETRY: c_long = 4;
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -18,6 +18,10 @@ use libc::{c_uchar, c_uint};
 #[cfg(any(feature = "npn", feature = "alpn"))]
 use std::slice;
 use std::marker::PhantomData;
+#[cfg(any(feature = "dtlsv1", feature = "dtlsv1_2"))]
+use std::time;
+#[cfg(any(feature = "dtlsv1", feature = "dtlsv1_2"))]
+use libc::timeval;
 
 use ffi;
 use ffi_extras;
@@ -1221,6 +1225,41 @@ impl<S> MidHandshakeSslStream<S> {
     /// Returns the underlying error which interrupted this handshake.
     pub fn error(&self) -> &Error {
         &self.error
+    }
+
+    /// Gets the next DTLS handshake timeout.
+    ///
+    /// This is intended to be used with a nonblocking socket, where the value
+    /// can be used to set timeouts on reading and performing handshakes.
+    ///
+    /// `handle_dtlsv1_timeout` should be called when the timeout expires to
+    /// ask OpenSSL to retransmit.
+    ///
+    /// This method requires either the `dtlsv1` or `dtlsv1_2` feature.
+    #[cfg(any(feature = "dtlsv1", feature = "dtlsv1_2"))]
+    pub fn get_dtlsv1_timeout(&mut self) -> Option<time::Duration> {
+        let mut timeout: timeval = unsafe { mem::zeroed() };
+        let ret = unsafe { ffi::SSL_ctrl(self.stream.ssl.ssl, ffi::DTLS_CTRL_GET_TIMEOUT, 0,
+                                         &mut timeout as *mut _ as *mut _) };
+        if ret > 0 {
+            Some(time::Duration::new(timeout.tv_sec as u64, (timeout.tv_usec * 1000) as u32))
+        } else {
+            None
+        }
+    }
+
+    /// Handles DTLS handshake timeout expiry.
+    ///
+    /// This should be called when the timeout from `get_dtlsv1_timeout`
+    /// expires, to retransmit the handshake.
+    ///
+    /// This method requires either the `dtlsv1` or `dtlsv1_2` feature.
+    #[cfg(any(feature = "dtlsv1", feature = "dtlsv1_2"))]
+    pub fn handle_dtlsv1_timeout(&mut self) -> Result<(), ErrorStack> {
+        wrap_ssl_result(unsafe {
+            ffi::SSL_ctrl(self.stream.ssl.ssl, ffi::DTLS_CTRL_HANDLE_TIMEOUT, 0,
+                          ptr::null_mut()) as i32
+        })
     }
 
     /// Restarts the handshake process.


### PR DESCRIPTION
This introduces two new methods on MidHandshakeSslStream:
- get_dtlsv1_timeout: Gets the next DTLS handshake timeout.
- handle_dtlsv1_timeout: Handles DTLS handshake timeout expiry.

This is against the breaks branch which contains MidHandshakeSslStream.
