### PR TITLE
Add PKey context options

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -153,6 +153,10 @@ pub const EVP_PKEY_EC: c_int = NID_X9_62_id_ecPublicKey;
 
 pub const EVP_PKEY_ALG_CTRL: c_int = 0x1000;
 
+pub const EVP_PKEY_CTRL_RSA_PADDING: c_int = EVP_PKEY_ALG_CTRL + 1;
+
+pub const EVP_PKEY_CTRL_GET_RSA_PADDING: c_int = EVP_PKEY_ALG_CTRL + 6;
+
 pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
 pub const EVP_CTRL_GCM_GET_TAG: c_int = 0x10;
 pub const EVP_CTRL_GCM_SET_TAG: c_int = 0x11;
@@ -1123,10 +1127,6 @@ pub const RSA_NO_PADDING: c_int = 3;
 pub const RSA_PKCS1_OAEP_PADDING: c_int = 4;
 pub const RSA_X931_PADDING: c_int = 5;
 
-pub const RSA_PKEY_CTRL_RSA_PADDING: c_int = EVP_PKEY_ALG_CTRL + 1;
-
-pub const RSA_PKEY_CTRL_GET_RSA_PADDING: c_int = EVP_PKEY_ALG_CTRL + 6;
-
 pub const SSL_CTRL_SET_TMP_DH: c_int = 3;
 pub const SSL_CTRL_SET_TMP_ECDH: c_int = 4;
 pub const SSL_CTRL_EXTRA_CHAIN_CERT: c_int = 14;
