### PR TITLE
Support OpenSSL conditional compilation

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -283,6 +283,7 @@ The build is now aborting due to this version mismatch.
 
         // Look for `#define OPENSSL_FOO`, print out everything as our own
         // #[cfg] flag.
+        let mut vars = vec![];
         for line in conf_header.lines() {
             let i = match line.find("define ") {
                 Some(i) => i,
@@ -291,8 +292,10 @@ The build is now aborting due to this version mismatch.
             let var = line[i + "define ".len()..].trim();
             if var.starts_with("OPENSSL") && !var.contains(" ") {
                 println!("cargo:rustc-cfg=osslconf=\"{}\"", var);
+                vars.push(var);
             }
         }
+        println!("cargo:osslconf={}", vars.join(","));
     }
 
     return version_text.to_string()

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -549,6 +549,7 @@ extern {
     pub fn OPENSSL_add_all_algorithms_noconf();
     pub fn HMAC_CTX_init(ctx: *mut ::HMAC_CTX);
     pub fn HMAC_CTX_cleanup(ctx: *mut ::HMAC_CTX);
+    #[cfg(not(osslconf = "OPENSSL_NO_SSL3_METHOD"))]
     pub fn SSLv3_method() -> *const ::SSL_METHOD;
     pub fn TLSv1_method() -> *const ::SSL_METHOD;
     pub fn SSLv23_method() -> *const ::SSL_METHOD;

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -31,6 +31,11 @@ fn main() {
     if env::var("DEP_OPENSSL_IS_110").is_ok() {
         cfg.cfg("ossl110", None);
     }
+    if let Ok(vars) = env::var("DEP_OPENSSL_OSSLCONF") {
+        for var in vars.split(",") {
+            cfg.cfg("osslconf", Some(var));
+        }
+    }
 
     cfg.header("openssl/comp.h")
        .header("openssl/dh.h")


### PR DESCRIPTION
I'm a bit conflicted as to how to handle the OPENSSL_NO_CONF case. There are 3 options I see:

* We remove the `Ssl::compression` method automatically when `OPENSSL_NO_CONF` is detected.
* We have people opt-in to compression with a Cargo feature.
* We have people opt-out of compression with a Cargo feature.

I went with option 3 for now. It's pretty rare to disable compression, and it's a breaking change if we discover that we've missed some other conditional API if we go the opt-in route. On the other hand, opt-out features aren't composable in the way that Cargo would like features to be. Option 1 might be the best approach, but it may be unclear as to why some methods aren't available.

We do have people opt-in to features from newer OpenSSL versions via Cargo features, for reference.

Thoughts, @alexcrichton?