### PR TITLE
Implement new feature setup

### DIFF
--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -12,8 +12,9 @@ build = "build.rs"
 exclude = ["test/*"]
 
 [features]
-openssl-102 = []
-openssl-110 = ["openssl-102"]
+v101 = []
+v102 = []
+v110 = []
 
 [dependencies]
 bitflags = "0.7"

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -4,20 +4,17 @@ fn main() {
     if env::var("DEP_OPENSSL_IS_110").is_ok() {
         println!("cargo:rustc-cfg=ossl110");
         return;
-    } else if cfg!(feature = "openssl-110") {
-        panic!("the openssl-110 feature is enabled but OpenSSL 1.1.0+ is not being linked against");
-    }
-    if env::var("DEP_OPENSSL_IS_102").is_ok() {
+    } else if env::var("DEP_OPENSSL_IS_102").is_ok() {
         println!("cargo:rustc-cfg=ossl102");
         println!("cargo:rustc-cfg=ossl10x");
         return;
-    } else if cfg!(feature = "openssl-102") {
-        panic!("the openssl-102 feature is enabled but OpenSSL 1.0.2+")
-    }
-    if env::var("DEP_OPENSSL_IS_101").is_ok() {
+    } else if env::var("DEP_OPENSSL_IS_101").is_ok() {
         println!("cargo:rustc-cfg=ossl101");
         println!("cargo:rustc-cfg=ossl10x");
+    } else {
+        panic!("Unable to detect OpenSSL version");
     }
+
     if let Ok(vars) = env::var("DEP_OPENSSL_OSSLCONF") {
         for var in vars.split(",") {
             println!("cargo:rustc-cfg=osslconf=\"{}\"", var);

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -33,21 +33,24 @@ impl DH {
         }
     }
 
-    #[cfg(feature = "openssl-102")]
+    /// Requires the `v102` or `v110` features and OpenSSL 1.0.2 or OpenSSL 1.1.0.
+    #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
     pub fn get_1024_160() -> Result<DH, ErrorStack> {
         unsafe {
             cvt_p(ffi::DH_get_1024_160()).map(DH)
         }
     }
 
-    #[cfg(feature = "openssl-102")]
+    /// Requires the `v102` or `v110` features and OpenSSL 1.0.2 or OpenSSL 1.1.0.
+    #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
     pub fn get_2048_224() -> Result<DH, ErrorStack> {
         unsafe {
             cvt_p(ffi::DH_get_2048_224()).map(DH)
         }
     }
 
-    #[cfg(feature = "openssl-102")]
+    /// Requires the `v102` or `v110` features and OpenSSL 1.0.2 or OpenSSL 1.1.0.
+    #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
     pub fn get_2048_256() -> Result<DH, ErrorStack> {
         unsafe {
             cvt_p(ffi::DH_get_2048_256()).map(DH)
@@ -96,7 +99,7 @@ mod tests {
     use ssl::{SslMethod, SslContext};
 
     #[test]
-    #[cfg(feature = "openssl-102")]
+    #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
     fn test_dh_rfc5114() {
         let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
         let dh1 = DH::get_1024_160().unwrap();

--- a/openssl/src/ssl/tests/mod.rs
+++ b/openssl/src/ssl/tests/mod.rs
@@ -20,12 +20,12 @@ use ssl::SSL_VERIFY_PEER;
 use ssl::{SslMethod, HandshakeError};
 use ssl::error::Error;
 use ssl::{SslContext, SslStream};
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 use ssl::IntoSsl;
 use x509::X509StoreContext;
 use x509::X509FileType;
 use x509::X509;
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 use x509::verify::X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS;
 use crypto::pkey::PKey;
 
@@ -509,7 +509,7 @@ fn test_state() {
 /// Tests that connecting with the client using ALPN, but the server not does not
 /// break the existing connection behavior.
 #[test]
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 fn test_connect_with_unilateral_alpn() {
     let (_s, stream) = Server::new();
     let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
@@ -552,7 +552,7 @@ fn test_connect_with_unilateral_npn() {
 /// Tests that when both the client as well as the server use ALPN and their
 /// lists of supported protocols have an overlap, the correct protocol is chosen.
 #[test]
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 fn test_connect_with_alpn_successful_multiple_matching() {
     let (_s, stream) = Server::new_alpn();
     let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
@@ -574,7 +574,7 @@ fn test_connect_with_alpn_successful_multiple_matching() {
 /// Tests that when both the client as well as the server use NPN and their
 /// lists of supported protocols have an overlap, the correct protocol is chosen.
 #[test]
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 fn test_connect_with_npn_successful_multiple_matching() {
     let (_s, stream) = Server::new_alpn();
     let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
@@ -597,7 +597,7 @@ fn test_connect_with_npn_successful_multiple_matching() {
 /// lists of supported protocols have an overlap -- with only ONE protocol
 /// being valid for both.
 #[test]
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 fn test_connect_with_alpn_successful_single_match() {
     let (_s, stream) = Server::new_alpn();
     let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
@@ -621,7 +621,7 @@ fn test_connect_with_alpn_successful_single_match() {
 /// lists of supported protocols have an overlap -- with only ONE protocol
 /// being valid for both.
 #[test]
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 fn test_connect_with_npn_successful_single_match() {
     let (_s, stream) = Server::new_alpn();
     let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
@@ -683,7 +683,7 @@ fn test_npn_server_advertise_multiple() {
 /// Tests that when the `SslStream` is created as a server stream, the protocols
 /// are correctly advertised to the client.
 #[test]
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 fn test_alpn_server_advertise_multiple() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let localhost = listener.local_addr().unwrap();
@@ -724,7 +724,7 @@ fn test_alpn_server_advertise_multiple() {
 /// Test that Servers supporting ALPN don't report a protocol when none of their protocols match
 /// the client's reported protocol.
 #[test]
-#[cfg(all(feature = "openssl-102", ossl102))]
+#[cfg(all(feature = "v102", ossl102))]
 fn test_alpn_server_select_none() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let localhost = listener.local_addr().unwrap();
@@ -759,7 +759,7 @@ fn test_alpn_server_select_none() {
 
 // In 1.1.0, ALPN negotiation failure is a fatal error
 #[test]
-#[cfg(all(feature = "openssl-102", ossl110))]
+#[cfg(all(feature = "v110", ossl110))]
 fn test_alpn_server_select_none() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let localhost = listener.local_addr().unwrap();
@@ -1066,7 +1066,7 @@ fn add_extra_chain_cert() {
 
 #[test]
 #[cfg_attr(windows, ignore)] // don't have a trusted CA list easily available :(
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 fn valid_hostname() {
     let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
     ctx.set_default_verify_paths().unwrap();
@@ -1090,7 +1090,7 @@ fn valid_hostname() {
 
 #[test]
 #[cfg_attr(windows, ignore)] // don't have a trusted CA list easily available :(
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 fn invalid_hostname() {
     let mut ctx = SslContext::new(SslMethod::tls()).unwrap();
     ctx.set_default_verify_paths().unwrap();

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -36,7 +36,7 @@ use ffi::{
 
 pub mod extension;
 
-#[cfg(feature = "openssl-102")]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 pub mod verify;
 
 use self::extension::{ExtensionType, Extension};

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -1,3 +1,7 @@
+//! X509 certificate verification
+//!
+//! Requires the `v102` or `v110` features and OpenSSL 1.0.2 or 1.1.0.
+
 use std::marker::PhantomData;
 use libc::c_uint;
 use ffi;
@@ -13,7 +17,8 @@ bitflags! {
         const X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS = ffi::X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS,
         const X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS
             = ffi::X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS,
-        #[cfg(feature = "openssl-110")]
+        /// Requires the `v110` feature and OpenSSL 1.1.0.
+        #[cfg(all(feature = "v110", ossl110))]
         const X509_CHECK_FLAG_NEVER_CHECK_SUBJECT = ffi::X509_CHECK_FLAG_NEVER_CHECK_SUBJECT,
     }
 }

--- a/openssl/test/run.sh
+++ b/openssl/test/run.sh
@@ -3,10 +3,10 @@ set -e
 
 case "$BUILD_OPENSSL_VERSION" in
     1.0.2*)
-        FEATURES="openssl-102"
+        FEATURES="v102"
         ;;
     1.1.0*)
-        FEATURES="openssl-110"
+        FEATURES="v110"
         ;;
 esac
 


### PR DESCRIPTION
The basic idea here is that there is a feature for each supported
OpenSSL version. Enabling multiple features represents support for
multiple OpenSSL versions, but it's then up to you to check which
version you link against (probably by depending on openssl-sys and
making a build script similar to what openssl does).

@alexcrichton this is basically the structure you proposed for scenarios.