### PR TITLE
Use metadeps to specify pkg-config dependencies declaratively

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -14,8 +14,11 @@ build = "build.rs"
 libc = "0.2"
 
 [build-dependencies]
-pkg-config = "0.3"
+metadeps = "1"
 
 [target.'cfg(windows)'.dependencies]
 user32-sys = "0.2"
 gdi32-sys = "0.2"
+
+[package.metadata.pkg-config]
+openssl = "1.0.1"

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -1,4 +1,4 @@
-extern crate pkg_config;
+extern crate metadeps;
 
 use std::collections::HashSet;
 use std::env;
@@ -172,8 +172,8 @@ fn try_pkg_config() {
     // cflags dirs for showing us lots of `-I`.
     env::set_var("PKG_CONFIG_ALLOW_SYSTEM_CFLAGS", "1");
 
-    let lib = match pkg_config::find_library("openssl") {
-        Ok(lib) => lib,
+    let lib = match metadeps::probe() {
+        Ok(mut libs) => libs.remove("openssl").unwrap(),
         Err(_) => return,
     };
 


### PR DESCRIPTION
This makes it easier for distribution packaging tools to generate
appropriate package dependencies.