### PR TITLE
Fix cross-compiling from Linux to windows-gnu (MinGW)

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -44,7 +44,11 @@ fn main() {
     let libs = if (version.contains("0x10001") ||
                    version.contains("0x10002")) &&
                   target.contains("windows") {
-        ["ssleay32", "libeay32"]
+        if target.contains("windows-gnu") {
+            ["ssl", "crypto"]
+        } else {
+            ["ssleay32", "libeay32"]
+        }
     } else if target.contains("windows") {
         ["libssl", "libcrypto"]
     } else {

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -168,6 +168,13 @@ fn try_pkg_config() {
     // Otherwise if we're going to windows we probably can't use pkg-config.
     if target.contains("windows-gnu") && host.contains("windows") {
         env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
+    } else if target.contains("windows-gnu") && host.contains("linux") {
+        env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
+        if target.contains("x86_64") {
+            env::set_var("PKG_CONFIG_PATH", "/usr/x86_64-w64-mingw32/lib/pkgconfig");
+        } else if target.contains("i686") {
+            env::set_var("PKG_CONFIG_PATH", "/usr/i686-w64-mingw32/lib/pkgconfig");
+        }
     } else if target.contains("windows") {
         return
     }

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -174,10 +174,13 @@ fn try_pkg_config() {
     if target.contains("windows-gnu") && host.contains("windows") {
         env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
     } else if target.contains("windows-gnu") && host.contains("linux") {
-        env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
-        if target.contains("x86_64") {
+        let pc_x86_64 = Path::new("/usr/x86_64-w64-mingw32/lib/pkgconfig/libssl.pc");
+        let pc_i686 = Path::new("/usr/i686-w64-mingw32/lib/pkgconfig/libssl.pc");
+        if target.contains("x86_64") && pc_x86_64.exists() {
+            env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
             env::set_var("PKG_CONFIG_PATH", "/usr/x86_64-w64-mingw32/lib/pkgconfig");
-        } else if target.contains("i686") {
+        } else if target.contains("i686") && pc_i686.exists() {
+            env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
             env::set_var("PKG_CONFIG_PATH", "/usr/i686-w64-mingw32/lib/pkgconfig");
         }
     } else if target.contains("windows") {

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -44,16 +44,16 @@ fn main() {
 
     let libs = if target.contains("windows-gnu") && host.contains("linux") {
         ["ssl", "crypto"]
-    } else if version.contains("0x10100") && target.contains("windows-gnu") {
-        if target.contains("x86_64") {
-            ["libssl-1_1-x64" ,"libcrypto-1_1-x64"]
-        } else {
-            ["libssl-1_1" ,"libcrypto-1_1"]
-        }
     } else if (version.contains("0x10001") ||
                    version.contains("0x10002")) &&
                   target.contains("windows") {
         ["ssleay32", "libeay32"]
+    } else if version.contains("0x00908") && target.contains("windows") {
+        if target.contains("x86_64") {
+            ["ssleay32", "libeay32"]
+        } else {
+            ["ssl", "crypto"]
+        }
     } else if target.contains("windows") {
         ["libssl", "libcrypto"]
     } else {

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -44,7 +44,7 @@ fn main() {
 
     let libs = if target.contains("windows-gnu") && host.contains("linux") {
         ["ssl", "crypto"]
-    } else if version.contains("0x10100") && target.contains("windows") {
+    } else if version.contains("0x10100") && target.contains("windows-gnu") {
         if target.contains("x86_64") {
             ["libssl-1_1-x64" ,"libcrypto-1_1-x64"]
         } else {

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -174,14 +174,17 @@ fn try_pkg_config() {
     if target.contains("windows-gnu") && host.contains("windows") {
         env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
     } else if target.contains("windows-gnu") && host.contains("linux") {
-        let pc_x86_64 = Path::new("/usr/x86_64-w64-mingw32/lib/pkgconfig/libssl.pc");
-        let pc_i686 = Path::new("/usr/i686-w64-mingw32/lib/pkgconfig/libssl.pc");
-        if target.contains("x86_64") && pc_x86_64.exists() {
-            env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
-            env::set_var("PKG_CONFIG_PATH", "/usr/x86_64-w64-mingw32/lib/pkgconfig");
-        } else if target.contains("i686") && pc_i686.exists() {
-            env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
-            env::set_var("PKG_CONFIG_PATH", "/usr/i686-w64-mingw32/lib/pkgconfig");
+        env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
+        if target.contains("x86_64") {
+            env::set_var("PKG_CONFIG_PATH",
+                         &format!("{}:{}",
+                                  env::var("PKG_CONFIG_PATH").unwrap_or("".to_string()),
+                                  "/usr/x86_64-w64-mingw32/lib/pkgconfig"));
+        } else if target.contains("i686") {
+            env::set_var("PKG_CONFIG_PATH",
+                         &format!("{}:{}",
+                                  env::var("PKG_CONFIG_PATH").unwrap_or("".to_string()),
+                                  "/usr/i686-w64-mingw32/lib/pkgconfig"));
         }
     } else if target.contains("windows") {
         return


### PR DESCRIPTION
***NOTE*** I'm not quite familiar with the naming convention of OpenSSL libraries. This PR did fix my issue, but I'm not sure whether it would work or not under other platforms.

I was working on a Docker image to help myself cross-compile from Linux (Debian) to `x86_64-pc-windows-gnu`. ([Docker Hub](https://hub.docker.com/r/frederickzh/mingw/), [Dockerfile](https://git.tsundere.moe/Frederick888/docker-mingw/blob/rust-nightly/Dockerfile)). The `build.rs` was not able to find the libraries although I've compiled it so I made this PR.

Tested: native compilation on Linux & cross-compilation from Linux to `x86_64-pc-windows-gnu`.