### PR TITLE
Added SSL_SESSION and SSL_get_session

### DIFF
--- a/openssl-sys/src/libressl.rs
+++ b/openssl-sys/src/libressl.rs
@@ -2,7 +2,7 @@ use std::sync::{Mutex, MutexGuard};
 use std::sync::{Once, ONCE_INIT};
 use std::mem;
 
-use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong};
+use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong, uint32_t};
 use libc::time_t;
 
 #[repr(C)]
@@ -43,11 +43,6 @@ pub struct stack_st_GENERAL_NAME {
 #[repr(C)]
 pub struct stack_st_void {
     pub stack: _STACK,
-}
-
-#[repr(C)]
-pub struct crypto_ex_data_st {
-    pub sk: stack_st_void,
 }
 
 #[repr(C)]
@@ -391,7 +386,7 @@ pub struct SSL_SESSION {
     cipher: *const ::SSL_CIPHER,
     cipher_id: c_ulong,
     ciphers: *mut stack_st_SSL_CIPHER,
-    ex_data: crypto_ex_data_st,
+    ex_data: ::CRYPTO_EX_DATA,
     prev: *mut SSL_SESSION,
     next: *mut SSL_SESSION,
     tlsext_hostname: *mut c_char,
@@ -403,8 +398,9 @@ pub struct SSL_SESSION {
     tlsext_ticklen: size_t,
     tlsext_tick_lifetime_hint: c_long,
     srp_username: *mut c_char,
-    flags: u32,
+    flags: uint32_t,
     lock: *mut c_void,
+    pub dummy: c_int,
 }
 
 #[repr(C)]
@@ -579,7 +575,7 @@ extern {
                                                                 is_export: c_int,
                                                                 keylength: c_int)
                                                                 -> *mut ::EC_KEY);
-    pub fn SSL_get_session(ssl: *mut ::SSL) -> *mut ::SSL_SESSION;
+    pub fn SSL_get_session(ssl: *const ::SSL) -> *mut ::SSL_SESSION;
     pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
     pub fn X509_set_notAfter(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
     pub fn X509_set_notBefore(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;

--- a/openssl-sys/src/libressl.rs
+++ b/openssl-sys/src/libressl.rs
@@ -363,58 +363,6 @@ pub struct SSL_CTX {
     srtp_profiles: *mut c_void,
 }
 
-#[repr(C)]
-pub struct SSL_SESSION {
-    ssl_version: c_int,
-    master_key_length: size_t,
-    master_key: [c_uchar; SSL_MAX_MASTER_KEY_LENGTH],
-    session_id_length: size_t,
-    session_id: [c_uchar; SSL_MAX_SSL_SESSION_ID_LENGTH],
-    sid_ctx_length: size_t,
-    sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH],
-
-    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
-    psk_identity_hint: *mut c_char,
-    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
-    psk_identity: *mut c_char,
-
-
-    not_resumable: c_int,
-    peer: *mut X509,
-    peer_type: c_int,
-    peer_chain: *mut stack_st_X509,
-    verify_result: c_long,
-    references: c_int, //This must be atomic
-    timeout: c_long,
-    time: c_long,
-    compress_meth: c_uint,
-    cipher: *const ::SSL_CIPHER,
-    cipher_id: c_ulong,
-    ciphers: *mut stack_st_SSL_CIPHER,
-    ex_data: ::CRYPTO_EX_DATA,
-    prev: *mut SSL_SESSION,
-    next: *mut SSL_SESSION,
-    tlsext_hostname: *mut c_char,
-
-    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
-    tlsext_ecpointformatlist_length: size_t,
-    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
-    tlsext_ecpointformatlist: *mut c_uchar,
-    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
-    tlsext_supportedgroupslist_length: size_t,
-    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
-    tlsext_supportedgroupslist: *mut c_uchar,
-
-    tlsext_tick: *mut c_uchar,
-    tlsext_ticklen: size_t,
-    tlsext_tick_lifetime_hint: c_ulong,
-
-    #[cfg(not(osslconf = "OPENSSL_NO_SRP"))]
-    srp_username: *mut c_char,
-
-    flags: uint32_t,
-    lock: *mut c_void,
-}
 
 #[repr(C)]
 pub struct X509_VERIFY_PARAM {
@@ -431,10 +379,6 @@ pub struct X509_VERIFY_PARAM {
 
 pub enum X509_VERIFY_PARAM_ID {}
 
-
-pub const SSL_MAX_MASTER_KEY_LENGTH: usize = 48;
-pub const SSL_MAX_SSL_SESSION_ID_LENGTH: usize = 32;
-pub const SSL_MAX_SID_CTX_LENGTH: usize = 32;
 
 pub const SSL_CTRL_OPTIONS: c_int = 32;
 pub const SSL_CTRL_CLEAR_OPTIONS: c_int = 77;
@@ -588,7 +532,7 @@ extern {
                                                                 is_export: c_int,
                                                                 keylength: c_int)
                                                                 -> *mut ::EC_KEY);
-    pub fn SSL_get_session(ssl: *const ::SSL) -> *mut ::SSL_SESSION;
+    
     pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
     pub fn X509_set_notAfter(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
     pub fn X509_set_notBefore(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;

--- a/openssl-sys/src/libressl.rs
+++ b/openssl-sys/src/libressl.rs
@@ -2,7 +2,7 @@ use std::sync::{Mutex, MutexGuard};
 use std::sync::{Once, ONCE_INIT};
 use std::mem;
 
-use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong, uint32_t};
+use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong};
 use libc::time_t;
 
 #[repr(C)]
@@ -532,7 +532,7 @@ extern {
                                                                 is_export: c_int,
                                                                 keylength: c_int)
                                                                 -> *mut ::EC_KEY);
-    
+
     pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
     pub fn X509_set_notAfter(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
     pub fn X509_set_notBefore(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;

--- a/openssl-sys/src/libressl.rs
+++ b/openssl-sys/src/libressl.rs
@@ -400,7 +400,6 @@ pub struct SSL_SESSION {
     srp_username: *mut c_char,
     flags: uint32_t,
     lock: *mut c_void,
-    pub dummy: c_int,
 }
 
 #[repr(C)]

--- a/openssl-sys/src/libressl.rs
+++ b/openssl-sys/src/libressl.rs
@@ -6,6 +6,11 @@ use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong};
 use libc::time_t;
 
 #[repr(C)]
+pub struct stack_st_SSL_CIPHER {
+    pub stack: _STACK,
+}
+
+#[repr(C)]
 pub struct stack_st_ASN1_OBJECT {
     pub stack: _STACK,
 }
@@ -38,6 +43,11 @@ pub struct stack_st_GENERAL_NAME {
 #[repr(C)]
 pub struct stack_st_void {
     pub stack: _STACK,
+}
+
+#[repr(C)]
+pub struct crypto_ex_data_st {
+    pub sk: stack_st_void,
 }
 
 #[repr(C)]
@@ -359,6 +369,45 @@ pub struct SSL_CTX {
 }
 
 #[repr(C)]
+pub struct SSL_SESSION {
+    ssl_version: c_int,
+    master_key_length: size_t,
+    master_key: [c_uchar; SSL_MAX_MASTER_KEY_LENGTH],
+    session_id_length: size_t,
+    session_id: [c_uchar; SSL_MAX_SSL_SESSION_ID_LENGTH],
+    sid_ctx_length: size_t,
+    sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH],
+    psk_identity_hint: *mut c_char,
+    psk_identity: *mut c_char,
+    not_resumable: c_int,
+    peer: *mut X509,
+    peer_type: c_int,
+    peer_chain: *mut stack_st_X509,
+    verify_result: c_long,
+    references: c_int, //This must be atomic
+    timeout: c_long,
+    time: c_long,
+    compress_meth: c_uint,
+    cipher: *const ::SSL_CIPHER,
+    cipher_id: c_ulong,
+    ciphers: *mut stack_st_SSL_CIPHER,
+    ex_data: crypto_ex_data_st,
+    prev: *mut SSL_SESSION,
+    next: *mut SSL_SESSION,
+    tlsext_hostname: *mut c_char,
+    tlsext_ecpointformatlist_length: size_t,
+    tlsext_ecpointformatlist: *mut c_uchar,
+    tlsext_supportedgroupslist_length: size_t,
+    tlsext_supportedgroupslist: *mut c_uchar,
+    tlsext_tick: *mut c_uchar,
+    tlsext_ticklen: size_t,
+    tlsext_tick_lifetime_hint: c_long,
+    srp_username: *mut c_char,
+    flags: u32,
+    lock: *mut c_void,
+}
+
+#[repr(C)]
 pub struct X509_VERIFY_PARAM {
     pub name: *mut c_char,
     pub check_time: time_t,
@@ -372,6 +421,11 @@ pub struct X509_VERIFY_PARAM {
 }
 
 pub enum X509_VERIFY_PARAM_ID {}
+
+
+pub const SSL_MAX_MASTER_KEY_LENGTH: usize = 48;
+pub const SSL_MAX_SSL_SESSION_ID_LENGTH: usize = 32;
+pub const SSL_MAX_SID_CTX_LENGTH: usize = 32;
 
 pub const SSL_CTRL_OPTIONS: c_int = 32;
 pub const SSL_CTRL_CLEAR_OPTIONS: c_int = 77;
@@ -525,6 +579,7 @@ extern {
                                                                 is_export: c_int,
                                                                 keylength: c_int)
                                                                 -> *mut ::EC_KEY);
+    pub fn SSL_get_session(ssl: *mut ::SSL) -> *mut ::SSL_SESSION;
     pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
     pub fn X509_set_notAfter(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
     pub fn X509_set_notBefore(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;

--- a/openssl-sys/src/libressl.rs
+++ b/openssl-sys/src/libressl.rs
@@ -372,8 +372,13 @@ pub struct SSL_SESSION {
     session_id: [c_uchar; SSL_MAX_SSL_SESSION_ID_LENGTH],
     sid_ctx_length: size_t,
     sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH],
+
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
     psk_identity_hint: *mut c_char,
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
     psk_identity: *mut c_char,
+
+
     not_resumable: c_int,
     peer: *mut X509,
     peer_type: c_int,
@@ -390,14 +395,23 @@ pub struct SSL_SESSION {
     prev: *mut SSL_SESSION,
     next: *mut SSL_SESSION,
     tlsext_hostname: *mut c_char,
+
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_ecpointformatlist_length: size_t,
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_ecpointformatlist: *mut c_uchar,
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_supportedgroupslist_length: size_t,
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_supportedgroupslist: *mut c_uchar,
+
     tlsext_tick: *mut c_uchar,
     tlsext_ticklen: size_t,
-    tlsext_tick_lifetime_hint: c_long,
+    tlsext_tick_lifetime_hint: c_ulong,
+
+    #[cfg(not(osslconf = "OPENSSL_NO_SRP"))]
     srp_username: *mut c_char,
+
     flags: uint32_t,
     lock: *mut c_void,
 }

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -2,7 +2,7 @@ use std::sync::{Mutex, MutexGuard};
 use std::sync::{Once, ONCE_INIT};
 use std::mem;
 
-use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong};
+use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong, uint32_t};
 #[cfg(not(ossl101))]
 use libc::time_t;
 
@@ -47,10 +47,6 @@ pub struct stack_st_void {
     pub stack: _STACK,
 }
 
-#[repr(C)]
-pub struct crypto_ex_data_st {
-    pub sk: *mut stack_st_void,
-}
 
 #[repr(C)]
 pub struct _STACK {
@@ -452,7 +448,7 @@ pub struct SSL_SESSION {
     cipher: *const ::SSL_CIPHER,
     cipher_id: c_ulong,
     ciphers: *mut stack_st_SSL_CIPHER,
-    ex_data: crypto_ex_data_st,
+    ex_data: ::CRYPTO_EX_DATA,
     prev: *mut SSL_SESSION,
     next: *mut SSL_SESSION,
     tlsext_hostname: *mut c_char,
@@ -464,8 +460,9 @@ pub struct SSL_SESSION {
     tlsext_ticklen: size_t,
     tlsext_tick_lifetime_hint: c_long,
     srp_username: *mut c_char,
-    flags: u32,
+    flags: uint32_t,
     lock: *mut c_void,
+    pub dummy: c_int,
 }
 
 #[repr(C)]
@@ -664,7 +661,7 @@ extern {
                                                                 is_export: c_int,
                                                                 keylength: c_int)
                                                                 -> *mut ::EC_KEY);
-    pub fn SSL_get_session(ssl: *mut ::SSL) -> *mut ::SSL_SESSION;
+    pub fn SSL_get_session(ssl: *const ::SSL) -> *mut ::SSL_SESSION;
     pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
     pub fn X509_set_notAfter(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
     pub fn X509_set_notBefore(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -664,7 +664,7 @@ extern {
                                                                 is_export: c_int,
                                                                 keylength: c_int)
                                                                 -> *mut ::EC_KEY);
-    pub fn SSL_get_session(ssl: *mut ::SSL) -> *mut ::SSL_SESSION;
+    pub fn SSL_get_session(ssl: *mut ::SSL,ssl_session: *mut ::SSL_SESSION) -> c_int;
     pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
     pub fn X509_set_notAfter(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
     pub fn X509_set_notBefore(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -6,6 +6,12 @@ use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong};
 #[cfg(not(ossl101))]
 use libc::time_t;
 
+
+#[repr(C)]
+pub struct stack_st_SSL_CIPHER {
+    pub stack: _STACK,
+}
+
 #[repr(C)]
 pub struct stack_st_ASN1_OBJECT {
     pub stack: _STACK,
@@ -39,6 +45,11 @@ pub struct stack_st_GENERAL_NAME {
 #[repr(C)]
 pub struct stack_st_void {
     pub stack: _STACK,
+}
+
+#[repr(C)]
+pub struct crypto_ex_data_st {
+    pub sk: stack_st_void,
 }
 
 #[repr(C)]
@@ -417,6 +428,46 @@ pub struct SSL_CTX {
     tlsext_ellipticcurvelist: *mut c_uchar,
 }
 
+
+#[repr(C)]
+pub struct SSL_SESSION {
+    ssl_version: c_int,
+    master_key_length: size_t,
+    master_key: [c_uchar; SSL_MAX_MASTER_KEY_LENGTH],
+    session_id_length: size_t,
+    session_id: [c_uchar; SSL_MAX_SSL_SESSION_ID_LENGTH],
+    sid_ctx_length: size_t,
+    sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH],
+    psk_identity_hint: *mut c_char,
+    psk_identity: *mut c_char,
+    not_resumable: c_int,
+    peer: *mut X509,
+    peer_type: c_int,
+    peer_chain: *mut stack_st_X509,
+    verify_result: c_long,
+    references: c_int, //This must be atomic
+    timeout: c_long,
+    time: c_long,
+    compress_meth: c_uint,
+    cipher: *const ::SSL_CIPHER,
+    cipher_id: c_ulong,
+    ciphers: *mut stack_st_SSL_CIPHER,
+    ex_data: crypto_ex_data_st,
+    prev: *mut SSL_SESSION,
+    next: *mut SSL_SESSION,
+    tlsext_hostname: *mut c_char,
+    tlsext_ecpointformatlist_length: size_t,
+    tlsext_ecpointformatlist: *mut c_uchar,
+    tlsext_supportedgroupslist_length: size_t,
+    tlsext_supportedgroupslist: *mut c_uchar,
+    tlsext_tick: *mut c_uchar,
+    tlsext_ticklen: size_t,
+    tlsext_tick_lifetime_hint: c_long,
+    srp_username: *mut c_char,
+    flags: u32,
+    lock: *mut c_void,
+}
+
 #[repr(C)]
 pub struct SRP_CTX {
     SRP_cb_arg: *mut c_void,
@@ -453,6 +504,11 @@ pub struct X509_VERIFY_PARAM {
 
 #[cfg(not(ossl101))]
 pub enum X509_VERIFY_PARAM_ID {}
+
+
+pub const SSL_MAX_MASTER_KEY_LENGTH: usize = 48;
+pub const SSL_MAX_SSL_SESSION_ID_LENGTH: usize = 32;
+pub const SSL_MAX_SID_CTX_LENGTH: usize = 32;
 
 pub const SSL_CTRL_OPTIONS: c_int = 32;
 pub const SSL_CTRL_CLEAR_OPTIONS: c_int = 77;
@@ -608,6 +664,7 @@ extern {
                                                                 is_export: c_int,
                                                                 keylength: c_int)
                                                                 -> *mut ::EC_KEY);
+    pub fn SSL_get_session(ssl: *mut ::SSL) -> *mut ::SSL_SESSION;
     pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
     pub fn X509_set_notAfter(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
     pub fn X509_set_notBefore(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -436,10 +436,10 @@ pub struct SSL_SESSION {
     sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH],
 
     #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
-    psk_identity_hint: *mut c_char,
-    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
-    psk_identity: *mut c_char,
+    psk_identity_hint: *mut c_void,
 
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+    psk_identity: *mut c_void,
 
     not_resumable: c_int,
     peer: *mut X509,
@@ -456,7 +456,7 @@ pub struct SSL_SESSION {
     ex_data: ::CRYPTO_EX_DATA,
     prev: *mut SSL_SESSION,
     next: *mut SSL_SESSION,
-    tlsext_hostname: *mut c_char,
+    tlsext_hostname: *mut c_void,
 
     #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_ecpointformatlist_length: size_t,
@@ -465,14 +465,14 @@ pub struct SSL_SESSION {
     #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_supportedgroupslist_length: size_t,
     #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
-    tlsext_supportedgroupslist: *mut c_uchar,
+    tlsext_supportedgroupslist: *mut c_void,
 
-    tlsext_tick: *mut c_uchar,
+    tlsext_tick: *mut c_void,
     tlsext_ticklen: size_t,
     tlsext_tick_lifetime_hint: c_ulong,
 
     #[cfg(not(osslconf = "OPENSSL_NO_SRP"))]
-    srp_username: *mut c_char,
+    srp_username: *mut c_void,
 
     flags: uint32_t,
     lock: *mut c_void,
@@ -703,4 +703,16 @@ extern {
 
     pub fn SSLeay() -> c_ulong;
     pub fn SSLeay_version(key: c_int) -> *const c_char;
+}
+
+
+#[cfg(test)]
+mod test {
+    use std::mem;
+    use super::SSL_SESSION;
+
+    #[test]
+    fn testsize() {
+        println!("THE SIZE IS: {}",  mem::size_of::<SSL_SESSION>());
+    }
 }

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -2,7 +2,7 @@ use std::sync::{Mutex, MutexGuard};
 use std::sync::{Once, ONCE_INIT};
 use std::mem;
 
-use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong, uint32_t};
+use libc::{c_int, c_char, c_void, c_long, c_uchar, size_t, c_uint, c_ulong};
 #[cfg(not(ossl101))]
 use libc::time_t;
 
@@ -425,58 +425,7 @@ pub struct SSL_CTX {
 }
 
 
-#[repr(C)]
-pub struct SSL_SESSION {
-    ssl_version: c_int,
-    master_key_length: size_t,
-    master_key: [c_uchar; SSL_MAX_MASTER_KEY_LENGTH],
-    session_id_length: size_t,
-    session_id: [c_uchar; SSL_MAX_SSL_SESSION_ID_LENGTH],
-    sid_ctx_length: size_t,
-    sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH],
 
-    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
-    psk_identity_hint: *mut c_void,
-
-    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
-    psk_identity: *mut c_void,
-
-    not_resumable: c_int,
-    peer: *mut X509,
-    peer_type: c_int,
-    peer_chain: *mut stack_st_X509,
-    verify_result: c_long,
-    references: c_int, //This must be atomic
-    timeout: c_long,
-    time: c_long,
-    compress_meth: c_uint,
-    cipher: *const ::SSL_CIPHER,
-    cipher_id: c_ulong,
-    ciphers: *mut stack_st_SSL_CIPHER,
-    ex_data: ::CRYPTO_EX_DATA,
-    prev: *mut SSL_SESSION,
-    next: *mut SSL_SESSION,
-    tlsext_hostname: *mut c_void,
-
-    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
-    tlsext_ecpointformatlist_length: size_t,
-    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
-    tlsext_ecpointformatlist: *mut c_uchar,
-    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
-    tlsext_supportedgroupslist_length: size_t,
-    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
-    tlsext_supportedgroupslist: *mut c_void,
-
-    tlsext_tick: *mut c_void,
-    tlsext_ticklen: size_t,
-    tlsext_tick_lifetime_hint: c_ulong,
-
-    #[cfg(not(osslconf = "OPENSSL_NO_SRP"))]
-    srp_username: *mut c_void,
-
-    flags: uint32_t,
-    lock: *mut c_void,
-}
 
 #[repr(C)]
 pub struct SRP_CTX {
@@ -516,9 +465,6 @@ pub struct X509_VERIFY_PARAM {
 pub enum X509_VERIFY_PARAM_ID {}
 
 
-pub const SSL_MAX_MASTER_KEY_LENGTH: usize = 48;
-pub const SSL_MAX_SSL_SESSION_ID_LENGTH: usize = 32;
-pub const SSL_MAX_SID_CTX_LENGTH: usize = 32;
 
 pub const SSL_CTRL_OPTIONS: c_int = 32;
 pub const SSL_CTRL_CLEAR_OPTIONS: c_int = 77;
@@ -674,7 +620,7 @@ extern {
                                                                 is_export: c_int,
                                                                 keylength: c_int)
                                                                 -> *mut ::EC_KEY);
-    pub fn SSL_get_session(ssl: *const ::SSL) -> *mut ::SSL_SESSION;
+
     pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
     pub fn X509_set_notAfter(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
     pub fn X509_set_notBefore(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
@@ -703,16 +649,4 @@ extern {
 
     pub fn SSLeay() -> c_ulong;
     pub fn SSLeay_version(key: c_int) -> *const c_char;
-}
-
-
-#[cfg(test)]
-mod test {
-    use std::mem;
-    use super::SSL_SESSION;
-
-    #[test]
-    fn testsize() {
-        println!("THE SIZE IS: {}",  mem::size_of::<SSL_SESSION>());
-    }
 }

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -49,7 +49,7 @@ pub struct stack_st_void {
 
 #[repr(C)]
 pub struct crypto_ex_data_st {
-    pub sk: stack_st_void,
+    pub sk: *mut stack_st_void,
 }
 
 #[repr(C)]
@@ -664,7 +664,7 @@ extern {
                                                                 is_export: c_int,
                                                                 keylength: c_int)
                                                                 -> *mut ::EC_KEY);
-    pub fn SSL_get_session(ssl: *mut ::SSL,ssl_session: *mut ::SSL_SESSION) -> c_int;
+    pub fn SSL_get_session(ssl: *mut ::SSL) -> *mut ::SSL_SESSION;
     pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
     pub fn X509_set_notAfter(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;
     pub fn X509_set_notBefore(x: *mut ::X509, tm: *const ::ASN1_TIME) -> c_int;

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -434,8 +434,13 @@ pub struct SSL_SESSION {
     session_id: [c_uchar; SSL_MAX_SSL_SESSION_ID_LENGTH],
     sid_ctx_length: size_t,
     sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH],
+
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
     psk_identity_hint: *mut c_char,
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
     psk_identity: *mut c_char,
+
+
     not_resumable: c_int,
     peer: *mut X509,
     peer_type: c_int,
@@ -452,14 +457,23 @@ pub struct SSL_SESSION {
     prev: *mut SSL_SESSION,
     next: *mut SSL_SESSION,
     tlsext_hostname: *mut c_char,
+
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_ecpointformatlist_length: size_t,
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_ecpointformatlist: *mut c_uchar,
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_supportedgroupslist_length: size_t,
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
     tlsext_supportedgroupslist: *mut c_uchar,
+
     tlsext_tick: *mut c_uchar,
     tlsext_ticklen: size_t,
-    tlsext_tick_lifetime_hint: c_long,
+    tlsext_tick_lifetime_hint: c_ulong,
+
+    #[cfg(not(osslconf = "OPENSSL_NO_SRP"))]
     srp_username: *mut c_char,
+
     flags: uint32_t,
     lock: *mut c_void,
 }

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -462,7 +462,6 @@ pub struct SSL_SESSION {
     srp_username: *mut c_char,
     flags: uint32_t,
     lock: *mut c_void,
-    pub dummy: c_int,
 }
 
 #[repr(C)]

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, c_void, c_char, c_uchar, c_ulong, c_long, c_uint}; 
+use libc::{c_int, c_void, c_char, c_uchar, c_ulong, c_long, c_uint, size_t, uint32_t}; 
 
 pub enum BIGNUM {}
 pub enum BIO {}

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, c_void, c_char, c_uchar, c_ulong, c_long, c_uint};
+use libc::{c_int, c_void, c_char, c_uchar, c_ulong, c_long, c_uint}; 
 
 pub enum BIGNUM {}
 pub enum BIO {}
@@ -13,7 +13,6 @@ pub enum HMAC_CTX {}
 pub enum OPENSSL_STACK {}
 pub enum RSA {}
 pub enum SSL_CTX {}
-pub enum SSL_SESSION {}
 pub enum stack_st_SSL_CIPHER {}
 pub enum stack_st_ASN1_OBJECT {}
 pub enum stack_st_GENERAL_NAME {}
@@ -25,6 +24,66 @@ pub enum stack_st_X509_ATTRIBUTE {}
 pub enum stack_st_X509_EXTENSION {}
 pub enum X509 {}
 pub enum X509_VERIFY_PARAM {}
+
+
+
+
+pub const SSL_MAX_MASTER_KEY_LENGTH: usize = 48;
+pub const SSL_MAX_SSL_SESSION_ID_LENGTH: usize = 32;
+pub const SSL_MAX_SID_CTX_LENGTH: usize = 32;
+
+#[repr(C)]
+pub struct SSL_SESSION {
+    ssl_version: c_int,
+    master_key_length: size_t,
+    master_key: [c_uchar; SSL_MAX_MASTER_KEY_LENGTH],
+    session_id_length: size_t,
+    session_id: [c_uchar; SSL_MAX_SSL_SESSION_ID_LENGTH],
+    sid_ctx_length: size_t,
+    sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH],
+
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+    psk_identity_hint: *mut c_void,
+
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+    psk_identity: *mut c_void,
+
+    not_resumable: c_int,
+    peer: *mut X509,
+    peer_type: c_int,
+    peer_chain: *mut stack_st_X509,
+    verify_result: c_long,
+    references: c_int, //This must be atomic
+    timeout: c_long,
+    time: c_long,
+    compress_meth: c_uint,
+    cipher: *const ::SSL_CIPHER,
+    cipher_id: c_ulong,
+    ciphers: *mut stack_st_SSL_CIPHER,
+    ex_data: ::CRYPTO_EX_DATA,
+    prev: *mut SSL_SESSION,
+    next: *mut SSL_SESSION,
+    tlsext_hostname: *mut c_void,
+
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
+    tlsext_ecpointformatlist_length: size_t,
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
+    tlsext_ecpointformatlist: *mut c_uchar,
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
+    tlsext_supportedgroupslist_length: size_t,
+    #[cfg(all(not(osslconf = "OPENSSL_NO_TLSEXT"), not(osslconf = "OPENSSL_NO_EC"), ossl102))]
+    tlsext_supportedgroupslist: *mut c_void,
+
+    tlsext_tick: *mut c_void,
+    tlsext_ticklen: size_t,
+    tlsext_tick_lifetime_hint: c_ulong,
+
+    #[cfg(not(osslconf = "OPENSSL_NO_SRP"))]
+    srp_username: *mut c_void,
+
+    flags: uint32_t,
+    lock: *mut c_void,
+}
 
 
 pub const SSL_OP_MICROSOFT_SESS_ID_BUG: c_ulong =                   0x00000000;

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -23,7 +23,6 @@ pub enum stack_st_X509 {}
 pub enum stack_st_X509_NAME {}
 pub enum stack_st_X509_ATTRIBUTE {}
 pub enum stack_st_X509_EXTENSION {}
-pub enum crypto_ex_data_st {}
 pub enum X509 {}
 pub enum X509_VERIFY_PARAM {}
 
@@ -123,7 +122,7 @@ extern {
     pub fn SSL_CTX_get_options(ctx: *const ::SSL_CTX) -> c_ulong;
     pub fn SSL_CTX_set_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
     pub fn SSL_CTX_clear_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
-    pub fn SSL_get_session(ssl: *mut ::SSL, ssl_session: *mut ::SSL_SESSION) -> c_int;
+    pub fn SSL_get_session(ssl: *const ::SSL, ssl_session: *mut ::SSL_SESSION) -> c_int;
     pub fn X509_getm_notAfter(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn X509_getm_notBefore(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn DH_set0_pqg(dh: *mut ::DH,

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -123,7 +123,7 @@ extern {
     pub fn SSL_CTX_get_options(ctx: *const ::SSL_CTX) -> c_ulong;
     pub fn SSL_CTX_set_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
     pub fn SSL_CTX_clear_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
-    pub fn SSL_get_session(ssl: *mut ::SSL) -> *mut ::SSL_SESSION;
+    pub fn SSL_get_session(ssl: *mut ::SSL, ssl_session: *mut ::SSL_SESSION) -> c_int;
     pub fn X509_getm_notAfter(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn X509_getm_notBefore(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn DH_set0_pqg(dh: *mut ::DH,

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -13,6 +13,8 @@ pub enum HMAC_CTX {}
 pub enum OPENSSL_STACK {}
 pub enum RSA {}
 pub enum SSL_CTX {}
+pub enum SSL_SESSION {}
+pub enum stack_st_SSL_CIPHER {}
 pub enum stack_st_ASN1_OBJECT {}
 pub enum stack_st_GENERAL_NAME {}
 pub enum stack_st_OPENSSL_STRING {}
@@ -21,8 +23,14 @@ pub enum stack_st_X509 {}
 pub enum stack_st_X509_NAME {}
 pub enum stack_st_X509_ATTRIBUTE {}
 pub enum stack_st_X509_EXTENSION {}
+pub enum crypto_ex_data_st {}
 pub enum X509 {}
 pub enum X509_VERIFY_PARAM {}
+
+
+const SSL_MAX_MASTER_KEY_LENGTH: usize = 48;
+const SSL_MAX_SSL_SESSION_ID_LENGTH: usize = 32;
+const SSL_MAX_SID_CTX_LENGTH: usize = 32;
 
 pub const SSL_OP_MICROSOFT_SESS_ID_BUG: c_ulong =                   0x00000000;
 pub const SSL_OP_NETSCAPE_CHALLENGE_BUG: c_ulong =                  0x00000000;

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -123,6 +123,7 @@ extern {
     pub fn SSL_CTX_get_options(ctx: *const ::SSL_CTX) -> c_ulong;
     pub fn SSL_CTX_set_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
     pub fn SSL_CTX_clear_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
+    pub fn SSL_get_session(ssl: *mut ::SSL) -> *mut ::SSL_SESSION;
     pub fn X509_getm_notAfter(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn X509_getm_notBefore(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn DH_set0_pqg(dh: *mut ::DH,

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -122,7 +122,7 @@ extern {
     pub fn SSL_CTX_get_options(ctx: *const ::SSL_CTX) -> c_ulong;
     pub fn SSL_CTX_set_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
     pub fn SSL_CTX_clear_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
-    pub fn SSL_get_session(ssl: *const ::SSL, ssl_session: *mut ::SSL_SESSION) -> c_int;
+    pub fn SSL_get_session(ssl: *mut ::SSL, ssl_session: *mut ::SSL_SESSION) -> c_int;
     pub fn X509_getm_notAfter(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn X509_getm_notBefore(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn DH_set0_pqg(dh: *mut ::DH,

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -27,10 +27,6 @@ pub enum X509 {}
 pub enum X509_VERIFY_PARAM {}
 
 
-const SSL_MAX_MASTER_KEY_LENGTH: usize = 48;
-const SSL_MAX_SSL_SESSION_ID_LENGTH: usize = 32;
-const SSL_MAX_SID_CTX_LENGTH: usize = 32;
-
 pub const SSL_OP_MICROSOFT_SESS_ID_BUG: c_ulong =                   0x00000000;
 pub const SSL_OP_NETSCAPE_CHALLENGE_BUG: c_ulong =                  0x00000000;
 pub const SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG: c_ulong =        0x00000000;
@@ -122,7 +118,7 @@ extern {
     pub fn SSL_CTX_get_options(ctx: *const ::SSL_CTX) -> c_ulong;
     pub fn SSL_CTX_set_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
     pub fn SSL_CTX_clear_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
-    pub fn SSL_get_session(ssl: *mut ::SSL, ssl_session: *mut ::SSL_SESSION) -> c_int;
+
     pub fn X509_getm_notAfter(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn X509_getm_notBefore(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn DH_set0_pqg(dh: *mut ::DH,

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, c_void, c_char, c_uchar, c_ulong, c_long, c_uint, size_t, uint32_t}; 
+use libc::{c_int, c_void, c_char, c_uchar, c_ulong, c_long, c_uint, size_t, uint32_t};
 
 pub enum BIGNUM {}
 pub enum BIO {}
@@ -22,6 +22,7 @@ pub enum stack_st_X509 {}
 pub enum stack_st_X509_NAME {}
 pub enum stack_st_X509_ATTRIBUTE {}
 pub enum stack_st_X509_EXTENSION {}
+pub enum ssl_session_st {} 
 pub enum X509 {}
 pub enum X509_VERIFY_PARAM {}
 
@@ -177,7 +178,7 @@ extern {
     pub fn SSL_CTX_get_options(ctx: *const ::SSL_CTX) -> c_ulong;
     pub fn SSL_CTX_set_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
     pub fn SSL_CTX_clear_options(ctx: *mut ::SSL_CTX, op: c_ulong) -> c_ulong;
-
+    pub fn SSL_get_session(ssl: *const ::SSL) -> *mut ::SSL_SESSION;
     pub fn X509_getm_notAfter(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn X509_getm_notBefore(x: *const ::X509) -> *mut ::ASN1_TIME;
     pub fn DH_set0_pqg(dh: *mut ::DH,


### PR DESCRIPTION
I have modified libressl.rs, ossl10x.rs, and ossl110.rs in openssl-sys to include SSL_SESSION which is a struct representing the current session. Also, I added SSL_get_session which is a function returning a pointer to SSL_SESSION. This is a useful addition that provides access to session data including the session key. 