### PR TITLE
Turn enums into structs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ dist: trusty
 env:
   global:
     - TARGET=x86_64-unknown-linux-gnu
+    - BUILD_OPENSSL_VERSION=1.0.1u
 matrix:
   include:
     # ARM-bit version compat
@@ -44,7 +45,6 @@ matrix:
     - rust: nightly
 
     # 64-bit version compat
-    - env: BUILD_OPENSSL_VERSION=1.0.1u
     - env: BUILD_OPENSSL_VERSION=1.0.2h
     - env: BUILD_OPENSSL_VERSION=1.1.0b
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -110,6 +110,7 @@ pub const CRYPTO_LOCK: c_int = 1;
 pub const EVP_MAX_MD_SIZE: c_uint = 64;
 pub const EVP_PKEY_RSA: c_int = NID_rsaEncryption;
 pub const EVP_PKEY_HMAC: c_int = NID_hmac;
+pub const EVP_PKEY_DSA: c_int = NID_dsa;
 
 pub const MBSTRING_ASC:  c_int = MBSTRING_FLAG | 1;
 pub const MBSTRING_BMP:  c_int = MBSTRING_FLAG | 2;
@@ -120,6 +121,7 @@ pub const MBSTRING_UTF8: c_int = MBSTRING_FLAG;
 pub const NID_rsaEncryption: c_int = 6;
 pub const NID_ext_key_usage: c_int = 126;
 pub const NID_key_usage:     c_int = 83;
+pub const NID_dsa:           c_int = 116;
 pub const NID_hmac:          c_int = 855;
 
 pub const PKCS5_SALT_LEN: c_int = 8;

--- a/openssl/src/crypto/dsa.rs
+++ b/openssl/src/crypto/dsa.rs
@@ -2,16 +2,14 @@ use ffi;
 use std::fmt;
 use error::ErrorStack;
 use std::ptr;
-use libc::{c_uint, c_int, c_char, c_void};
+use libc::{c_int, c_char, c_void};
 
 use bn::BigNumRef;
 use bio::{MemBio, MemBioSlice};
-use crypto::hash;
-use HashTypeInternals;
 use crypto::util::{CallbackState, invoke_passwd_cb};
 
 
-/// Builder for upfront DSA parameter generateration
+/// Builder for upfront DSA parameter generation
 pub struct DSAParams(*mut ffi::DSA);
 
 impl DSAParams {
@@ -156,39 +154,6 @@ impl DSA {
         }
     }
 
-    pub fn sign(&self, hash: hash::Type, message: &[u8]) -> Result<Vec<u8>, ErrorStack> {
-        let k_len = self.size().expect("DSA missing a q") as c_uint;
-        let mut sig = vec![0; k_len as usize];
-        let mut sig_len = k_len;
-        assert!(self.has_private_key());
-
-        unsafe {
-            try_ssl!(ffi::DSA_sign(hash.as_nid() as c_int,
-                                   message.as_ptr(),
-                                   message.len() as c_int,
-                                   sig.as_mut_ptr(),
-                                   &mut sig_len,
-                                   self.0));
-            sig.set_len(sig_len as usize);
-            sig.shrink_to_fit();
-            Ok(sig)
-        }
-    }
-
-    pub fn verify(&self, hash: hash::Type, message: &[u8], sig: &[u8]) -> Result<bool, ErrorStack> {
-        unsafe {
-            let result = ffi::DSA_verify(hash.as_nid() as c_int,
-                                         message.as_ptr(),
-                                         message.len() as c_int,
-                                         sig.as_ptr(),
-                                         sig.len() as c_int,
-                                         self.0);
-
-            try_ssl_if!(result == -1);
-            Ok(result == 1)
-        }
-    }
-
     pub fn as_ptr(&self) -> *mut ffi::DSA {
         self.0
     }
