### PR TITLE
Get rid of Ref

### DIFF
--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -9,11 +9,11 @@ use {cvt, cvt_p};
 use bio::MemBio;
 use crypto::CryptoString;
 use error::ErrorStack;
-use types::{OpenSslType, Ref};
+use types::{OpenSslType, OpenSslTypeRef};
 
-type_!(Asn1Time, ffi::ASN1_TIME, ffi::ASN1_TIME_free);
+type_!(Asn1Time, Asn1TimeRef, ffi::ASN1_TIME, ffi::ASN1_TIME_free);
 
-impl fmt::Display for Ref<Asn1Time> {
+impl fmt::Display for Asn1TimeRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
             let mem_bio = try!(MemBio::new());
@@ -39,9 +39,9 @@ impl Asn1Time {
     }
 }
 
-type_!(Asn1String, ffi::ASN1_STRING, ffi::ASN1_STRING_free);
+type_!(Asn1String, Asn1StringRef, ffi::ASN1_STRING, ffi::ASN1_STRING_free);
 
-impl Ref<Asn1String> {
+impl Asn1StringRef {
     pub fn as_utf8(&self) -> Result<CryptoString, ErrorStack> {
         unsafe {
             let mut ptr = ptr::null_mut();

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -8,7 +8,7 @@ use std::ops::{Add, Div, Mul, Neg, Rem, Shl, Shr, Sub, Deref};
 use {cvt, cvt_p, cvt_n};
 use crypto::CryptoString;
 use error::ErrorStack;
-use types::{Ref, OpenSslType};
+use types::{OpenSslType, OpenSslTypeRef};
 
 /// Options for the most significant bits of a randomly generated `BigNum`.
 pub struct MsbOption(c_int);
@@ -25,7 +25,7 @@ pub const MSB_ONE: MsbOption = MsbOption(0);
 /// of bits in the original numbers.
 pub const TWO_MSB_ONE: MsbOption = MsbOption(1);
 
-type_!(BigNumContext, ffi::BN_CTX, ffi::BN_CTX_free);
+type_!(BigNumContext, BigNumContextRef, ffi::BN_CTX, ffi::BN_CTX_free);
 
 impl BigNumContext {
     /// Returns a new `BigNumContext`.
@@ -35,19 +35,19 @@ impl BigNumContext {
 
     /// Places the result of `a * b` in `r`.
     pub fn mul(&mut self,
-               r: &mut Ref<BigNum>,
-               a: &Ref<BigNum>,
-               b: &Ref<BigNum>)
+               r: &mut BigNumRef,
+               a: &BigNumRef,
+               b: &BigNumRef)
                -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_mul(r.as_ptr(), a.as_ptr(), b.as_ptr(), self.as_ptr())).map(|_| ()) }
     }
 
     /// Places the result of `a / b` in `dv` and `a mod b` in `rem`.
     pub fn div(&mut self,
-               dv: Option<&mut Ref<BigNum>>,
-               rem: Option<&mut Ref<BigNum>>,
-               a: &Ref<BigNum>,
-               b: &Ref<BigNum>)
+               dv: Option<&mut BigNumRef>,
+               rem: Option<&mut BigNumRef>,
+               a: &BigNumRef,
+               b: &BigNumRef)
                -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::BN_div(dv.map(|b| b.as_ptr()).unwrap_or(ptr::null_mut()),
@@ -60,25 +60,25 @@ impl BigNumContext {
     }
 
     /// Places the result of `a²` in `r`.
-    pub fn sqr(&mut self, r: &mut Ref<BigNum>, a: &Ref<BigNum>) -> Result<(), ErrorStack> {
+    pub fn sqr(&mut self, r: &mut BigNumRef, a: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_sqr(r.as_ptr(), a.as_ptr(), self.as_ptr())).map(|_| ()) }
     }
 
     /// Places the result of `a mod m` in `r`.
     pub fn nnmod(&mut self,
-                 r: &mut Ref<BigNum>,
-                 a: &Ref<BigNum>,
-                 m: &Ref<BigNum>)
+                 r: &mut BigNumRef,
+                 a: &BigNumRef,
+                 m: &BigNumRef)
                  -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_nnmod(r.as_ptr(), a.as_ptr(), m.as_ptr(), self.0)).map(|_| ()) }
     }
 
     /// Places the result of `(a + b) mod m` in `r`.
     pub fn mod_add(&mut self,
-                   r: &mut Ref<BigNum>,
-                   a: &Ref<BigNum>,
-                   b: &Ref<BigNum>,
-                   m: &Ref<BigNum>)
+                   r: &mut BigNumRef,
+                   a: &BigNumRef,
+                   b: &BigNumRef,
+                   m: &BigNumRef)
                    -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::BN_mod_add(r.as_ptr(), a.as_ptr(), b.as_ptr(), m.as_ptr(), self.0)).map(|_| ())
