### PR TITLE
Add MacOS and XCode hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Homebrew:
 brew install openssl
 ```
 
+> Occasionally an update of XCode or MacOS will cause the linker to fail after complication, to rectify this you may want to try and run:
+
+```bash
+xcode-select --install
+```
+
 If Homebrew is installed to the default location of `/usr/local`, OpenSSL will be
 automatically detected.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Homebrew:
 brew install openssl
 ```
 
-> Occasionally an update of XCode or MacOS will cause the linker to fail after complication, to rectify this you may want to try and run:
+> Occasionally an update of XCode or MacOS will cause the linker to fail after compilation, to rectify this you may want to try and run:
 
 ```bash
 xcode-select --install


### PR DESCRIPTION
Occasionally a MacOS or XCode update may cause the linker to start failing again.