@@ -282,76 +247,7 @@ mod test {
 
     #[test]
     pub fn test_generate() {
-        let key = DSA::generate(1024).unwrap();
-
-        key.public_key_to_pem().unwrap();
-        key.private_key_to_pem().unwrap();
-
-        let input: Vec<u8> = (0..25).cycle().take(1024).collect();
-
-        let digest = {
-            let mut sha = Hasher::new(Type::SHA1).unwrap();
-            sha.write_all(&input).unwrap();
-            sha.finish().unwrap()
-        };
-
-        let sig = key.sign(Type::SHA1, &digest).unwrap();
-        let verified = key.verify(Type::SHA1, &digest, &sig).unwrap();
-        assert!(verified);
-    }
-
-    #[test]
-    pub fn test_sign_verify() {
-        let input: Vec<u8> = (0..25).cycle().take(1024).collect();
-
-        let private_key = {
-            let key = include_bytes!("../../test/dsa.pem");
-            DSA::private_key_from_pem(key).unwrap()
-        };
-
-        let public_key = {
-            let key = include_bytes!("../../test/dsa.pem.pub");
-            DSA::public_key_from_pem(key).unwrap()
-        };
-
-        let digest = {
-            let mut sha = Hasher::new(Type::SHA1).unwrap();
-            sha.write_all(&input).unwrap();
-            sha.finish().unwrap()
-        };
-
-        let sig = private_key.sign(Type::SHA1, &digest).unwrap();
-        let verified = public_key.verify(Type::SHA1, &digest, &sig).unwrap();
-        assert!(verified);
-    }
-
-    #[test]
-    pub fn test_sign_verify_fail() {
-        let input: Vec<u8> = (0..25).cycle().take(128).collect();
-        let private_key = {
-            let key = include_bytes!("../../test/dsa.pem");
-            DSA::private_key_from_pem(key).unwrap()
-        };
-
-        let public_key = {
-            let key = include_bytes!("../../test/dsa.pem.pub");
-            DSA::public_key_from_pem(key).unwrap()
-        };
-
-        let digest = {
-            let mut sha = Hasher::new(Type::SHA1).unwrap();
-            sha.write_all(&input).unwrap();
-            sha.finish().unwrap()
-        };
-
-        let mut sig = private_key.sign(Type::SHA1, &digest).unwrap();
-        // tamper with the sig this should cause a failure
-        let len = sig.len();
-        sig[len / 2] = 0;
-        sig[len - 1] = 0;
-        if let Ok(true) = public_key.verify(Type::SHA1, &digest, &sig) {
-            panic!("Tampered with signatures should not verify!");
-        }
+        DSA::generate(1024).unwrap();
     }
 
     #[test]

--- a/openssl/src/crypto/pkcs12.rs
+++ b/openssl/src/crypto/pkcs12.rs
@@ -97,7 +97,7 @@ mod compat {
 
 #[cfg(test)]
 mod test {
-    use crypto::hash::Type::SHA1;
+    use crypto::hash::MessageDigest;
     use serialize::hex::ToHex;
 
     use super::*;
@@ -108,11 +108,11 @@ mod test {
         let pkcs12 = Pkcs12::from_der(der).unwrap();
         let parsed = pkcs12.parse("mypass").unwrap();
 
-        assert_eq!(parsed.cert.fingerprint(SHA1).unwrap().to_hex(),
+        assert_eq!(parsed.cert.fingerprint(MessageDigest::sha1()).unwrap().to_hex(),
                    "59172d9313e84459bcff27f967e79e6e9217e584");
 
         assert_eq!(parsed.chain.len(), 1);
-        assert_eq!(parsed.chain[0].fingerprint(SHA1).unwrap().to_hex(),
+        assert_eq!(parsed.chain[0].fingerprint(MessageDigest::sha1()).unwrap().to_hex(),
                    "c0cbdf7cdd03c9773e5468e1f6d2da7d5cbb1875");
     }
 }

--- a/openssl/src/crypto/pkcs5.rs
+++ b/openssl/src/crypto/pkcs5.rs
@@ -2,8 +2,7 @@ use libc::c_int;
 use std::ptr;
 use ffi;
 
-use HashTypeInternals;
-use crypto::hash;
+use crypto::hash::MessageDigest;
 use crypto::symm;
 use error::ErrorStack;
 
@@ -24,7 +23,7 @@ pub struct KeyIvPair {
 /// New applications should not use this and instead use `pbkdf2_hmac_sha1` or
 /// another more modern key derivation algorithm.
 pub fn evp_bytes_to_key_pbkdf1_compatible(typ: symm::Type,
-                                          message_digest_type: hash::Type,
+                                          message_digest_type: MessageDigest,
                                           data: &[u8],
                                           salt: Option<&[u8]>,
                                           count: u32)
@@ -41,7 +40,7 @@ pub fn evp_bytes_to_key_pbkdf1_compatible(typ: symm::Type,
         ffi::init();
 
         let typ = typ.as_ptr();
-        let message_digest_type = message_digest_type.evp_md();
+        let message_digest_type = message_digest_type.as_ptr();
 
         let len = ffi::EVP_BytesToKey(typ,
                                       message_digest_type,
@@ -97,7 +96,7 @@ pub fn pbkdf2_hmac_sha1(pass: &[u8],
 pub fn pbkdf2_hmac(pass: &[u8],
                    salt: &[u8],
                    iter: usize,
-                   hash: hash::Type,
+                   hash: MessageDigest,
                    keylen: usize)
                    -> Result<Vec<u8>, ErrorStack> {
     unsafe {
@@ -108,7 +107,7 @@ pub fn pbkdf2_hmac(pass: &[u8],
                                         salt.as_ptr(),
                                         salt.len() as c_int,
                                         iter as c_int,
-                                        hash.evp_md(),
+                                        hash.as_ptr(),
                                         keylen as c_int,
                                         out.as_mut_ptr()));
         Ok(out)
@@ -117,7 +116,7 @@ pub fn pbkdf2_hmac(pass: &[u8],
 
 #[cfg(test)]
 mod tests {
-    use crypto::hash;
+    use crypto::hash::MessageDigest;
     use crypto::symm;
 
     // Test vectors from
@@ -162,11 +161,11 @@ mod tests {
     // https://git.lysator.liu.se/nettle/nettle/blob/nettle_3.1.1_release_20150424/testsuite/pbkdf2-test.c
     #[test]
     fn test_pbkdf2_hmac_sha256() {
-        assert_eq!(super::pbkdf2_hmac(b"passwd", b"salt", 1, hash::Type::SHA256, 16).unwrap(),
+        assert_eq!(super::pbkdf2_hmac(b"passwd", b"salt", 1, MessageDigest::sha256(), 16).unwrap(),
                    vec![0x55_u8, 0xac_u8, 0x04_u8, 0x6e_u8, 0x56_u8, 0xe3_u8, 0x08_u8, 0x9f_u8,
                         0xec_u8, 0x16_u8, 0x91_u8, 0xc2_u8, 0x25_u8, 0x44_u8, 0xb6_u8, 0x05_u8]);
 
-        assert_eq!(super::pbkdf2_hmac(b"Password", b"NaCl", 80000, hash::Type::SHA256, 16).unwrap(),
+        assert_eq!(super::pbkdf2_hmac(b"Password", b"NaCl", 80000, MessageDigest::sha256(), 16).unwrap(),
                    vec![0x4d_u8, 0xdc_u8, 0xd8_u8, 0xf6_u8, 0x0b_u8, 0x98_u8, 0xbe_u8, 0x21_u8,
                         0x83_u8, 0x0c_u8, 0xee_u8, 0x5e_u8, 0xf2_u8, 0x27_u8, 0x01_u8, 0xf9_u8]);
     }
@@ -175,7 +174,7 @@ mod tests {
     // https://git.lysator.liu.se/nettle/nettle/blob/nettle_3.1.1_release_20150424/testsuite/pbkdf2-test.c
     #[test]
     fn test_pbkdf2_hmac_sha512() {
-        assert_eq!(super::pbkdf2_hmac(b"password", b"NaCL", 1, hash::Type::SHA512, 64).unwrap(),
+        assert_eq!(super::pbkdf2_hmac(b"password", b"NaCL", 1, MessageDigest::sha512(), 64).unwrap(),
                    vec![0x73_u8, 0xde_u8, 0xcf_u8, 0xa5_u8, 0x8a_u8, 0xa2_u8, 0xe8_u8, 0x4f_u8,
                         0x94_u8, 0x77_u8, 0x1a_u8, 0x75_u8, 0x73_u8, 0x6b_u8, 0xb8_u8, 0x8b_u8,
                         0xd3_u8, 0xc7_u8, 0xb3_u8, 0x82_u8, 0x70_u8, 0xcf_u8, 0xb5_u8, 0x0c_u8,
@@ -185,7 +184,7 @@ mod tests {
                         0x60_u8, 0x60_u8, 0xa0_u8, 0x9f_u8, 0x76_u8, 0x41_u8, 0x5e_u8, 0x9f_u8,
                         0x71_u8, 0xea_u8, 0x47_u8, 0xf9_u8, 0xe9_u8, 0x06_u8, 0x43_u8, 0x06_u8]);
 
-        assert_eq!(super::pbkdf2_hmac(b"pass\0word", b"sa\0lt", 1, hash::Type::SHA512, 64).unwrap(),
+        assert_eq!(super::pbkdf2_hmac(b"pass\0word", b"sa\0lt", 1, MessageDigest::sha512(), 64).unwrap(),
                    vec![0x71_u8, 0xa0_u8, 0xec_u8, 0x84_u8, 0x2a_u8, 0xbd_u8, 0x5c_u8, 0x67_u8,
                         0x8b_u8, 0xcf_u8, 0xd1_u8, 0x45_u8, 0xf0_u8, 0x9d_u8, 0x83_u8, 0x52_u8,
                         0x2f_u8, 0x93_u8, 0x36_u8, 0x15_u8, 0x60_u8, 0x56_u8, 0x3c_u8, 0x4d_u8,
@@ -198,7 +197,7 @@ mod tests {
         assert_eq!(super::pbkdf2_hmac(b"passwordPASSWORDpassword",
                                       b"salt\0\0\0",
                                       50,
-                                      hash::Type::SHA512,
+                                      MessageDigest::sha512(),
                                       64).unwrap(),
                    vec![0x01_u8, 0x68_u8, 0x71_u8, 0xa4_u8, 0xc4_u8, 0xb7_u8, 0x5f_u8, 0x96_u8,
                         0x85_u8, 0x7f_u8, 0xd2_u8, 0xb9_u8, 0xf8_u8, 0xca_u8, 0x28_u8, 0x02_u8,
@@ -230,7 +229,7 @@ mod tests {
                                0_u8, 0_u8, 0_u8];
 
         assert_eq!(super::evp_bytes_to_key_pbkdf1_compatible(symm::Type::AES_256_CBC,
-                                                             hash::Type::SHA1,
+                                                             MessageDigest::sha1(),
                                                              &data,
                                                              Some(&salt),
                                                              1).unwrap(),

--- a/openssl/src/crypto/pkey.rs
+++ b/openssl/src/crypto/pkey.rs
@@ -4,6 +4,7 @@ use std::mem;
 use ffi;
 
 use bio::{MemBio, MemBioSlice};
+use crypto::dsa::DSA;
 use crypto::rsa::RSA;
 use error::ErrorStack;
 use crypto::util::{CallbackState, invoke_passwd_cb};
@@ -22,6 +23,17 @@ impl PKey {
             let pkey = PKey(evp);
             try_ssl!(ffi::EVP_PKEY_assign(pkey.0, ffi::EVP_PKEY_RSA, rsa.as_ptr() as *mut _));
             mem::forget(rsa);
+            Ok(pkey)
+        }
+    }
+
+    /// Create a new `PKey` containing a DSA key.
+    pub fn from_dsa(dsa: DSA) -> Result<PKey, ErrorStack> {
+        unsafe {
+            let evp = try_ssl_null!(ffi::EVP_PKEY_new());
+            let pkey = PKey(evp);
+            try_ssl!(ffi::EVP_PKEY_assign(pkey.0, ffi::EVP_PKEY_DSA, dsa.as_ptr() as *mut _));
+            mem::forget(dsa);
             Ok(pkey)
         }
     }

--- a/openssl/src/crypto/symm.rs
+++ b/openssl/src/crypto/symm.rs
@@ -11,57 +11,120 @@ pub enum Mode {
     Decrypt,
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
-pub enum Type {
-    AES_128_ECB,
-    AES_128_CBC,
-    AES_128_XTS,
-    AES_128_CTR,
-    AES_128_CFB1,
-    AES_128_CFB128,
-    AES_128_CFB8,
-    AES_256_ECB,
-    AES_256_CBC,
-    AES_256_XTS,
-    AES_256_CTR,
-    AES_256_CFB1,
-    AES_256_CFB128,
-    AES_256_CFB8,
-    DES_CBC,
-    DES_ECB,
-    RC4_128,
-}
+pub struct Cipher(*const ffi::EVP_CIPHER);
 
-impl Type {
-    pub fn as_ptr(&self) -> *const ffi::EVP_CIPHER {
+impl Cipher {
+    pub fn aes_128_ecb() -> Cipher {
         unsafe {
-            match *self {
-                Type::AES_128_ECB => ffi::EVP_aes_128_ecb(),
-                Type::AES_128_CBC => ffi::EVP_aes_128_cbc(),
-                Type::AES_128_XTS => ffi::EVP_aes_128_xts(),
-                Type::AES_128_CTR => ffi::EVP_aes_128_ctr(),
-                Type::AES_128_CFB1 => ffi::EVP_aes_128_cfb1(),
-                Type::AES_128_CFB128 => ffi::EVP_aes_128_cfb128(),
-                Type::AES_128_CFB8 => ffi::EVP_aes_128_cfb8(),
-                Type::AES_256_ECB => ffi::EVP_aes_256_ecb(),
-                Type::AES_256_CBC => ffi::EVP_aes_256_cbc(),
-                Type::AES_256_XTS => ffi::EVP_aes_256_xts(),
-                Type::AES_256_CTR => ffi::EVP_aes_256_ctr(),
-                Type::AES_256_CFB1 => ffi::EVP_aes_256_cfb1(),
-                Type::AES_256_CFB128 => ffi::EVP_aes_256_cfb128(),
-                Type::AES_256_CFB8 => ffi::EVP_aes_256_cfb8(),
-                Type::DES_CBC => ffi::EVP_des_cbc(),
-                Type::DES_ECB => ffi::EVP_des_ecb(),
-                Type::RC4_128 => ffi::EVP_rc4(),
-            }
+            Cipher(ffi::EVP_aes_128_ecb())
         }
+    }
+
+    pub fn aes_128_cbc() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_128_cbc())
+        }
+    }
+
+    pub fn aes_128_xts() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_128_xts())
+        }
+    }
+
+    pub fn aes_128_ctr() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_128_ctr())
+        }
+    }
+
+    pub fn aes_128_cfb1() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_128_cfb1())
+        }
+    }
+
+    pub fn aes_128_cfb128() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_128_cfb128())
+        }
+    }
+
+    pub fn aes_128_cfb8() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_128_cfb8())
+        }
+    }
+
+    pub fn aes_256_ecb() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_256_ecb())
+        }
+    }
+
+    pub fn aes_256_cbc() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_256_cbc())
+        }
+    }
+
+    pub fn aes_256_xts() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_256_xts())
+        }
+    }
+
+    pub fn aes_256_ctr() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_256_ctr())
+        }
+    }
+
+    pub fn aes_256_cfb1() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_256_cfb1())
+        }
+    }
+
+    pub fn aes_256_cfb128() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_256_cfb128())
+        }
+    }
+
+    pub fn aes_256_cfb8() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_aes_256_cfb8())
+        }
+    }
+
+    pub fn des_cbc() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_des_cbc())
+        }
+    }
+
+    pub fn des_ecb() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_des_ecb())
+        }
+    }
+
+    pub fn rc4() -> Cipher {
+        unsafe {
+            Cipher(ffi::EVP_rc4())
+        }
+    }
+
+    pub fn as_ptr(&self) -> *const ffi::EVP_CIPHER {
+        self.0
     }
 
     /// Returns the length of keys used with this cipher.
     pub fn key_len(&self) -> usize {
         unsafe {
-            EVP_CIPHER_key_length(self.as_ptr()) as usize
+            EVP_CIPHER_key_length(self.0) as usize
         }
     }
 
