### PR TITLE
Allow OPENSSL_{LIB,INCLUDE}_DIR to override OPENSSL_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ The build script can be configured via environment variables:
 * `OPENSSL_DIR` - If specified, a directory that will be used to find
   OpenSSL installation. It's expected that under this directory the `include`
   folder has header files and a `lib` folder has the runtime libraries.
+* `OPENSSL_LIB_DIR` - If specified, a directory that will be used to find
+  OpenSSL libraries. Overrides the `lib` folder implied by `OPENSSL_DIR`
+  (if specified).
+* `OPENSSL_INCLUDE_DIR` - If specified, a directory that will be used to find
+  OpenSSL header files. Overrides the `include` folder implied by `OPENSSL_DIR`
+  (if specified).
 * `OPENSSL_STATIC` - If specified, OpenSSL libraries will be statically rather
   than dynamically linked.
 


### PR DESCRIPTION
Lost as part of #464, there's now no way to show cargo where the lib and include dirs are if they're not under the same directory, like on Ubuntu 16.04 (for example):
```
$ cat /usr/lib/x86_64-linux-gnu/pkgconfig/openssl.pc
prefix=/usr
exec_prefix=${prefix}
libdir=${exec_prefix}/lib/x86_64-linux-gnu
includedir=${prefix}/include

Name: OpenSSL
Description: Secure Sockets Layer and cryptography libraries and tools
Version: 1.0.2g
Requires: libssl libcrypto
```

I assume this hasn't been a problem because most people use pkg-config.