@@ -87,10 +87,10 @@ impl BigNumContext {
 
     /// Places the result of `(a - b) mod m` in `r`.
     pub fn mod_sub(&mut self,
-                   r: &mut Ref<BigNum>,
-                   a: &Ref<BigNum>,
-                   b: &Ref<BigNum>,
-                   m: &Ref<BigNum>)
+                   r: &mut BigNumRef,
+                   a: &BigNumRef,
+                   b: &BigNumRef,
+                   m: &BigNumRef)
                    -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::BN_mod_sub(r.as_ptr(), a.as_ptr(), b.as_ptr(), m.as_ptr(), self.0)).map(|_| ())
@@ -99,10 +99,10 @@ impl BigNumContext {
 
     /// Places the result of `(a * b) mod m` in `r`.
     pub fn mod_mul(&mut self,
-                   r: &mut Ref<BigNum>,
-                   a: &Ref<BigNum>,
-                   b: &Ref<BigNum>,
-                   m: &Ref<BigNum>)
+                   r: &mut BigNumRef,
+                   a: &BigNumRef,
+                   b: &BigNumRef,
+                   m: &BigNumRef)
                    -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::BN_mod_mul(r.as_ptr(), a.as_ptr(), b.as_ptr(), m.as_ptr(), self.0)).map(|_| ())
@@ -111,28 +111,28 @@ impl BigNumContext {
 
     /// Places the result of `a² mod m` in `r`.
     pub fn mod_sqr(&mut self,
-                   r: &mut Ref<BigNum>,
-                   a: &Ref<BigNum>,
-                   m: &Ref<BigNum>)
+                   r: &mut BigNumRef,
+                   a: &BigNumRef,
+                   m: &BigNumRef)
                    -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_mod_sqr(r.as_ptr(), a.as_ptr(), m.as_ptr(), self.0)).map(|_| ()) }
     }
 
     /// Places the result of `a^p` in `r`.
     pub fn exp(&mut self,
-               r: &mut Ref<BigNum>,
-               a: &Ref<BigNum>,
-               p: &Ref<BigNum>)
+               r: &mut BigNumRef,
+               a: &BigNumRef,
+               p: &BigNumRef)
                -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_exp(r.as_ptr(), a.as_ptr(), p.as_ptr(), self.0)).map(|_| ()) }
     }
 
     /// Places the result of `a^p mod m` in `r`.
     pub fn mod_exp(&mut self,
-                   r: &mut Ref<BigNum>,
-                   a: &Ref<BigNum>,
-                   p: &Ref<BigNum>,
-                   m: &Ref<BigNum>)
+                   r: &mut BigNumRef,
+                   a: &BigNumRef,
+                   p: &BigNumRef,
+                   m: &BigNumRef)
                    -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::BN_mod_exp(r.as_ptr(), a.as_ptr(), p.as_ptr(), m.as_ptr(), self.0)).map(|_| ())
@@ -141,9 +141,9 @@ impl BigNumContext {
 
     /// Places the inverse of `a` modulo `n` in `r`.
     pub fn mod_inverse(&mut self,
-                       r: &mut Ref<BigNum>,
-                       a: &Ref<BigNum>,
-                       n: &Ref<BigNum>)
+                       r: &mut BigNumRef,
+                       a: &BigNumRef,
+                       n: &BigNumRef)
                        -> Result<(), ErrorStack> {
         unsafe {
             cvt_p(ffi::BN_mod_inverse(r.as_ptr(), a.as_ptr(), n.as_ptr(), self.as_ptr()))
@@ -153,9 +153,9 @@ impl BigNumContext {
 
     /// Places the greatest common denominator of `a` and `b` in `r`.
     pub fn gcd(&mut self,
-               r: &mut Ref<BigNum>,
-               a: &Ref<BigNum>,
-               b: &Ref<BigNum>)
+               r: &mut BigNumRef,
+               a: &BigNumRef,
+               b: &BigNumRef)
                -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_gcd(r.as_ptr(), a.as_ptr(), b.as_ptr(), self.as_ptr())).map(|_| ()) }
     }