@@ -69,7 +132,7 @@ impl Type {
     /// cipher does not use an IV.
     pub fn iv_len(&self) -> Option<usize> {
         unsafe {
-            let len = EVP_CIPHER_iv_length(self.as_ptr()) as usize;
+            let len = EVP_CIPHER_iv_length(self.0) as usize;
             if len == 0 {
                 None
             } else {
@@ -85,7 +148,7 @@ impl Type {
     /// Stream ciphers such as RC4 have a block size of 1.
     pub fn block_size(&self) -> usize {
         unsafe {
-            EVP_CIPHER_block_size(self.as_ptr()) as usize
+            EVP_CIPHER_block_size(self.0) as usize
         }
     }
 }
@@ -102,8 +165,8 @@ impl Crypter {
     /// # Panics
     ///
     /// Panics if an IV is required by the cipher but not provided, or if the
-    /// IV's length does not match the expected length (see `Type::iv_len`).
-    pub fn new(t: Type, mode: Mode, key: &[u8], iv: Option<&[u8]>) -> Result<Crypter, ErrorStack> {
+    /// IV's length does not match the expected length (see `Cipher::iv_len`).
+    pub fn new(t: Cipher, mode: Mode, key: &[u8], iv: Option<&[u8]>) -> Result<Crypter, ErrorStack> {
         ffi::init();
 
         unsafe {
@@ -165,7 +228,7 @@ impl Crypter {
     /// # Panics
     ///
     /// Panics if `output.len() < input.len() + block_size` where
-    /// `block_size` is the block size of the cipher (see `Type::block_size`),
+    /// `block_size` is the block size of the cipher (see `Cipher::block_size`),
     /// or if `output.len() > c_int::max_value()`.
     pub fn update(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize, ErrorStack> {
         unsafe {
@@ -218,7 +281,7 @@ impl Drop for Crypter {
  * Encrypts data, using the specified crypter type in encrypt mode with the
  * specified key and iv; returns the resulting (encrypted) data.
  */
-pub fn encrypt(t: Type,
+pub fn encrypt(t: Cipher,
                key: &[u8],
                iv: Option<&[u8]>,
                data: &[u8])
@@ -230,7 +293,7 @@ pub fn encrypt(t: Type,
  * Decrypts data, using the specified crypter type in decrypt mode with the
  * specified key and iv; returns the resulting (decrypted) data.
  */
-pub fn decrypt(t: Type,
+pub fn decrypt(t: Cipher,
                key: &[u8],
                iv: Option<&[u8]>,
                data: &[u8])
@@ -238,7 +301,7 @@ pub fn decrypt(t: Type,
     cipher(t, Mode::Decrypt, key, iv, data)
 }
 
-fn cipher(t: Type,
+fn cipher(t: Cipher,
           mode: Mode,
           key: &[u8],
           iv: Option<&[u8]>,
@@ -292,23 +355,23 @@ mod tests {
                   0xaau8, 0xbbu8, 0xccu8, 0xddu8, 0xeeu8, 0xffu8];
         let c0 = [0x8eu8, 0xa2u8, 0xb7u8, 0xcau8, 0x51u8, 0x67u8, 0x45u8, 0xbfu8, 0xeau8, 0xfcu8,
                   0x49u8, 0x90u8, 0x4bu8, 0x49u8, 0x60u8, 0x89u8];
-        let mut c = super::Crypter::new(super::Type::AES_256_ECB,
+        let mut c = super::Crypter::new(super::Cipher::aes_256_ecb(),
                                         super::Mode::Encrypt,
                                         &k0,
                                         None).unwrap();
         c.pad(false);
-        let mut r0 = vec![0; c0.len() + super::Type::AES_256_ECB.block_size()];
+        let mut r0 = vec![0; c0.len() + super::Cipher::aes_256_ecb().block_size()];
         let count = c.update(&p0, &mut r0).unwrap();
         let rest = c.finalize(&mut r0[count..]).unwrap();
         r0.truncate(count + rest);
         assert_eq!(r0.to_hex(), c0.to_hex());
 
-        let mut c = super::Crypter::new(super::Type::AES_256_ECB,
+        let mut c = super::Crypter::new(super::Cipher::aes_256_ecb(),
                                         super::Mode::Decrypt,
                                         &k0,
                                         None).unwrap();
         c.pad(false);
-        let mut p1 = vec![0; r0.len() + super::Type::AES_256_ECB.block_size()];
+        let mut p1 = vec![0; r0.len() + super::Cipher::aes_256_ecb().block_size()];
         let count = c.update(&r0, &mut p1).unwrap();
         let rest = c.finalize(&mut p1[count..]).unwrap();
         p1.truncate(count + rest);
@@ -326,12 +389,12 @@ mod tests {
         let ciphered_data = [0x4a_u8, 0x2e_u8, 0xe5_u8, 0x6_u8, 0xbf_u8, 0xcf_u8, 0xf2_u8,
                              0xd7_u8, 0xea_u8, 0x2d_u8, 0xb1_u8, 0x85_u8, 0x6c_u8, 0x93_u8,
                              0x65_u8, 0x6f_u8];
-        let mut cr = super::Crypter::new(super::Type::AES_256_CBC,
+        let mut cr = super::Crypter::new(super::Cipher::aes_256_cbc(),
                                          super::Mode::Decrypt,
                                          &data,
                                          Some(&iv)).unwrap();
         cr.pad(false);
-        let mut unciphered_data = vec![0; data.len() + super::Type::AES_256_CBC.block_size()];
+        let mut unciphered_data = vec![0; data.len() + super::Cipher::aes_256_cbc().block_size()];
         let count = cr.update(&ciphered_data, &mut unciphered_data).unwrap();
         let rest = cr.finalize(&mut unciphered_data[count..]).unwrap();
         unciphered_data.truncate(count + rest);
@@ -341,7 +404,7 @@ mod tests {
         assert_eq!(&unciphered_data, expected_unciphered_data);
     }
 
-    fn cipher_test(ciphertype: super::Type, pt: &str, ct: &str, key: &str, iv: &str) {
+    fn cipher_test(ciphertype: super::Cipher, pt: &str, ct: &str, key: &str, iv: &str) {
         use serialize::hex::ToHex;
 
         let pt = pt.from_hex().unwrap();
@@ -372,7 +435,7 @@ mod tests {
         let key = "97CD440324DA5FD1F7955C1C13B6B466";
         let iv = "";
 
-        cipher_test(super::Type::RC4_128, pt, ct, key, iv);
+        cipher_test(super::Cipher::rc4(), pt, ct, key, iv);
     }
 
     #[test]
@@ -387,7 +450,7 @@ mod tests {
                    4180026ad640b74243b3133e7b9fae629403f6733423dae28";
         let iv = "db200efb7eaaa737dbdf40babb68953f";
 
-        cipher_test(super::Type::AES_256_XTS, pt, ct, key, iv);
+        cipher_test(super::Cipher::aes_256_xts(), pt, ct, key, iv);
     }
 
     #[test]
@@ -400,7 +463,7 @@ mod tests {
         let key = "2B7E151628AED2A6ABF7158809CF4F3C";
         let iv = "F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF";
 
-        cipher_test(super::Type::AES_128_CTR, pt, ct, key, iv);
+        cipher_test(super::Cipher::aes_128_ctr(), pt, ct, key, iv);
     }
 
     #[test]
@@ -412,7 +475,7 @@ mod tests {
         let key = "2b7e151628aed2a6abf7158809cf4f3c";
         let iv = "000102030405060708090a0b0c0d0e0f";
 
-        cipher_test(super::Type::AES_128_CFB1, pt, ct, key, iv);
+        cipher_test(super::Cipher::aes_128_cfb1(), pt, ct, key, iv);
     }
 
     #[test]
@@ -423,7 +486,7 @@ mod tests {
         let key = "2b7e151628aed2a6abf7158809cf4f3c";
         let iv = "000102030405060708090a0b0c0d0e0f";
 
-        cipher_test(super::Type::AES_128_CFB128, pt, ct, key, iv);
+        cipher_test(super::Cipher::aes_128_cfb128(), pt, ct, key, iv);
     }
 
     #[test]
@@ -434,7 +497,7 @@ mod tests {
         let key = "2b7e151628aed2a6abf7158809cf4f3c";
         let iv = "000102030405060708090a0b0c0d0e0f";
 
-        cipher_test(super::Type::AES_128_CFB8, pt, ct, key, iv);
+        cipher_test(super::Cipher::aes_128_cfb8(), pt, ct, key, iv);
     }
 
     #[test]
@@ -445,7 +508,7 @@ mod tests {
         let key = "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4";
         let iv = "000102030405060708090a0b0c0d0e0f";
 
-        cipher_test(super::Type::AES_256_CFB1, pt, ct, key, iv);
+        cipher_test(super::Cipher::aes_256_cfb1(), pt, ct, key, iv);
     }
 
     #[test]
@@ -456,7 +519,7 @@ mod tests {
         let key = "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4";
         let iv = "000102030405060708090a0b0c0d0e0f";
 
-        cipher_test(super::Type::AES_256_CFB128, pt, ct, key, iv);
+        cipher_test(super::Cipher::aes_256_cfb128(), pt, ct, key, iv);
     }
 
     #[test]
@@ -467,7 +530,7 @@ mod tests {
         let key = "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4";
         let iv = "000102030405060708090a0b0c0d0e0f";
 
-        cipher_test(super::Type::AES_256_CFB8, pt, ct, key, iv);
+        cipher_test(super::Cipher::aes_256_cfb8(), pt, ct, key, iv);
     }
 
     #[test]
@@ -478,7 +541,7 @@ mod tests {
         let key = "7cb66337f3d3c0fe";
         let iv = "0001020304050607";
 
-        cipher_test(super::Type::DES_CBC, pt, ct, key, iv);
+        cipher_test(super::Cipher::des_cbc(), pt, ct, key, iv);
     }
 
     #[test]
@@ -489,6 +552,6 @@ mod tests {
         let key = "7cb66337f3d3c0fe";
         let iv = "0001020304050607";
 
-        cipher_test(super::Type::DES_ECB, pt, ct, key, iv);
+        cipher_test(super::Cipher::des_ecb(), pt, ct, key, iv);
     }
 }

--- a/openssl/src/dh/mod.rs
+++ b/openssl/src/dh/mod.rs
@@ -88,13 +88,12 @@ mod compat {
 mod tests {
     use super::DH;
     use bn::BigNum;
-    use ssl::SslContext;
-    use ssl::SslMethod::Tls;
+    use ssl::{SslMethod, SslContext};
 
     #[test]
     #[cfg(feature = "openssl-102")]
     fn test_dh_rfc5114() {
-        let mut ctx = SslContext::new(Tls).unwrap();
+        let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
         let dh1 = DH::get_1024_160().unwrap();
         ctx.set_tmp_dh(&dh1).unwrap();
         let dh2 = DH::get_2048_224().unwrap();
@@ -105,7 +104,7 @@ mod tests {
 
     #[test]
     fn test_dh() {
-        let mut ctx = SslContext::new(Tls).unwrap();
+        let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
         let p = BigNum::from_hex_str("87A8E61DB4B6663CFFBBD19C651959998CEEF608660DD0F25D2CEED4435\
                                       E3B00E00DF8F1D61957D4FAF7DF4561B2AA3016C3D91134096FAA3BF429\
                                       6D830E9A7C209E0C6497517ABD5A8A9D306BCF67ED91F9E6725B4758C02\
@@ -135,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_dh_from_pem() {
-        let mut ctx = SslContext::new(Tls).unwrap();
+        let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
         let params = include_bytes!("../../test/dhparams.pem");
         let dh = DH::from_pem(params).ok().expect("Failed to load PEM");
         ctx.set_tmp_dh(&dh).unwrap();

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -16,8 +16,6 @@ extern crate tempdir;
 #[doc(inline)]
 pub use ffi::init;
 
-use nid::Nid;
-
 mod macros;
 
 pub mod asn1;
@@ -30,8 +28,3 @@ pub mod nid;
 pub mod ssl;
 pub mod version;
 pub mod x509;
-
-trait HashTypeInternals {
-    fn as_nid(&self) -> Nid;
-    fn evp_md(&self) -> *const ffi::EVP_MD;
-}

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -407,9 +407,9 @@ impl<'a> SslContextRef<'a> {
         }
     }
 
-    pub fn set_read_ahead(&mut self, m: u32) {
+    pub fn set_read_ahead(&mut self, read_ahead: bool) {
         unsafe {
-            ffi::SSL_CTX_set_read_ahead(self.as_ptr(), m as c_long);
+            ffi::SSL_CTX_set_read_ahead(self.as_ptr(), read_ahead as c_long);
         }
     }
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -76,13 +76,29 @@ bitflags! {
     }
 }
 
-/// Determines the SSL method supported
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum SslMethod {
-    /// Support the TLS protocol
-    Tls,
-    /// Support DTLS protocol
-    Dtls,
+#[derive(Copy, Clone)]
+pub struct SslMethod(*const ffi::SSL_METHOD);
+
+impl SslMethod {
+    /// Support all versions of the TLS protocol.
+    ///
+    /// This corresponds to `TLS_method` on OpenSSL 1.1.0 and `SSLv23_method`
+    /// on OpenSSL 1.0.x.
+    pub fn tls() -> SslMethod {
+        SslMethod(compat::tls_method())
+    }
+
+    /// Support all versions of the DTLS protocol.
+    ///
+    /// This corresponds to `DTLS_method` on OpenSSL 1.1.0 and `DTLSv1_method`
+    /// on OpenSSL 1.0.x.
+    pub fn dtls() -> SslMethod {
+        SslMethod(compat::dtls_method())
+    }
+
+    pub fn as_ptr(&self) -> *const ffi::SSL_METHOD {
+        self.0
+    }
 }
 
 /// Determines the type of certificate verification used
@@ -653,15 +669,10 @@ impl SslContext {
         init();
 
         let mut ctx = unsafe {
-            let method = compat::get_method(method);
-            let ctx = try_ssl_null!(ffi::SSL_CTX_new(method));
+            let ctx = try_ssl_null!(ffi::SSL_CTX_new(method.as_ptr()));
             SslContext::from_ptr(ctx)
         };
 
-        match method {
-            SslMethod::Dtls => ctx.set_read_ahead(1),
-            _ => {}
-        }
         // this is a bit dubious (?)
         try!(ctx.set_mode(ffi::SSL_MODE_AUTO_RETRY | ffi::SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER));
 
@@ -1374,8 +1385,6 @@ mod compat {
     pub use ffi::{SSL_CTX_get_options, SSL_CTX_set_options};
     pub use ffi::{SSL_CTX_clear_options, SSL_CTX_up_ref};
 
-    use super::SslMethod;
-
     pub unsafe fn get_new_idx(f: ffi::CRYPTO_EX_free) -> c_int {
         ffi::CRYPTO_get_ex_new_index(ffi::CRYPTO_EX_INDEX_SSL_CTX,
                                      0,
@@ -1394,10 +1403,15 @@ mod compat {
                                      Some(f))
     }
 
-    pub unsafe fn get_method(method: SslMethod) -> *const ffi::SSL_METHOD {
-        match method {
-            SslMethod::Tls => ffi::TLS_method(),
-            SslMethod::Dtls => ffi::DTLS_method(),
+    pub fn tls_method() -> *const ffi::SSL_METHOD {
+        unsafe {
+            ffi::TLS_method()
+        }
+    }
+
+    pub fn dtls_method() -> *const ffi::SSL_METHOD {
+        unsafe {
+            ffi::DTLS_method()
         }
     }
 }
@@ -1409,8 +1423,6 @@ mod compat {
 
     use ffi;
     use libc::{self, c_long, c_ulong, c_int};
-
-    use super::SslMethod;
 
     pub unsafe fn SSL_CTX_get_options(ctx: *const ffi::SSL_CTX) -> c_ulong {
         ffi::SSL_CTX_ctrl(ctx as *mut _,
@@ -1451,13 +1463,6 @@ mod compat {
                                   Some(f))
     }
 
-    pub unsafe fn get_method(method: SslMethod) -> *const ffi::SSL_METHOD {
-        match method {
-            SslMethod::Tls => ffi::SSLv23_method(),
-            SslMethod::Dtls => ffi::DTLSv1_method(),
-        }
-    }
-
     pub unsafe fn SSL_CTX_up_ref(ssl: *mut ffi::SSL_CTX) -> libc::c_int {
         ffi::CRYPTO_add_lock(&mut (*ssl).references,
                              1,
@@ -1465,5 +1470,17 @@ mod compat {
                              "mod.rs\0".as_ptr() as *const _,
                              line!() as libc::c_int);
         0
+    }
+
+    pub fn tls_method() -> *const ffi::SSL_METHOD {
+        unsafe {
+            ffi::SSLv23_method()
+        }
+    }
+
+    pub fn dtls_method() -> *const ffi::SSL_METHOD {
+        unsafe {
+            ffi::DTLSv1_method()
+        }
     }
 }

--- a/openssl/src/ssl/tests/mod.rs
+++ b/openssl/src/ssl/tests/mod.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use tempdir::TempDir;
 
-use crypto::hash::Type::SHA256;
+use crypto::hash::MessageDigest;
 use ssl;
 use ssl::SSL_VERIFY_PEER;
 use ssl::SslMethod::Tls;
@@ -171,7 +171,7 @@ macro_rules! run_test(
             use ssl::SslMethod;
             use ssl::{SslContext, Ssl, SslStream};
             use ssl::SSL_VERIFY_PEER;
-            use crypto::hash::Type::{SHA1, SHA256};
+            use crypto::hash::MessageDigest;
             use x509::X509StoreContext;
             use serialize::hex::FromHex;
             use super::Server;
@@ -314,7 +314,7 @@ run_test!(verify_callback_data, |method, stream| {
         match cert {
             None => false,
             Some(cert) => {
-                let fingerprint = cert.fingerprint(SHA1).unwrap();
+                let fingerprint = cert.fingerprint(MessageDigest::sha1()).unwrap();
                 fingerprint == node_id
             }
         }
@@ -343,7 +343,7 @@ run_test!(ssl_verify_callback, |method, stream| {
         match x509.current_cert() {
             None => false,
             Some(cert) => {
-                let fingerprint = cert.fingerprint(SHA1).unwrap();
+                let fingerprint = cert.fingerprint(MessageDigest::sha1()).unwrap();
                 fingerprint == node_id
             }
         }
@@ -440,7 +440,7 @@ fn test_write_direct() {
 run_test!(get_peer_certificate, |method, stream| {
     let stream = SslStream::connect(&SslContext::new(method).unwrap(), stream).unwrap();
     let cert = stream.ssl().peer_certificate().unwrap();
-    let fingerprint = cert.fingerprint(SHA1).unwrap();
+    let fingerprint = cert.fingerprint(MessageDigest::sha1()).unwrap();
     let node_hash_str = "59172d9313e84459bcff27f967e79e6e9217e584";
     let node_id = node_hash_str.from_hex().unwrap();
     assert_eq!(node_id, fingerprint)
@@ -797,7 +797,7 @@ mod dtlsv1 {
     use std::net::TcpStream;
     use std::thread;
 
-    use crypto::hash::Type::SHA256;
+    use crypto::hash::MessageDigest;
     use ssl::SslMethod;
     use ssl::SslMethod::Dtls;
     use ssl::{SslContext, SslStream};

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -1,6 +1,6 @@
 use serialize::hex::FromHex;
 
-use crypto::hash::Type::SHA1;
+use crypto::hash::MessageDigest;
 use crypto::pkey::PKey;
 use crypto::rsa::RSA;
 use x509::{X509, X509Generator};
@@ -14,7 +14,7 @@ fn get_generator() -> X509Generator {
     X509Generator::new()
         .set_valid_period(365 * 2)
         .add_name("CN".to_string(), "test_me".to_string())
-        .set_sign_hash(SHA1)
+        .set_sign_hash(MessageDigest::sha1())
         .add_extension(KeyUsage(vec![DigitalSignature, KeyEncipherment]))
         .add_extension(ExtKeyUsage(vec![ClientAuth,
                                         ServerAuth,
@@ -83,7 +83,7 @@ fn test_req_gen() {
 fn test_cert_loading() {
     let cert = include_bytes!("../../test/cert.pem");
     let cert = X509::from_pem(cert).ok().expect("Failed to load PEM");
-    let fingerprint = cert.fingerprint(SHA1).unwrap();
+    let fingerprint = cert.fingerprint(MessageDigest::sha1()).unwrap();
 
     let hash_str = "59172d9313e84459bcff27f967e79e6e9217e584";
     let hash_vec = hash_str.from_hex().unwrap();


### PR DESCRIPTION
We never need to match on these things, and having them as wrapper structs makes it easier to enable extension traits, or lookup by string.