### PR TITLE
Panic if lock managed by `locking_function` is doubly unlocked

### DIFF
--- a/openssl-sys/src/libressl.rs
+++ b/openssl-sys/src/libressl.rs
@@ -576,7 +576,7 @@ unsafe extern fn locking_function(mode: c_int, n: c_int, _file: *const c_char,
     if mode & ::CRYPTO_LOCK != 0 {
         (*GUARDS)[n as usize] = Some(mutex.lock().unwrap());
     } else {
-        &(*GUARDS)[n as usize].take();
+        &(*GUARDS)[n as usize].take().expect("lock already unlocked");
     }
 }
 

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -719,7 +719,7 @@ unsafe extern fn locking_function(mode: c_int, n: c_int, _file: *const c_char,
     if mode & ::CRYPTO_LOCK != 0 {
         (*GUARDS)[n as usize] = Some(mutex.lock().unwrap());
     } else {
-        &(*GUARDS)[n as usize].take();
+        &(*GUARDS)[n as usize].take().expect("lock already unlocked");
     }
 }
 


### PR DESCRIPTION
Trying to unlock an unlocked lock is always an error and should
be treated as such.

This is related to #597.