@@ -165,7 +165,7 @@ impl BigNumContext {
     /// Performs a Miller-Rabin probabilistic primality test with `checks` iterations.
     ///
     /// Returns `true` if `p` is prime with an error probability of less than `0.25 ^ checks`.
-    pub fn is_prime(&mut self, p: &Ref<BigNum>, checks: i32) -> Result<bool, ErrorStack> {
+    pub fn is_prime(&mut self, p: &BigNumRef, checks: i32) -> Result<bool, ErrorStack> {
         unsafe {
             cvt_n(ffi::BN_is_prime_ex(p.as_ptr(), checks.into(), self.as_ptr(), ptr::null_mut()))
                 .map(|r| r != 0)
@@ -182,7 +182,7 @@ impl BigNumContext {
     ///
     /// Returns `true` if `p` is prime with an error probability of less than `0.25 ^ checks`.
     pub fn is_prime_fasttest(&mut self,
-                             p: &Ref<BigNum>,
+                             p: &BigNumRef,
                              checks: i32,
                              do_trial_division: bool)
                              -> Result<bool, ErrorStack> {
@@ -197,7 +197,7 @@ impl BigNumContext {
     }
 }
 
-impl Ref<BigNum> {
+impl BigNumRef {
     /// Erases the memory used by this `BigNum`, resetting its value to 0.
     ///
     /// This can be used to destroy sensitive data such as keys when they are no longer needed.
@@ -246,12 +246,12 @@ impl Ref<BigNum> {
 
     /// Places a cryptographically-secure pseudo-random number nonnegative
     /// number less than `self` in `rnd`.
-    pub fn rand_in_range(&self, rnd: &mut Ref<BigNum>) -> Result<(), ErrorStack> {
+    pub fn rand_in_range(&self, rnd: &mut BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_rand_range(self.as_ptr(), rnd.as_ptr())).map(|_| ()) }
     }
 
     /// The cryptographically weak counterpart to `rand_in_range`.
-    pub fn pseudo_rand_in_range(&self, rnd: &mut Ref<BigNum>) -> Result<(), ErrorStack> {
+    pub fn pseudo_rand_in_range(&self, rnd: &mut BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_pseudo_rand_range(self.as_ptr(), rnd.as_ptr())).map(|_| ()) }
     }
 
@@ -282,32 +282,32 @@ impl Ref<BigNum> {
     }
 
     /// Places `self << 1` in `r`.
-    pub fn lshift1(&self, r: &mut Ref<BigNum>) -> Result<(), ErrorStack> {
+    pub fn lshift1(&self, r: &mut BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_lshift1(r.as_ptr(), self.as_ptr())).map(|_| ()) }
     }
 
     /// Places `self >> 1` in `r`.
-    pub fn rshift1(&self, r: &mut Ref<BigNum>) -> Result<(), ErrorStack> {
+    pub fn rshift1(&self, r: &mut BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_rshift1(r.as_ptr(), self.as_ptr())).map(|_| ()) }
     }
 
     /// Places `self + b` in `r`.
-    pub fn add(&self, r: &mut Ref<BigNum>, b: &Ref<BigNum>) -> Result<(), ErrorStack> {
+    pub fn add(&self, r: &mut BigNumRef, b: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_add(r.as_ptr(), self.as_ptr(), b.as_ptr())).map(|_| ()) }
     }
 
     /// Places `self - b` in `r`.
-    pub fn sub(&self, r: &mut Ref<BigNum>, b: &Ref<BigNum>) -> Result<(), ErrorStack> {
+    pub fn sub(&self, r: &mut BigNumRef, b: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_sub(r.as_ptr(), self.as_ptr(), b.as_ptr())).map(|_| ()) }
     }
 
     /// Places `self << n` in `r`.
-    pub fn lshift(&self, r: &mut Ref<BigNum>, b: i32) -> Result<(), ErrorStack> {
+    pub fn lshift(&self, r: &mut BigNumRef, b: i32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_lshift(r.as_ptr(), self.as_ptr(), b.into())).map(|_| ()) }
     }
 
     /// Places `self >> n` in `r`.
-    pub fn rshift(&self, r: &mut Ref<BigNum>, n: i32) -> Result<(), ErrorStack> {
+    pub fn rshift(&self, r: &mut BigNumRef, n: i32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_rshift(r.as_ptr(), self.as_ptr(), n.into())).map(|_| ()) }
     }
 
