### PR TITLE
LibreSSL support improvements

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1206,15 +1206,15 @@ pub const X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE: c_int = 45;
 pub const X509_V_ERR_UNSUPPORTED_NAME_SYNTAX: c_int = 53;
 pub const X509_V_OK: c_int = 0;
 
-#[cfg(not(ossl101))]
+#[cfg(not(any(ossl101, libressl)))]
 pub const X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT: c_uint = 0x1;
-#[cfg(not(ossl101))]
+#[cfg(not(any(ossl101, libressl)))]
 pub const X509_CHECK_FLAG_NO_WILDCARDS: c_uint = 0x2;
-#[cfg(not(ossl101))]
+#[cfg(not(any(ossl101, libressl)))]
 pub const X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS: c_uint = 0x4;
-#[cfg(not(ossl101))]
+#[cfg(not(any(ossl101, libressl)))]
 pub const X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS: c_uint = 0x8;
-#[cfg(not(ossl101))]
+#[cfg(not(any(ossl101, libressl)))]
 pub const X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS: c_uint = 0x10;
 
 pub const GEN_OTHERNAME: c_int = 0;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -774,12 +774,12 @@ impl SslContextBuilder {
     /// curve.
     ///
     /// Requires the `v102` feature and OpenSSL 1.0.2.
-    #[cfg(all(feature = "v102", ossl102))]
+    #[cfg(all(feature = "v102", any(ossl102, libressl)))]
     pub fn set_ecdh_auto(&mut self, onoff: bool) -> Result<(), ErrorStack> {
         self._set_ecdh_auto(onoff)
     }
 
-    #[cfg(ossl102)]
+    #[cfg(any(ossl102,libressl))]
     fn _set_ecdh_auto(&mut self, onoff: bool) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::SSL_CTX_set_ecdh_auto(self.as_ptr(), onoff as c_int)).map(|_| ()) }
     }


### PR DESCRIPTION
Makes test pass with libressl 2.4.4 and export set_ecdh_auto