### PR TITLE
Pointer from PKey docs to sign module.

### DIFF
--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -117,7 +117,9 @@ impl PKey {
     }
 
     /// Creates a new `PKey` containing an HMAC key.
-    /// Note: To compute HMAC values, use the `sign` module.
+    ///
+    /// # Note
+    /// To compute HMAC values, use the `sign` module.
     pub fn hmac(key: &[u8]) -> Result<PKey, ErrorStack> {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize);

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -117,6 +117,7 @@ impl PKey {
     }
 
     /// Creates a new `PKey` containing an HMAC key.
+    /// Note: To compute HMAC values, use the `sign` module.
     pub fn hmac(key: &[u8]) -> Result<PKey, ErrorStack> {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize);


### PR DESCRIPTION
Could even add a link, but I don't know how.

Someone who wants to use OpenSSL to compute an HMAC won't find a "hmac" module and won't find HMACs in the "hash" module. Unless the person knows that HMACs are used to "sign" messages (the usual term in this context would be "authenticate"), they will probably use the search function and look for "hmac", then they'll find this method. So it's helpful to include a pointer to the right API to use. Without such a pointer, the API user is left with a seemingly useless Pkey instance.

Similar pointers could be helpful from the other creator methods in this file. And/or from the top-level documentation or the hash documentation towards the sign module. Another idea would be a trivial `hmac` module with a few helper functions that internally just use Pkey. If many users who just want a simple HMAC value can use that API, there are fewer dependencies on `Pkey` and `sign`, which is probably a good thing.