### PR TITLE
Improve build script

### DIFF
--- a/openssl/test/build.sh
+++ b/openssl/test/build.sh
@@ -24,9 +24,10 @@ cd /tmp/openssl
 curl -o $OUT -L --max-redirs $MAX_REDIRECTS https://openssl.org/source/$OPENSSL \
   || curl -o $OUT -L --max-redirs ${MAX_REDIRECTS} http://mirrors.ibiblio.org/openssl/source/$OPENSSL
 
-echo "$SHA1 $OUT" | sha1sum -c - || exit 1
+echo "$SHA1  $OUT" | sha1sum -c -
 
 tar --strip-components=1 -xzf $OUT
+
 ./Configure --prefix=$HOME/openssl shared --cross-compile-prefix=$CROSS $OS_COMPILER
 make
 make install

--- a/openssl/test/build.sh
+++ b/openssl/test/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+MAX_REDIRECTS=5
+OPENSSL=openssl-1.0.2h.tar.gz
+OUT=/tmp/$OPENSSL
+SHA1="577585f5f5d299c44dd3c993d3c0ac7a219e4949"
+
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     exit 0
 fi
@@ -13,9 +18,15 @@ else
     OS_COMPILER=linux-x86_64
 fi
 
-mkdir /tmp/openssl
+mkdir -p /tmp/openssl
 cd /tmp/openssl
-curl https://openssl.org/source/openssl-1.0.2h.tar.gz | tar --strip-components=1 -xzf -
+
+curl -o $OUT -L --max-redirs $MAX_REDIRECTS https://openssl.org/source/$OPENSSL \
+  || curl -o $OUT -L --max-redirs ${MAX_REDIRECTS} http://mirrors.ibiblio.org/openssl/source/$OPENSSL
+
+echo "$SHA1 $OUT" | sha1sum -c - || exit 1
+
+tar --strip-components=1 -xzf $OUT
 ./Configure --prefix=$HOME/openssl shared --cross-compile-prefix=$CROSS $OS_COMPILER
 make
 make install


### PR DESCRIPTION
- try and fallback to a mirror when openssl.org is down
- check the sha1 of the downloaded tarball