### PR TITLE
(maint) Recreate ability to pass in OPENSSL_LIBS variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ The build script can be configured via environment variables:
   (if specified).
 * `OPENSSL_STATIC` - If specified, OpenSSL libraries will be statically rather
   than dynamically linked.
+* `OPENSSL_LIBS` - If specified, the names of the OpenSSL libraries that will be
+  linked, e.g. `ssl:crypto`.
 
 If `OPENSSL_DIR` is specified, then the build script will skip the pkg-config
 step.


### PR DESCRIPTION
Prior to this commit in 43c951f743e68fac5f45119eda7c994882a1d489 the
ability to pass OPENSSL_LIBS was removed from the build.rs of
openssl-sys. This commit adds the ability to pass custom names for the
OPENSSL_LIBS back in. This is useful for when building openssl across
linux and windows with the same lib names (ssl:crypto) and the default
names provided by the build script are not valid.