### PR TITLE
Handle zero-length writes in SSL_write

### DIFF
--- a/openssl/src/ssl/tests/mod.rs
+++ b/openssl/src/ssl/tests/mod.rs
@@ -421,6 +421,16 @@ fn test_write() {
     stream.flush().unwrap();
 }
 
+#[test]
+fn zero_length_buffers() {
+    let (_s, stream) = Server::new();
+    let ctx = SslContext::builder(SslMethod::tls()).unwrap();
+    let mut stream = Ssl::new(&ctx.build()).unwrap().connect(stream).unwrap();
+
+    assert_eq!(stream.write(b"").unwrap(), 0);
+    assert_eq!(stream.read(&mut []).unwrap(), 0);
+}
+
 run_test!(get_peer_certificate, |method, stream| {
     let ctx = SslContext::builder(method).unwrap();
     let stream = Ssl::new(&ctx.build()).unwrap().connect(stream).unwrap();


### PR DESCRIPTION
This commit adds some short-circuits for zero-length reads/writes to
`SslStream`. Because OpenSSL returns 0 on error, then we could mistakenly
confuse a 0-length success as an actual error, so we avoid writing or reading 0
bytes by returning quickly with a success.