@@ -330,7 +330,7 @@ impl Ref<BigNum> {
     ///
     /// assert_eq!(s.ucmp(&o), Ordering::Equal);
     /// ```
-    pub fn ucmp(&self, oth: &Ref<BigNum>) -> Ordering {
+    pub fn ucmp(&self, oth: &BigNumRef) -> Ordering {
         unsafe { ffi::BN_ucmp(self.as_ptr(), oth.as_ptr()).cmp(&0) }
     }
 
@@ -397,8 +397,8 @@ impl Ref<BigNum> {
     pub fn generate_prime(&mut self,
                           bits: i32,
                           safe: bool,
-                          add: Option<&Ref<BigNum>>,
-                          rem: Option<&Ref<BigNum>>)
+                          add: Option<&BigNumRef>,
+                          rem: Option<&BigNumRef>)
                           -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::BN_generate_prime_ex(self.as_ptr(),
@@ -464,7 +464,7 @@ impl Ref<BigNum> {
     }
 }
 
-type_!(BigNum, ffi::BIGNUM, ffi::BN_free);
+type_!(BigNum, BigNumRef, ffi::BIGNUM, ffi::BN_free);
 
 impl BigNum {
     /// Creates a new `BigNum` with the value 0.
@@ -520,13 +520,13 @@ impl BigNum {
     }
 }
 
-impl AsRef<Ref<BigNum>> for BigNum {
-    fn as_ref(&self) -> &Ref<BigNum> {
+impl AsRef<BigNumRef> for BigNum {
+    fn as_ref(&self) -> &BigNumRef {
         self.deref()
     }
 }
 
-impl fmt::Debug for Ref<BigNum> {
+impl fmt::Debug for BigNumRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.to_dec_str() {
             Ok(s) => f.write_str(&s),
@@ -544,7 +544,7 @@ impl fmt::Debug for BigNum {
     }
 }
 
-impl fmt::Display for Ref<BigNum> {
+impl fmt::Display for BigNumRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.to_dec_str() {
             Ok(s) => f.write_str(&s),
@@ -562,19 +562,19 @@ impl fmt::Display for BigNum {
     }
 }
 
-impl PartialEq<Ref<BigNum>> for Ref<BigNum> {
-    fn eq(&self, oth: &Ref<BigNum>) -> bool {
+impl PartialEq<BigNumRef> for BigNumRef {
+    fn eq(&self, oth: &BigNumRef) -> bool {
         self.cmp(oth) == Ordering::Equal
     }
 }
 
-impl PartialEq<BigNum> for Ref<BigNum> {
+impl PartialEq<BigNum> for BigNumRef {
     fn eq(&self, oth: &BigNum) -> bool {
         self.eq(oth.deref())
     }
 }
 
-impl Eq for Ref<BigNum> {}
+impl Eq for BigNumRef {}
 
 impl PartialEq for BigNum {
     fn eq(&self, oth: &BigNum) -> bool {
@@ -582,28 +582,28 @@ impl PartialEq for BigNum {
     }
 }
 
-impl PartialEq<Ref<BigNum>> for BigNum {
-    fn eq(&self, oth: &Ref<BigNum>) -> bool {
+impl PartialEq<BigNumRef> for BigNum {
+    fn eq(&self, oth: &BigNumRef) -> bool {
         self.deref().eq(oth)
     }
 }
 
 impl Eq for BigNum {}
 
-impl PartialOrd<Ref<BigNum>> for Ref<BigNum> {
-    fn partial_cmp(&self, oth: &Ref<BigNum>) -> Option<Ordering> {
+impl PartialOrd<BigNumRef> for BigNumRef {
+    fn partial_cmp(&self, oth: &BigNumRef) -> Option<Ordering> {
         Some(self.cmp(oth))
     }
 }
 
-impl PartialOrd<BigNum> for Ref<BigNum> {
+impl PartialOrd<BigNum> for BigNumRef {
     fn partial_cmp(&self, oth: &BigNum) -> Option<Ordering> {
         Some(self.cmp(oth.deref()))
     }
 }
 
-impl Ord for Ref<BigNum> {
-    fn cmp(&self, oth: &Ref<BigNum>) -> Ordering {
+impl Ord for BigNumRef {
+    fn cmp(&self, oth: &BigNumRef) -> Ordering {
         unsafe { ffi::BN_cmp(self.as_ptr(), oth.as_ptr()).cmp(&0) }
     }
 }
@@ -614,8 +614,8 @@ impl PartialOrd for BigNum {
     }
 }
 
-impl PartialOrd<Ref<BigNum>> for BigNum {
-    fn partial_cmp(&self, oth: &Ref<BigNum>) -> Option<Ordering> {
+impl PartialOrd<BigNumRef> for BigNum {
+    fn partial_cmp(&self, oth: &BigNumRef) -> Option<Ordering> {
         self.deref().partial_cmp(oth)
     }
 }
@@ -628,7 +628,7 @@ impl Ord for BigNum {
 
 macro_rules! delegate {
     ($t:ident, $m:ident) => {
-        impl<'a, 'b> $t<&'b BigNum> for &'a Ref<BigNum> {
+        impl<'a, 'b> $t<&'b BigNum> for &'a BigNumRef {
             type Output = BigNum;
 
             fn $m(self, oth: &BigNum) -> BigNum {
@@ -636,10 +636,10 @@ macro_rules! delegate {
             }
         }
 
-        impl<'a, 'b> $t<&'b Ref<BigNum>> for &'a BigNum {
+        impl<'a, 'b> $t<&'b BigNumRef> for &'a BigNum {
             type Output = BigNum;
 
-            fn $m(self, oth: &Ref<BigNum>) -> BigNum {
+            fn $m(self, oth: &BigNumRef) -> BigNum {
                 $t::$m(self.deref(), oth)
             }
         }
@@ -654,10 +654,10 @@ macro_rules! delegate {
     }
 }
 
-impl<'a, 'b> Add<&'b Ref<BigNum>> for &'a Ref<BigNum> {
+impl<'a, 'b> Add<&'b BigNumRef> for &'a BigNumRef {
     type Output = BigNum;
 
-    fn add(self, oth: &Ref<BigNum>) -> BigNum {
+    fn add(self, oth: &BigNumRef) -> BigNum {
         let mut r = BigNum::new().unwrap();
         self.add(&mut r, oth).unwrap();
         r
@@ -666,10 +666,10 @@ impl<'a, 'b> Add<&'b Ref<BigNum>> for &'a Ref<BigNum> {
 
 delegate!(Add, add);
 
-impl<'a, 'b> Sub<&'b Ref<BigNum>> for &'a Ref<BigNum> {
+impl<'a, 'b> Sub<&'b BigNumRef> for &'a BigNumRef {
     type Output = BigNum;
 
-    fn sub(self, oth: &Ref<BigNum>) -> BigNum {
+    fn sub(self, oth: &BigNumRef) -> BigNum {
         let mut r = BigNum::new().unwrap();
         self.sub(&mut r, oth).unwrap();
         r
@@ -678,10 +678,10 @@ impl<'a, 'b> Sub<&'b Ref<BigNum>> for &'a Ref<BigNum> {
 
 delegate!(Sub, sub);
 
-impl<'a, 'b> Mul<&'b Ref<BigNum>> for &'a Ref<BigNum> {
+impl<'a, 'b> Mul<&'b BigNumRef> for &'a BigNumRef {
     type Output = BigNum;
 
-    fn mul(self, oth: &Ref<BigNum>) -> BigNum {
+    fn mul(self, oth: &BigNumRef) -> BigNum {
         let mut ctx = BigNumContext::new().unwrap();
         let mut r = BigNum::new().unwrap();
         ctx.mul(&mut r, self, oth).unwrap();
@@ -691,10 +691,10 @@ impl<'a, 'b> Mul<&'b Ref<BigNum>> for &'a Ref<BigNum> {
 
 delegate!(Mul, mul);
 
-impl<'a, 'b> Div<&'b Ref<BigNum>> for &'a Ref<BigNum> {
+impl<'a, 'b> Div<&'b BigNumRef> for &'a BigNumRef {
     type Output = BigNum;
 
-    fn div(self, oth: &'b Ref<BigNum>) -> BigNum {
+    fn div(self, oth: &'b BigNumRef) -> BigNum {
         let mut ctx = BigNumContext::new().unwrap();
         let mut dv = BigNum::new().unwrap();
         ctx.div(Some(&mut dv), None, self, oth).unwrap();
@@ -704,10 +704,10 @@ impl<'a, 'b> Div<&'b Ref<BigNum>> for &'a Ref<BigNum> {
 
 delegate!(Div, div);
 
-impl<'a, 'b> Rem<&'b Ref<BigNum>> for &'a Ref<BigNum> {
+impl<'a, 'b> Rem<&'b BigNumRef> for &'a BigNumRef {
     type Output = BigNum;
 
-    fn rem(self, oth: &'b Ref<BigNum>) -> BigNum {
+    fn rem(self, oth: &'b BigNumRef) -> BigNum {
         let mut ctx = BigNumContext::new().unwrap();
         let mut rem = BigNum::new().unwrap();
         ctx.div(None, Some(&mut rem), self, oth).unwrap();
@@ -717,7 +717,7 @@ impl<'a, 'b> Rem<&'b Ref<BigNum>> for &'a Ref<BigNum> {
 
 delegate!(Rem, rem);
 
-impl<'a> Shl<i32> for &'a Ref<BigNum> {
+impl<'a> Shl<i32> for &'a BigNumRef {
     type Output = BigNum;
 
     fn shl(self, n: i32) -> BigNum {
@@ -735,7 +735,7 @@ impl<'a> Shl<i32> for &'a BigNum {
     }
 }
 
-impl<'a> Shr<i32> for &'a Ref<BigNum> {
+impl<'a> Shr<i32> for &'a BigNumRef {
     type Output = BigNum;
 
     fn shr(self, n: i32) -> BigNum {
@@ -753,7 +753,7 @@ impl<'a> Shr<i32> for &'a BigNum {
     }
 }
 
-impl<'a> Neg for &'a Ref<BigNum> {
+impl<'a> Neg for &'a BigNumRef {
     type Output = BigNum;
 
     fn neg(self) -> BigNum {

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -7,11 +7,11 @@ use std::mem;
 use {cvt, cvt_p};
 use bio::MemBio;
 use bn::BigNum;
-use types::{OpenSslType, Ref};
+use types::OpenSslTypeRef;
 
-type_!(Dh, ffi::DH, ffi::DH_free);
+type_!(Dh, DhRef, ffi::DH, ffi::DH_free);
 
-impl Ref<Dh> {
+impl DhRef {
     /// Encodes the parameters to PEM.
     pub fn to_pem(&self) -> Result<Vec<u8>, ErrorStack> {
         let mem_bio = try!(MemBio::new());

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -5,14 +5,14 @@ use std::fmt;
 use std::ptr;
 
 use bio::{MemBio, MemBioSlice};
-use bn::BigNum;
+use bn::BigNumRef;
 use {cvt, cvt_p};
-use types::Ref;
+use types::OpenSslTypeRef;
 use util::{CallbackState, invoke_passwd_cb};
 
-type_!(Dsa, ffi::DSA, ffi::DSA_free);
+type_!(Dsa, DsaRef, ffi::DSA, ffi::DSA_free);
 
-impl Ref<Dsa> {
+impl DsaRef {
     /// Writes an DSA private key as unencrypted PEM formatted data
     pub fn private_key_to_pem(&self) -> Result<Vec<u8>, ErrorStack> {
         assert!(self.has_private_key());
@@ -44,35 +44,35 @@ impl Ref<Dsa> {
         }
     }
 
-    pub fn p(&self) -> Option<&Ref<BigNum>> {
+    pub fn p(&self) -> Option<&BigNumRef> {
         unsafe {
             let p = compat::pqg(self.as_ptr())[0];
             if p.is_null() {
                 None
             } else {
-                Some(Ref::<BigNum>::from_ptr(p as *mut _))
+                Some(BigNumRef::from_ptr(p as *mut _))
             }
         }
     }
 
-    pub fn q(&self) -> Option<&Ref<BigNum>> {
+    pub fn q(&self) -> Option<&BigNumRef> {
         unsafe {
             let q = compat::pqg(self.as_ptr())[1];
             if q.is_null() {
                 None
             } else {
-                Some(Ref::<BigNum>::from_ptr(q as *mut _))
+                Some(BigNumRef::from_ptr(q as *mut _))
             }
         }
     }
 
-    pub fn g(&self) -> Option<&Ref<BigNum>> {
+    pub fn g(&self) -> Option<&BigNumRef> {
         unsafe {
             let g = compat::pqg(self.as_ptr())[2];
             if g.is_null() {
                 None
             } else {
-                Some(Ref::<BigNum>::from_ptr(g as *mut _))
+                Some(BigNumRef::from_ptr(g as *mut _))
             }
         }
     }

--- a/openssl/src/ec_key.rs
+++ b/openssl/src/ec_key.rs
@@ -4,7 +4,7 @@ use cvt_p;
 use error::ErrorStack;
 use nid::Nid;
 
-type_!(EcKey, ffi::EC_KEY, ffi::EC_KEY_free);
+type_!(EcKey, EcKeyRef, ffi::EC_KEY, ffi::EC_KEY_free);
 
 impl EcKey {
     pub fn new_by_curve_name(nid: Nid) -> Result<EcKey, ErrorStack> {

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -21,18 +21,15 @@ use libc::c_int;
 use error::ErrorStack;
 
 macro_rules! type_ {
-    ($n:ident, $c:path, $d:path) => {
+    ($n:ident, $r:ident, $c:path, $d:path) => {
         pub struct $n(*mut $c);
 
-        unsafe impl ::types::OpenSslType for $n {
+        impl ::types::OpenSslType for $n {
             type CType = $c;
+            type Ref = $r;
 
             unsafe fn from_ptr(ptr: *mut $c) -> $n {
                 $n(ptr)
-            }
-
-            fn as_ptr(&self) -> *mut $c {
-                self.0
             }
         }
 
@@ -43,17 +40,23 @@ macro_rules! type_ {
         }
 
         impl ::std::ops::Deref for $n {
-            type Target = ::types::Ref<$n>;
+            type Target = $r;
 
-            fn deref(&self) -> &::types::Ref<$n> {
-                unsafe { ::types::Ref::from_ptr(self.0) }
+            fn deref(&self) -> &$r {
+                unsafe { ::types::OpenSslTypeRef::from_ptr(self.0) }
             }
         }
 
         impl ::std::ops::DerefMut for $n {
-            fn deref_mut(&mut self) -> &mut ::types::Ref<$n> {
-                unsafe { ::types::Ref::from_ptr_mut(self.0) }
+            fn deref_mut(&mut self) -> &mut $r {
+                unsafe { ::types::OpenSslTypeRef::from_ptr_mut(self.0) }
             }
+        }
+
+        pub struct $r(::util::Opaque);
+
+        impl ::types::OpenSslTypeRef for $r {
+            type CType = $c;
         }
     }
 }

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -6,14 +6,14 @@ use ffi;
 use {cvt, cvt_p};
 use bio::{MemBio, MemBioSlice};
 use dsa::Dsa;
-use rsa::Rsa;
+use rsa::{Rsa, RsaRef};
 use error::ErrorStack;
 use util::{CallbackState, invoke_passwd_cb};
-use types::{OpenSslType, Ref};
+use types::{OpenSslType, OpenSslTypeRef};
 
-type_!(PKey, ffi::EVP_PKEY, ffi::EVP_PKEY_free);
+type_!(PKey, PKeyRef, ffi::EVP_PKEY, ffi::EVP_PKEY_free);
 
-impl Ref<PKey> {
+impl PKeyRef {
     /// Get a reference to the interal RSA key for direct access to the key components
     pub fn rsa(&self) -> Result<Rsa, ErrorStack> {
         unsafe {
@@ -58,7 +58,7 @@ impl Ref<PKey> {
         Ok(mem_bio.get_buf().to_owned())
     }
 
-    pub fn public_eq(&self, other: &Ref<PKey>) -> bool {
+    pub fn public_eq(&self, other: &PKeyRef) -> bool {
         unsafe { ffi::EVP_PKEY_cmp(self.as_ptr(), other.as_ptr()) == 1 }
     }
 }
@@ -148,7 +148,7 @@ impl PKey {
     }
 
     /// Assign an RSA key to this pkey.
-    pub fn set_rsa(&mut self, rsa: &Ref<Rsa>) -> Result<(), ErrorStack> {
+    pub fn set_rsa(&mut self, rsa: &RsaRef) -> Result<(), ErrorStack> {
         unsafe {
             // this needs to be a reference as the set1_RSA ups the reference count
             let rsa_ptr = rsa.as_ptr();

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -5,11 +5,11 @@ use std::mem;
 use libc::{c_int, c_void, c_char};
 
 use {cvt, cvt_p, cvt_n};
-use bn::BigNum;
+use bn::{BigNum, BigNumRef};
 use bio::{MemBio, MemBioSlice};
 use error::ErrorStack;
 use util::{CallbackState, invoke_passwd_cb};
-use types::{OpenSslType, Ref};
+use types::OpenSslTypeRef;
 
 /// Type of encryption padding to use.
 #[derive(Copy, Clone)]
@@ -19,9 +19,9 @@ pub const NO_PADDING: Padding = Padding(ffi::RSA_NO_PADDING);
 pub const PKCS1_PADDING: Padding = Padding(ffi::RSA_PKCS1_PADDING);
 pub const PKCS1_OAEP_PADDING: Padding = Padding(ffi::RSA_PKCS1_OAEP_PADDING);
 
-type_!(Rsa, ffi::RSA, ffi::RSA_free);
+type_!(Rsa, RsaRef, ffi::RSA, ffi::RSA_free);
 
-impl Ref<Rsa> {
+impl RsaRef {
     /// Writes an RSA private key as unencrypted PEM formatted data
     pub fn private_key_to_pem(&self) -> Result<Vec<u8>, ErrorStack> {
         let mem_bio = try!(MemBio::new());
@@ -153,57 +153,57 @@ impl Ref<Rsa> {
         }
     }
 
-    pub fn n(&self) -> Option<&Ref<BigNum>> {
+    pub fn n(&self) -> Option<&BigNumRef> {
         unsafe {
             let n = compat::key(self.as_ptr())[0];
             if n.is_null() {
                 None
             } else {
-                Some(Ref::<BigNum>::from_ptr(n as *mut _))
+                Some(BigNumRef::from_ptr(n as *mut _))
             }
         }
     }
 
-    pub fn d(&self) -> Option<&Ref<BigNum>> {
+    pub fn d(&self) -> Option<&BigNumRef> {
         unsafe {
             let d = compat::key(self.as_ptr())[2];
             if d.is_null() {
                 None
             } else {
-                Some(Ref::<BigNum>::from_ptr(d as *mut _))
+                Some(BigNumRef::from_ptr(d as *mut _))
             }
         }
     }
 
-    pub fn e(&self) -> Option<&Ref<BigNum>> {
+    pub fn e(&self) -> Option<&BigNumRef> {
         unsafe {
             let e = compat::key(self.as_ptr())[1];
             if e.is_null() {
                 None
             } else {
-                Some(Ref::<BigNum>::from_ptr(e as *mut _))
+                Some(BigNumRef::from_ptr(e as *mut _))
             }
         }
     }
 
-    pub fn p(&self) -> Option<&Ref<BigNum>> {
+    pub fn p(&self) -> Option<&BigNumRef> {
         unsafe {
             let p = compat::factors(self.as_ptr())[0];
             if p.is_null() {
                 None
             } else {
-                Some(Ref::<BigNum>::from_ptr(p as *mut _))
+                Some(BigNumRef::from_ptr(p as *mut _))
             }
         }
     }
 
-    pub fn q(&self) -> Option<&Ref<BigNum>> {
+    pub fn q(&self) -> Option<&BigNumRef> {
         unsafe {
             let q = compat::factors(self.as_ptr())[1];
             if q.is_null() {
                 None
             } else {
-                Some(Ref::<BigNum>::from_ptr(q as *mut _))
+                Some(BigNumRef::from_ptr(q as *mut _))
             }
         }
     }

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -61,16 +61,16 @@ use std::ptr;
 
 use {cvt, cvt_p};
 use hash::MessageDigest;
-use pkey::PKey;
+use pkey::PKeyRef;
 use error::ErrorStack;
-use types::Ref;
+use types::OpenSslTypeRef;
 
 #[cfg(ossl110)]
 use ffi::{EVP_MD_CTX_new, EVP_MD_CTX_free};
 #[cfg(any(ossl101, ossl102))]
 use ffi::{EVP_MD_CTX_create as EVP_MD_CTX_new, EVP_MD_CTX_destroy as EVP_MD_CTX_free};
 
-pub struct Signer<'a>(*mut ffi::EVP_MD_CTX, PhantomData<&'a Ref<PKey>>);
+pub struct Signer<'a>(*mut ffi::EVP_MD_CTX, PhantomData<&'a PKeyRef>);
 
 impl<'a> Drop for Signer<'a> {
     fn drop(&mut self) {
@@ -81,7 +81,7 @@ impl<'a> Drop for Signer<'a> {
 }
 
 impl<'a> Signer<'a> {
-    pub fn new(type_: MessageDigest, pkey: &'a Ref<PKey>) -> Result<Signer<'a>, ErrorStack> {
+    pub fn new(type_: MessageDigest, pkey: &'a PKeyRef) -> Result<Signer<'a>, ErrorStack> {
         unsafe {
             ffi::init();
 
@@ -129,7 +129,7 @@ impl<'a> Write for Signer<'a> {
     }
 }
 
-pub struct Verifier<'a>(*mut ffi::EVP_MD_CTX, PhantomData<&'a Ref<PKey>>);
+pub struct Verifier<'a>(*mut ffi::EVP_MD_CTX, PhantomData<&'a PKeyRef>);
 
 impl<'a> Drop for Verifier<'a> {
     fn drop(&mut self) {
@@ -140,7 +140,7 @@ impl<'a> Drop for Verifier<'a> {
 }
 
 impl<'a> Verifier<'a> {
-    pub fn new(type_: MessageDigest, pkey: &'a Ref<PKey>) -> Result<Verifier<'a>, ErrorStack> {
+    pub fn new(type_: MessageDigest, pkey: &'a PKeyRef) -> Result<Verifier<'a>, ErrorStack> {
         unsafe {
             ffi::init();
 

--- a/openssl/src/ssl/tests/mod.rs
+++ b/openssl/src/ssl/tests/mod.rs
@@ -171,7 +171,7 @@ macro_rules! run_test(
             use hash::MessageDigest;
             use x509::X509StoreContext;
             use serialize::hex::FromHex;
-            use types::Ref;
+            use types::OpenSslTypeRef;
             use super::Server;
 
             #[test]

--- a/openssl/src/types.rs
+++ b/openssl/src/types.rs
@@ -1,39 +1,40 @@
 //! Items used by other types.
 
-use std::cell::UnsafeCell;
-use std::marker::PhantomData;
-
 /// A type implemented by wrappers over OpenSSL types.
 ///
 /// This should not be implemented by anything outside of this crate; new methods may be added at
 /// any time.
-pub unsafe trait OpenSslType {
+pub trait OpenSslType: Sized {
     /// The raw C type.
     type CType;
 
+    /// The type representing a reference to this type.
+    type Ref: OpenSslTypeRef<CType = Self::CType>;
+
     /// Constructs an instance of this type from its raw type.
     unsafe fn from_ptr(ptr: *mut Self::CType) -> Self;
-
-    /// Returns a pointer to its raw type.
-    fn as_ptr(&self) -> *mut Self::CType;
 }
 
-/// A reference to an OpenSSL type.
-pub struct Ref<T>(UnsafeCell<()>, PhantomData<T>);
+/// A trait implemented by types which reference borrowed OpenSSL types.
+///
+/// This should not be implemented by anything outside of this crate; new methods may be added at
+/// any time.
+pub trait OpenSslTypeRef: Sized {
+    /// The raw C type.
+    type CType;
 
-impl<T: OpenSslType> Ref<T> {
-    /// Constructs a shared reference to this type from its raw type.
-    pub unsafe fn from_ptr<'a>(ptr: *mut T::CType) -> &'a Ref<T> {
+    /// Constructs a shared instance of this type from its raw type.
+    unsafe fn from_ptr<'a>(ptr: *mut Self::CType) -> &'a Self {
         &*(ptr as *mut _)
     }
 
-    /// Constructs a mutable reference to this type from its raw type.
-    pub unsafe fn from_ptr_mut<'a>(ptr: *mut T::CType) -> &'a mut Ref<T> {
+    /// Constructs a mutable reference of this type from its raw type.
+    unsafe fn from_ptr_mut<'a>(ptr: *mut Self::CType) -> &'a mut Self {
         &mut *(ptr as *mut _)
     }
 
-    /// Returns a pointer to its raw type.
-    pub fn as_ptr(&self) -> *mut T::CType {
+    /// Returns a raw pointer to the wrapped value.
+    fn as_ptr(&self) -> *mut Self::CType {
         self as *const _ as *mut _
     }
 }

--- a/openssl/src/util.rs
+++ b/openssl/src/util.rs
@@ -1,6 +1,6 @@
 use libc::{c_int, c_char, c_void};
-
 use std::any::Any;
+use std::cell::UnsafeCell;
 use std::panic::{self, AssertUnwindSafe};
 use std::slice;
 
@@ -60,3 +60,8 @@ pub unsafe extern "C" fn invoke_passwd_cb<F>(buf: *mut c_char,
         }
     }
 }
+
+/// This is intended to be used as the inner type for `FooRef` types converted from raw C pointers.
+/// It has an `UnsafeCell` internally to inform the compiler about aliasability and doesn't
+/// implement `Copy`, so it can't be dereferenced.
+pub struct Opaque(UnsafeCell<()>);

--- a/openssl/src/verify.rs
+++ b/openssl/src/verify.rs
@@ -3,7 +3,7 @@ use ffi;
 
 use cvt;
 use error::ErrorStack;
-use types::Ref;
+use types::OpenSslTypeRef;
 
 bitflags! {
     pub flags X509CheckFlags: c_uint {
@@ -19,9 +19,9 @@ bitflags! {
     }
 }
 
-type_!(X509VerifyParam, ffi::X509_VERIFY_PARAM, ffi::X509_VERIFY_PARAM_free);
+type_!(X509VerifyParam, X509VerifyParamRef, ffi::X509_VERIFY_PARAM, ffi::X509_VERIFY_PARAM_free);
 
-impl Ref<X509VerifyParam> {
+impl X509VerifyParamRef {
     pub fn set_hostflags(&mut self, hostflags: X509CheckFlags) {
         unsafe {
             ffi::X509_VERIFY_PARAM_set_hostflags(self.as_ptr(), hostflags.bits);


### PR DESCRIPTION
There's unfortunately a rustdoc bug that causes all methods implemented
for any Ref<T> to be inlined in the deref methods section :(