### PR TITLE
Fix test_alpn_server_select_none

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -318,6 +318,18 @@ pub unsafe fn SSL_set_tlsext_host_name(s: *mut SSL, name: *mut c_char) -> c_long
              name as *mut c_void)
 }
 
+pub fn ERR_GET_LIB(l: c_ulong) -> c_int {
+    ((l >> 24) & 0x0FF) as c_int
+}
+
+pub fn ERR_GET_FUNC(l: c_ulong) -> c_int {
+    ((l >> 12) & 0xFFF) as c_int
+}
+
+pub fn ERR_GET_REASON(l: c_ulong) -> c_int {
+    (l & 0xFFF) as c_int
+}
+
 extern {
     pub fn ASN1_INTEGER_set(dest: *mut ASN1_INTEGER, value: c_long) -> c_int;
     pub fn ASN1_STRING_type_new(ty: c_int) -> *mut ASN1_STRING;


### PR DESCRIPTION
In OpenSSL 1.1, a failure to negotiate a protocol is a fatal error, so
fork that test. This also popped up an issue where we assumed all errors
had library, function, and reason strings which is not necessarily the
case.

While we're in here, adjust the Display impl to match what OpenSSL
prints out.

Closes #465