### PR TITLE
add set_verify_cert_store() to ssl ctx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
             - binfmt-support
     - env: >
         TARGET=arm-unknown-linux-gnueabihf
-        BUILD_OPENSSL_VERSION=1.1.0d
+        BUILD_OPENSSL_VERSION=1.1.0e
         CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
         QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf
         RUST_TEST_THREADS=1
@@ -53,7 +53,7 @@ matrix:
 
     # 64-bit version compat
     - env: BUILD_OPENSSL_VERSION=1.0.2k
-    - env: BUILD_OPENSSL_VERSION=1.1.0d
+    - env: BUILD_OPENSSL_VERSION=1.1.0e
 
     # 32-bit version compat
     - env: TARGET=i686-unknown-linux-gnu BUILD_OPENSSL_VERSION=1.0.1u
@@ -66,7 +66,7 @@ matrix:
         apt:
           packages:
             - gcc-multilib
-    - env: TARGET=i686-unknown-linux-gnu BUILD_OPENSSL_VERSION=1.1.0d
+    - env: TARGET=i686-unknown-linux-gnu BUILD_OPENSSL_VERSION=1.1.0e
       addons:
         apt:
           packages:

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ compiling to a separate target, you'll typically need to compile OpenSSL from
 source. That can normally be done with:
 
 ```
-curl -O https://www.openssl.org/source/openssl-1.1.0c.tar.gz
-tar xf openssl-1.1.0c.tar.gz
-cd openssl-1.1.0c
+curl -O https://www.openssl.org/source/openssl-1.1.0e.tar.gz
+tar xf openssl-1.1.0e.tar.gz
+cd openssl-1.1.0e
 export CC=...
 ./Configure --prefix=... linux-x86_64 -fPIC
 make -j$(nproc)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ environment:
     - TARGET: i686-pc-windows-gnu
       BITS: 32
       MSYS2: 1
-      OPENSSL_VERSION: 1_1_0d
+      OPENSSL_VERSION: 1_1_0e
     - TARGET: x86_64-pc-windows-msvc
       BITS: 64
-      OPENSSL_VERSION: 1_1_0d
+      OPENSSL_VERSION: 1_1_0e
       OPENSSL_DIR: C:\OpenSSL
 
     # 1.0.2, 64/32 bit

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1143,6 +1143,7 @@ pub const SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE: c_int = 65;
 pub const SSL_CTRL_GET_TLSEXT_STATUS_REQ_OCSP_RESP: c_int = 70;
 pub const SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP: c_int = 71;
 pub const SSL_CTRL_GET_EXTRA_CHAIN_CERTS: c_int = 82;
+#[cfg(not(any(ossl101, libressl)))]
 pub const SSL_CTRL_SET_VERIFY_CERT_STORE: c_int = 106;
 
 pub const SSL_MODE_ENABLE_PARTIAL_WRITE: c_long = 0x1;
@@ -1350,6 +1351,7 @@ pub unsafe fn SSL_CTX_add_extra_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -
     SSL_CTX_ctrl(ctx, SSL_CTRL_EXTRA_CHAIN_CERT, 0, x509 as *mut c_void)
 }
 
+#[cfg(not(any(ossl101, libressl)))]
 pub unsafe fn SSL_CTX_set0_verify_cert_store(ctx: *mut SSL_CTX, st: *mut X509_STORE) -> c_long {
     SSL_CTX_ctrl(ctx, SSL_CTRL_SET_VERIFY_CERT_STORE, 0, st as *mut c_void)    
 }

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1143,6 +1143,7 @@ pub const SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE: c_int = 65;
 pub const SSL_CTRL_GET_TLSEXT_STATUS_REQ_OCSP_RESP: c_int = 70;
 pub const SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP: c_int = 71;
 pub const SSL_CTRL_GET_EXTRA_CHAIN_CERTS: c_int = 82;
+pub const SSL_CTRL_SET_VERIFY_CERT_STORE: c_int = 106;
 
 pub const SSL_MODE_ENABLE_PARTIAL_WRITE: c_long = 0x1;
 pub const SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER: c_long = 0x2;
@@ -1347,6 +1348,10 @@ pub unsafe fn SSL_set_tmp_ecdh(ssl: *mut SSL, key: *mut EC_KEY) -> c_long {
 
 pub unsafe fn SSL_CTX_add_extra_chain_cert(ctx: *mut SSL_CTX, x509: *mut X509) -> c_long {
     SSL_CTX_ctrl(ctx, SSL_CTRL_EXTRA_CHAIN_CERT, 0, x509 as *mut c_void)
+}
+
+pub unsafe fn SSL_CTX_set0_verify_cert_store(ctx: *mut SSL_CTX, st: *mut X509_STORE) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SET_VERIFY_CERT_STORE, 0, st as *mut c_void)    
 }
 
 pub unsafe fn SSL_CTX_set_tlsext_servername_callback(ctx: *mut SSL_CTX,

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -654,14 +654,18 @@ impl SslContextBuilder {
         }
     }
 
-    /// Sets a custom X509Store for verifying peer certificates
+    /// Sets a custom X509Store for verifying peer certificates.
+    ///
+    /// Requires the `v102` feature and OpenSSL 1.0.2, or the `v110` feature and OpenSSL 1.1.0.
     #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
     pub fn set_verify_cert_store(&mut self, cert_store: X509Store) -> Result<(), ErrorStack> {
         unsafe {
             // set0 will free, set1 increments, and then requires a free
             let ptr = cert_store.as_ptr();
+            let result = cvt(ffi::SSL_CTX_set0_verify_cert_store(self.as_ptr(), ptr) as c_int).map(|_|());
+            
             mem::forget(cert_store);
-            cvt(ffi::SSL_CTX_set0_verify_cert_store(self.as_ptr(), ptr) as c_int).map(|_|())
+            result
         }
     }
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -99,7 +99,7 @@ use ec::EcKeyRef;
 use ec::EcKey;
 use x509::{X509StoreContextRef, X509FileType, X509, X509Ref, X509VerifyError, X509Name};
 use x509::store::{X509StoreBuilderRef, X509StoreRef};
-#[cfg(any(all(feature = "v101", ossl101), all(feature = "v102", ossl102)))]
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 use x509::store::X509Store;
 #[cfg(any(ossl102, ossl110))]
 use verify::X509VerifyParamRef;
@@ -655,7 +655,7 @@ impl SslContextBuilder {
     }
 
     /// Sets a custom X509Store for verifying peer certificates
-    #[cfg(any(all(feature = "v101", ossl101), all(feature = "v102", ossl102)))]
+    #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
     pub fn set_verify_cert_store(&mut self, cert_store: X509Store) -> Result<(), ErrorStack> {
         unsafe {
             // set0 will free, set1 increments, and then requires a free

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -665,7 +665,7 @@ impl SslContextBuilder {
             let result = try!(cvt(ffi::SSL_CTX_set0_verify_cert_store(self.as_ptr(), ptr) as c_int).map(|_|()));
             
             mem::forget(cert_store);
-            result
+            Ok(result)
         }
     }
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -662,7 +662,7 @@ impl SslContextBuilder {
         unsafe {
             // set0 will free, set1 increments, and then requires a free
             let ptr = cert_store.as_ptr();
-            let result = cvt(ffi::SSL_CTX_set0_verify_cert_store(self.as_ptr(), ptr) as c_int).map(|_|());
+            let result = try!(cvt(ffi::SSL_CTX_set0_verify_cert_store(self.as_ptr(), ptr) as c_int).map(|_|()));
             
             mem::forget(cert_store);
             result

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -99,6 +99,8 @@ use ec::EcKeyRef;
 use ec::EcKey;
 use x509::{X509StoreContextRef, X509FileType, X509, X509Ref, X509VerifyError, X509Name};
 use x509::store::{X509StoreBuilderRef, X509StoreRef};
+#[cfg(any(all(feature = "v101", ossl101), all(feature = "v102", ossl102)))]
+use x509::store::X509Store;
 #[cfg(any(ossl102, ossl110))]
 use verify::X509VerifyParamRef;
 use pkey::PKeyRef;
@@ -649,6 +651,17 @@ impl SslContextBuilder {
     pub fn set_verify_depth(&mut self, depth: u32) {
         unsafe {
             ffi::SSL_CTX_set_verify_depth(self.as_ptr(), depth as c_int);
+        }
+    }
+
+    /// Sets a custom X509Store for verifying peer certificates
+    #[cfg(any(all(feature = "v101", ossl101), all(feature = "v102", ossl102)))]
+    pub fn set_verify_cert_store(&mut self, cert_store: X509Store) -> Result<(), ErrorStack> {
+        unsafe {
+            // set0 will free, set1 increments, and then requires a free
+            let ptr = cert_store.as_ptr();
+            mem::forget(cert_store);
+            cvt(ffi::SSL_CTX_set0_verify_cert_store(self.as_ptr(), ptr) as c_int).map(|_|())
         }
     }
 


### PR DESCRIPTION
This adds the set_verify_cert_store() function to the SslContextBuilder so that server certificates can be dynamically associated with the context. That is, it doesn't need to come from a file.

This is only supported in openssl 1.0.2+