### PR TITLE
Actually support AES GCM

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -114,6 +114,10 @@ pub const EVP_PKEY_RSA: c_int = NID_rsaEncryption;
 pub const EVP_PKEY_HMAC: c_int = NID_hmac;
 pub const EVP_PKEY_DSA: c_int = NID_dsa;
 
+pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
+pub const EVP_CTRL_GCM_GET_TAG: c_int = 0x10;
+pub const EVP_CTRL_GCM_SET_TAG: c_int = 0x11;
+
 pub const MBSTRING_ASC:  c_int = MBSTRING_FLAG | 1;
 pub const MBSTRING_BMP:  c_int = MBSTRING_FLAG | 2;
 pub const MBSTRING_FLAG: c_int = 0x1000;
@@ -1400,6 +1404,7 @@ extern {
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
     pub fn EVP_CIPHER_CTX_set_padding(ctx: *mut EVP_CIPHER_CTX, padding: c_int) -> c_int;
     pub fn EVP_CIPHER_CTX_set_key_length(ctx: *mut EVP_CIPHER_CTX, keylen: c_int) -> c_int;
+    pub fn EVP_CIPHER_CTX_ctrl(ctx: *mut EVP_CIPHER_CTX, type_: c_int, arg: c_int, ptr: *mut c_void) -> c_int;
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 
     pub fn EVP_CipherInit(ctx: *mut EVP_CIPHER_CTX, evp: *const EVP_CIPHER,


### PR DESCRIPTION
This is an AEAD cipher, so we need some extra functionality. As another
bonus, we no longer panic if provided an IV with a different length than
the cipher's default.

Closes #518