@@ -1312,11 +1312,11 @@ pub unsafe fn BIO_set_retry_write(b: *mut BIO) {
 
 // EVP_PKEY_CTX_ctrl macros
 pub unsafe fn EVP_PKEY_CTX_set_rsa_padding(ctx: *mut EVP_PKEY_CTX, pad: c_int) -> c_int {
-    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, RSA_PKEY_CTRL_RSA_PADDING, pad, ptr::null_mut())
+    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, EVP_PKEY_CTRL_RSA_PADDING, pad, ptr::null_mut())
 }
 
 pub unsafe fn EVP_PKEY_CTX_get_rsa_padding(ctx: *mut EVP_PKEY_CTX, ppad: *mut c_int) -> c_int {
-    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, RSA_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
+    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, EVP_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
 }
 
 pub unsafe fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, op: c_long) -> c_long {

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1638,6 +1638,9 @@ extern {
                                 key: *const c_uchar,
                                 keylen: c_int) -> *mut EVP_PKEY;
 
+
+    pub fn EVP_PKEY_CTX_ctrl(ctx: *mut EVP_PKEY_CTX, keytype: c_int, optype: c_int, cmd: c_int, p1: c_int, p2: *mut c_void) -> c_int;
+
     pub fn HMAC_CTX_copy(dst: *mut HMAC_CTX, src: *mut HMAC_CTX) -> c_int;
 
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
@@ -1732,7 +1735,6 @@ extern {
     pub fn RSA_new() -> *mut RSA;
     pub fn RSA_free(rsa: *mut RSA);
     pub fn RSA_generate_key_ex(rsa: *mut RSA, bits: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int;
-    pub fn RSA_pkey_ctx_ctrl(ctx: *mut EVP_PKEY_CTX, optype: c_int, cmd: c_int, p1: c_int, p2: *mut c_void) -> c_int;
     pub fn RSA_private_decrypt(flen: c_int, from: *const u8, to: *mut u8, k: *mut RSA,
                                pad: c_int) -> c_int;
     pub fn RSA_public_decrypt(flen: c_int, from: *const u8, to: *mut u8, k: *mut RSA,
@@ -2005,10 +2007,10 @@ extern {
 }
 
 // EVP_PKEY_CTX_ctrl macros
-unsafe fn EVP_PKEY_CTX_set_rsa_padding(ctx: *mut EVP_PKEY_CTX, pad: c_int) -> c_int {
-    RSA_pkey_ctx_ctrl(ctx, -1, RSA_PKEY_CTRL_RSA_PADDING, pad, ptr::null_mut())
+pub unsafe fn EVP_PKEY_CTX_set_rsa_padding(ctx: *mut EVP_PKEY_CTX, pad: c_int) -> c_int {
+    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, RSA_PKEY_CTRL_RSA_PADDING, pad, ptr::null_mut())
 }
 
-unsafe fn EVP_PKEY_CTX_get_rsa_padding(ctx: *mut EVP_PKEY_CTX, ppad: *mut c_int) -> c_int {
-    RSA_pkey_ctx_ctrl(ctx, -1, RSA_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
+pub unsafe fn EVP_PKEY_CTX_get_rsa_padding(ctx: *mut EVP_PKEY_CTX, ppad: *mut c_int) -> c_int {
+    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, RSA_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
 }

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -2005,12 +2005,3 @@ extern {
                       md: *mut c_uchar,
                       len: *mut c_uint) -> c_int;
 }
-
-// EVP_PKEY_CTX_ctrl macros
-pub unsafe fn EVP_PKEY_CTX_set_rsa_padding(ctx: *mut EVP_PKEY_CTX, pad: c_int) -> c_int {
-    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, RSA_PKEY_CTRL_RSA_PADDING, pad, ptr::null_mut())
-}
-
-pub unsafe fn EVP_PKEY_CTX_get_rsa_padding(ctx: *mut EVP_PKEY_CTX, ppad: *mut c_int) -> c_int {
-    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, RSA_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
-}

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -151,6 +151,8 @@ pub const EVP_PKEY_DSA: c_int = NID_dsa;
 pub const EVP_PKEY_DH: c_int = NID_dhKeyAgreement;
 pub const EVP_PKEY_EC: c_int = NID_X9_62_id_ecPublicKey;
 
+pub const EVP_PKEY_ALG_CTRL: c_int = 0x1000;
+
 pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
 pub const EVP_CTRL_GCM_GET_TAG: c_int = 0x10;
 pub const EVP_CTRL_GCM_SET_TAG: c_int = 0x11;
@@ -1121,6 +1123,10 @@ pub const RSA_NO_PADDING: c_int = 3;
 pub const RSA_PKCS1_OAEP_PADDING: c_int = 4;
 pub const RSA_X931_PADDING: c_int = 5;
 
+pub const RSA_PKEY_CTRL_RSA_PADDING: c_int = EVP_PKEY_ALG_CTRL + 1;
+
+pub const RSA_PKEY_CTRL_GET_RSA_PADDING: c_int = EVP_PKEY_ALG_CTRL + 6;
+
 pub const SSL_CTRL_SET_TMP_DH: c_int = 3;
 pub const SSL_CTRL_SET_TMP_ECDH: c_int = 4;
 pub const SSL_CTRL_EXTRA_CHAIN_CERT: c_int = 14;
@@ -1726,6 +1732,7 @@ extern {
     pub fn RSA_new() -> *mut RSA;
     pub fn RSA_free(rsa: *mut RSA);
     pub fn RSA_generate_key_ex(rsa: *mut RSA, bits: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int;
+    pub fn RSA_pkey_ctx_ctrl(ctx: *mut EVP_PKEY_CTX, optype: c_int, cmd: c_int, p1: c_int, p2: *mut c_void) -> c_int;
     pub fn RSA_private_decrypt(flen: c_int, from: *const u8, to: *mut u8, k: *mut RSA,
                                pad: c_int) -> c_int;
     pub fn RSA_public_decrypt(flen: c_int, from: *const u8, to: *mut u8, k: *mut RSA,
@@ -1995,4 +2002,13 @@ extern {
     pub fn HMAC_Final(ctx: *mut HMAC_CTX,
                       md: *mut c_uchar,
                       len: *mut c_uint) -> c_int;
+}
+
+// EVP_PKEY_CTX_ctrl macros
+unsafe fn EVP_PKEY_CTX_set_rsa_padding(ctx: *mut EVP_PKEY_CTX, pad: c_int) -> c_int {
+    RSA_pkey_ctx_ctrl(ctx, -1, RSA_PKEY_CTRL_RSA_PADDING, pad, ptr::null_mut())
+}
+
+unsafe fn EVP_PKEY_CTX_get_rsa_padding(ctx: *mut EVP_PKEY_CTX, ppad: *mut c_int) -> c_int {
+    RSA_pkey_ctx_ctrl(ctx, -1, RSA_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
 }

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1310,6 +1310,15 @@ pub unsafe fn BIO_set_retry_write(b: *mut BIO) {
     BIO_set_flags(b, BIO_FLAGS_WRITE | BIO_FLAGS_SHOULD_RETRY)
 }
 
+// EVP_PKEY_CTX_ctrl macros
+pub unsafe fn EVP_PKEY_CTX_set_rsa_padding(ctx: *mut EVP_PKEY_CTX, pad: c_int) -> c_int {
+    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, RSA_PKEY_CTRL_RSA_PADDING, pad, ptr::null_mut())
+}
+
+pub unsafe fn EVP_PKEY_CTX_get_rsa_padding(ctx: *mut EVP_PKEY_CTX, ppad: *mut c_int) -> c_int {
+    EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, -1, RSA_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
+}
+
 pub unsafe fn SSL_CTX_set_mode(ctx: *mut SSL_CTX, op: c_long) -> c_long {
     SSL_CTX_ctrl(ctx, SSL_CTRL_MODE, op, ptr::null_mut())
 }

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -151,6 +151,12 @@ impl PKey {
     }
 }
 
+pub struct PKeyCtxRef(::util::Opaque);
+
+impl ::types::OpenSslTypeRef for PKeyCtxRef {
+    type CType = ffi::EVP_PKEY_CTX;
+}
+
 #[cfg(test)]
 mod tests {
     use symm::Cipher;

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -8,7 +8,7 @@ use bio::MemBioSlice;
 use dh::Dh;
 use dsa::Dsa;
 use ec::EcKey;
-use rsa::Rsa;
+use rsa::{Rsa, Padding};
 use error::ErrorStack;
 use util::{CallbackState, invoke_passwd_cb_old};
 use types::{OpenSslType, OpenSslTypeRef};
@@ -152,6 +152,23 @@ impl PKey {
 }
 
 pub struct PKeyCtxRef(::util::Opaque);
+
+impl PKeyCtxRef {
+    pub fn set_rsa_padding(&mut self, pad: Padding) -> Result<(), ErrorStack> {
+        unsafe {
+            try!(cvt(ffi::EVP_PKEY_CTX_set_rsa_padding(self.as_ptr(), pad.as_raw())));
+        }
+        Ok(())
+    }
+
+    pub fn rsa_padding(&mut self) -> Result<Padding, ErrorStack> {
+        let mut pad: c_int = 0;
+        unsafe {
+            try!(cvt(ffi::EVP_PKEY_CTX_get_rsa_padding(self.as_ptr(), &mut pad)));
+        };
+        Ok(Padding::from_raw(pad))
+    }
+}
 
 impl ::types::OpenSslTypeRef for PKeyCtxRef {
     type CType = ffi::EVP_PKEY_CTX;

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -161,7 +161,7 @@ impl PKeyCtxRef {
         Ok(())
     }
 
-    pub fn rsa_padding(&mut self) -> Result<Padding, ErrorStack> {
+    pub fn rsa_padding(&self) -> Result<Padding, ErrorStack> {
         let mut pad: c_int = 0;
         unsafe {
             try!(cvt(ffi::EVP_PKEY_CTX_get_rsa_padding(self.as_ptr(), &mut pad)));

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -353,6 +353,7 @@ unsafe fn pkey_ctx_get_rsa_padding(ctx: *mut ffi::EVP_PKEY_CTX, ppad: *mut c_int
     ffi::EVP_PKEY_CTX_ctrl(ctx, ffi::EVP_PKEY_RSA, -1, ffi::RSA_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
 }
 
+// This is needed here, as it needs access to the privade data of Padding.
 impl PKeyCtxRef {
     pub fn set_rsa_padding(&mut self, pad: Padding) -> Result<(), ErrorStack> {
         unsafe {

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -344,10 +344,19 @@ mod compat {
     }
 }
 
+// EVP_PKEY_CTX_ctrl macros
+unsafe fn pkey_ctx_set_rsa_padding(ctx: *mut ffi::EVP_PKEY_CTX, pad: c_int) -> c_int {
+    ffi::EVP_PKEY_CTX_ctrl(ctx, ffi::EVP_PKEY_RSA, -1, ffi::RSA_PKEY_CTRL_RSA_PADDING, pad, ptr::null_mut())
+}
+
+unsafe fn pkey_ctx_get_rsa_padding(ctx: *mut ffi::EVP_PKEY_CTX, ppad: *mut c_int) -> c_int {
+    ffi::EVP_PKEY_CTX_ctrl(ctx, ffi::EVP_PKEY_RSA, -1, ffi::RSA_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
+}
+
 impl PKeyCtxRef {
     pub fn set_rsa_padding(&mut self, pad: Padding) -> Result<(), ErrorStack> {
         unsafe {
-            try!(cvt(ffi::EVP_PKEY_CTX_set_rsa_padding(self.as_ptr(), pad.0)));
+            try!(cvt(pkey_ctx_set_rsa_padding(self.as_ptr(), pad.0)));
         }
         Ok(())
     }
@@ -355,7 +364,7 @@ impl PKeyCtxRef {
     pub fn get_rsa_padding(&mut self) -> Result<Padding, ErrorStack> {
         let mut pad: c_int = 0;
         unsafe {
-            try!(cvt(ffi::EVP_PKEY_CTX_get_rsa_padding(self.as_ptr(), &mut pad)));
+            try!(cvt(pkey_ctx_get_rsa_padding(self.as_ptr(), &mut pad)));
         };
         Ok(Padding(pad))
     }

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -353,7 +353,7 @@ unsafe fn pkey_ctx_get_rsa_padding(ctx: *mut ffi::EVP_PKEY_CTX, ppad: *mut c_int
     ffi::EVP_PKEY_CTX_ctrl(ctx, ffi::EVP_PKEY_RSA, -1, ffi::RSA_PKEY_CTRL_GET_RSA_PADDING, 0, ppad as *mut c_void)
 }
 
-// This is needed here, as it needs access to the privade data of Padding.
+// This is needed here, as it needs access to the private data of Padding.
 impl PKeyCtxRef {
     pub fn set_rsa_padding(&mut self, pad: Padding) -> Result<(), ErrorStack> {
         unsafe {

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -10,9 +10,10 @@ use bio::MemBioSlice;
 use error::ErrorStack;
 use util::{CallbackState, invoke_passwd_cb_old};
 use types::OpenSslTypeRef;
+use pkey::PKeyCtxRef;
 
 /// Type of encryption padding to use.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Padding(c_int);
 
 pub const NO_PADDING: Padding = Padding(ffi::RSA_NO_PADDING);
@@ -343,6 +344,22 @@ mod compat {
     }
 }
 
+impl PKeyCtxRef {
+    pub fn set_rsa_padding(&mut self, pad: Padding) -> Result<(), ErrorStack> {
+        unsafe {
+            try!(cvt(ffi::EVP_PKEY_CTX_set_rsa_padding(self.as_ptr(), pad.0)));
+        }
+        Ok(())
+    }
+
+    pub fn get_rsa_padding(&mut self) -> Result<Padding, ErrorStack> {
+        let mut pad: c_int = 0;
+        unsafe {
+            try!(cvt(ffi::EVP_PKEY_CTX_get_rsa_padding(self.as_ptr(), &mut pad)));
+        };
+        Ok(Padding(pad))
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -109,6 +109,9 @@ impl<'a> Signer<'a> {
                 EVP_MD_CTX_free(ctx);
                 return Err(ErrorStack::get());
             }
+
+            assert!(!pctx.is_null());
+
             Ok(Signer {
                 md_ctx: ctx,
                 pkey_ctx: pctx,
@@ -118,8 +121,8 @@ impl<'a> Signer<'a> {
         }
     }
 
-    pub fn pkey_ctx(&mut self) -> Option<&mut PKeyCtxRef> {
-        unsafe { self.pkey_ctx.as_mut().map(|ctx| ::types::OpenSslTypeRef::from_ptr_mut(ctx)) }
+    pub fn pkey_ctx(&mut self) -> &mut PKeyCtxRef {
+        unsafe { ::types::OpenSslTypeRef::from_ptr_mut(self.pkey_ctx) }
     }
 
     pub fn update(&mut self, buf: &[u8]) -> Result<(), ErrorStack> {
@@ -185,6 +188,8 @@ impl<'a> Verifier<'a> {
                 return Err(ErrorStack::get());
             }
 
+            assert!(!pctx.is_null());
+
             Ok(Verifier {
                 md_ctx: ctx,
                 pkey_ctx: pctx,
@@ -194,8 +199,8 @@ impl<'a> Verifier<'a> {
         }
     }
 
-    pub fn pkey_ctx(&mut self) -> Option<&mut PKeyCtxRef> {
-        unsafe { self.pkey_ctx.as_mut().map(|ctx| ::types::OpenSslTypeRef::from_ptr_mut(ctx)) }
+    pub fn pkey_ctx(&mut self) -> &mut PKeyCtxRef {
+        unsafe { ::types::OpenSslTypeRef::from_ptr_mut(self.pkey_ctx) }
     }
 
     pub fn update(&mut self, buf: &[u8]) -> Result<(), ErrorStack> {
@@ -286,8 +291,8 @@ mod test {
         let pkey = PKey::from_rsa(private_key).unwrap();
 
         let mut signer = Signer::new(MessageDigest::sha256(), &pkey).unwrap();
-        assert_eq!(signer.pkey_ctx().unwrap().get_rsa_padding().unwrap(), PKCS1_PADDING);
-        signer.pkey_ctx().unwrap().set_rsa_padding(PKCS1_PADDING).unwrap();
+        assert_eq!(signer.pkey_ctx().get_rsa_padding().unwrap(), PKCS1_PADDING);
+        signer.pkey_ctx().set_rsa_padding(PKCS1_PADDING).unwrap();
         signer.update(INPUT).unwrap();
         let result = signer.finish().unwrap();
 
@@ -301,7 +306,7 @@ mod test {
         let pkey = PKey::from_rsa(private_key).unwrap();
 
         let mut verifier = Verifier::new(MessageDigest::sha256(), &pkey).unwrap();
-        assert_eq!(verifier.pkey_ctx().unwrap().get_rsa_padding().unwrap(), PKCS1_PADDING);
+        assert_eq!(verifier.pkey_ctx().get_rsa_padding().unwrap(), PKCS1_PADDING);
         verifier.update(INPUT).unwrap();
         assert!(verifier.finish(SIGNATURE).unwrap());
     }

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -81,7 +81,6 @@ pub struct Signer<'a> {
     md_ctx: *mut ffi::EVP_MD_CTX,
     pkey_ctx: *mut ffi::EVP_PKEY_CTX,
     pkey_pd: PhantomData<&'a PKeyRef>,
-    pkey_ctx_pd: PhantomData<&'a PKeyCtxRef>
 }
 
 impl<'a> Drop for Signer<'a> {
@@ -116,12 +115,11 @@ impl<'a> Signer<'a> {
                 md_ctx: ctx,
                 pkey_ctx: pctx,
                 pkey_pd: PhantomData,
-                pkey_ctx_pd: PhantomData
             })
         }
     }
 
-    pub fn pkey_ctx(&mut self) -> &mut PKeyCtxRef {
+    pub fn pkey_ctx_mut(&mut self) -> &mut PKeyCtxRef {
         unsafe { ::types::OpenSslTypeRef::from_ptr_mut(self.pkey_ctx) }
     }
 
@@ -159,7 +157,6 @@ pub struct Verifier<'a> {
     md_ctx: *mut ffi::EVP_MD_CTX,
     pkey_ctx: *mut ffi::EVP_PKEY_CTX,
     pkey_pd: PhantomData<&'a PKeyRef>,
-    pkey_ctx_pd: PhantomData<&'a PKeyCtxRef>,
 }
 
 impl<'a> Drop for Verifier<'a> {
@@ -194,12 +191,11 @@ impl<'a> Verifier<'a> {
                 md_ctx: ctx,
                 pkey_ctx: pctx,
                 pkey_pd: PhantomData,
-                pkey_ctx_pd: PhantomData,
             })
         }
     }
 
-    pub fn pkey_ctx(&mut self) -> &mut PKeyCtxRef {
+    pub fn pkey_ctx_mut(&mut self) -> &mut PKeyCtxRef {
         unsafe { ::types::OpenSslTypeRef::from_ptr_mut(self.pkey_ctx) }
     }
 
@@ -291,8 +287,8 @@ mod test {
         let pkey = PKey::from_rsa(private_key).unwrap();
 
         let mut signer = Signer::new(MessageDigest::sha256(), &pkey).unwrap();
-        assert_eq!(signer.pkey_ctx().get_rsa_padding().unwrap(), PKCS1_PADDING);
-        signer.pkey_ctx().set_rsa_padding(PKCS1_PADDING).unwrap();
+        assert_eq!(signer.pkey_ctx_mut().rsa_padding().unwrap(), PKCS1_PADDING);
+        signer.pkey_ctx_mut().set_rsa_padding(PKCS1_PADDING).unwrap();
         signer.update(INPUT).unwrap();
         let result = signer.finish().unwrap();
 
@@ -306,7 +302,7 @@ mod test {
         let pkey = PKey::from_rsa(private_key).unwrap();
 
         let mut verifier = Verifier::new(MessageDigest::sha256(), &pkey).unwrap();
-        assert_eq!(verifier.pkey_ctx().get_rsa_padding().unwrap(), PKCS1_PADDING);
+        assert_eq!(verifier.pkey_ctx_mut().rsa_padding().unwrap(), PKCS1_PADDING);
         verifier.update(INPUT).unwrap();
         assert!(verifier.finish(SIGNATURE).unwrap());
     }

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -119,6 +119,10 @@ impl<'a> Signer<'a> {
         }
     }
 
+    pub fn pkey_ctx(&self) -> &PKeyCtxRef {
+        unsafe { ::types::OpenSslTypeRef::from_ptr(self.pkey_ctx) }
+    }
+
     pub fn pkey_ctx_mut(&mut self) -> &mut PKeyCtxRef {
         unsafe { ::types::OpenSslTypeRef::from_ptr_mut(self.pkey_ctx) }
     }
@@ -193,6 +197,10 @@ impl<'a> Verifier<'a> {
                 pkey_pd: PhantomData,
             })
         }
+    }
+
+    pub fn pkey_ctx(&self) -> &PKeyCtxRef {
+        unsafe { ::types::OpenSslTypeRef::from_ptr(self.pkey_ctx) }
     }
 
     pub fn pkey_ctx_mut(&mut self) -> &mut PKeyCtxRef {


### PR DESCRIPTION
When using the Envelope API, OpenSSL often provides an EVP_PKEY_CTX object, which controls how the PKEY operations are performed. For example, the RSA algorithm has multiple possible padding modes. This PR provides a way of safely accessing EVP_PKEY_CTXs as a PKeyCtxRef, and provides accessors for the Signer and Verifier types.