### PR TITLE
WIP: add verify_cert and store_context_builder

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1930,7 +1930,6 @@ extern {
     pub fn X509_sign(x: *mut X509, pkey: *mut EVP_PKEY, md: *const EVP_MD) -> c_int;
     pub fn X509_get_pubkey(x: *mut X509) -> *mut EVP_PKEY;
     pub fn X509_to_X509_REQ(x: *mut X509, pkey: *mut EVP_PKEY, md: *const EVP_MD) -> *mut X509_REQ;
-    #[cfg(not(any(ossl101, libressl)))]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> c_int;
     pub fn X509_verify_cert_error_string(n: c_long) -> *const c_char;
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1930,6 +1930,8 @@ extern {
     pub fn X509_sign(x: *mut X509, pkey: *mut EVP_PKEY, md: *const EVP_MD) -> c_int;
     pub fn X509_get_pubkey(x: *mut X509) -> *mut EVP_PKEY;
     pub fn X509_to_X509_REQ(x: *mut X509, pkey: *mut EVP_PKEY, md: *const EVP_MD) -> *mut X509_REQ;
+    #[cfg(not(any(ossl101, libressl)))]
+    pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> c_int;
     pub fn X509_verify_cert_error_string(n: c_long) -> *const c_char;
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> c_int;
@@ -1955,6 +1957,8 @@ extern {
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x: *mut X509) -> c_int;
     pub fn X509_STORE_set_default_paths(store: *mut X509_STORE) -> c_int;
 
+    pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
+    pub fn X509_STORE_CTX_init(ctx: *mut X509_STORE_CTX, store: *mut X509_STORE, x509: *mut X509, chain: *mut stack_st_X509) -> c_int;
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> c_int;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1957,6 +1957,7 @@ extern {
     pub fn X509_STORE_set_default_paths(store: *mut X509_STORE) -> c_int;
 
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
+    pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
     pub fn X509_STORE_CTX_init(ctx: *mut X509_STORE_CTX, store: *mut X509_STORE, x509: *mut X509, chain: *mut stack_st_X509) -> c_int;
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -76,18 +76,21 @@ impl X509StoreContext {
     /// # Result
     /// 
     /// The Result must be `Some(None)` to be a valid certificate, otherwise the cert is not valid.
-    pub fn verify_cert(trust: store::X509Store, cert: X509, cert_chain: Stack<X509>) -> Result<Option<X509VerifyError>, ErrorStack> {
+    pub fn verify_cert(trust: store::X509Store, cert: X509, cert_chain: Stack<X509>) -> Result<(), ErrorStack> {
         unsafe {
             ffi::init();
             let context = try!(cvt_p(ffi::X509_STORE_CTX_new()).map(|p| X509StoreContext(p)));
             try!(cvt(ffi::X509_STORE_CTX_init(context.as_ptr(), trust.as_ptr(), cert.as_ptr(), cert_chain.as_ptr()))
                 .map(|_| ()));
+
+            mem::forget(trust);
+            mem::forget(cert);
+            mem::forget(cert_chain);
+
+            // verify_cert returns an error `<= 0` if there was a validation error
             try!(cvt(ffi::X509_verify_cert(context.as_ptr())).map(|_| ()));
             
-            let result = Ok(context.error());
-            ffi::X509_STORE_CTX_cleanup(context.as_ptr());
-
-            result
+            Ok(())
         }
     }
 }

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -82,13 +82,10 @@ impl X509StoreContext {
 }
 
 impl X509StoreContextBuilder {
-    pub fn build(self, trust: store::X509Store, cert: X509, cert_chain: Stack<X509>) -> Result<X509StoreContext, ErrorStack> {
+    pub fn build(self, trust: &store::X509StoreRef, cert: &X509Ref, cert_chain: &StackRef<X509>) -> Result<X509StoreContext, ErrorStack> {
         unsafe {
             try!(cvt(ffi::X509_STORE_CTX_init(self.0.as_ptr(), trust.as_ptr(), cert.as_ptr(), cert_chain.as_ptr()))
                 .map(|_| ()));
-            mem::forget(trust);
-            mem::forget(cert);
-            mem::forget(cert_chain);
         }
         Ok(self.0)
     }

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -80,12 +80,14 @@ impl X509StoreContext {
         unsafe {
             ffi::init();
             let context = try!(cvt_p(ffi::X509_STORE_CTX_new()).map(|p| X509StoreContext(p)));
-            try!(cvt(ffi::X509_STORE_CTX_init(context.as_ptr(), trust.as_ptr(), cert.as_ptr(), cert_chain.as_ptr()))
-                .map(|_| ()));
+            let init_result = cvt(ffi::X509_STORE_CTX_init(context.as_ptr(), trust.as_ptr(), cert.as_ptr(), cert_chain.as_ptr()))
+                .map(|_| ());
 
             mem::forget(trust);
             mem::forget(cert);
             mem::forget(cert_chain);
+
+            try!(init_result);
 
             // verify_cert returns an error `<= 0` if there was a validation error
             try!(cvt(ffi::X509_verify_cert(context.as_ptr())).map(|_| ()));

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -74,6 +74,9 @@ impl X509StoreContext {
         }
     }
 
+    /// Verifies the certificate associated in the `build()` method
+    ///
+    /// This consumes self as the `X509StoreContext` must be reinitialized subsequent to any cally to verify. 
     pub fn verify_cert(self) -> Result<Option<X509VerifyError>, ErrorStack> {
         unsafe {
             try!(cvt(ffi::X509_verify_cert(self.as_ptr())).map(|_| ()))

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -74,11 +74,11 @@ impl X509StoreContext {
         }
     }
 
-    #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
-    pub fn verify_cert(self) -> Result<(), ErrorStack> {
+    pub fn verify_cert(self) -> Result<Option<X509VerifyError>, ErrorStack> {
         unsafe {
-            cvt(ffi::X509_verify_cert(self.as_ptr())).map(|_| ())
+            try!(cvt(ffi::X509_verify_cert(self.as_ptr())).map(|_| ()))
         }
+        Ok(self.error())
     }
 }
 

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -74,6 +74,7 @@ impl X509StoreContext {
         }
     }
 
+    #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
     pub fn verify_cert(self) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_verify_cert(self.as_ptr())).map(|_| ())

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -76,14 +76,18 @@ impl X509StoreContext {
     /// # Result
     /// 
     /// The Result must be `Some(None)` to be a valid certificate, otherwise the cert is not valid.
-    pub fn verify_cert(trust: &store::X509StoreRef, cert: &X509Ref, cert_chain: &StackRef<X509>) -> Result<Option<X509VerifyError>, ErrorStack> {
+    pub fn verify_cert(trust: store::X509Store, cert: X509, cert_chain: Stack<X509>) -> Result<Option<X509VerifyError>, ErrorStack> {
         unsafe {
             ffi::init();
             let context = try!(cvt_p(ffi::X509_STORE_CTX_new()).map(|p| X509StoreContext(p)));
             try!(cvt(ffi::X509_STORE_CTX_init(context.as_ptr(), trust.as_ptr(), cert.as_ptr(), cert_chain.as_ptr()))
                 .map(|_| ()));
             try!(cvt(ffi::X509_verify_cert(context.as_ptr())).map(|_| ()));
-            Ok(context.error())
+            
+            let result = Ok(context.error());
+            ffi::X509_STORE_CTX_cleanup(context.as_ptr());
+
+            result
         }
     }
 }

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -74,14 +74,14 @@ impl X509StoreContext {
 
     /// Initializes the store context to verify the certificate.
     ///
-    /// This Context can only be used once, subsequent to any validation, the context must be reinitialized.
+    /// The context must be re-initialized before each call to `verify_cert`.
     ///
     /// # Arguments
     ///
     /// * `trust` - a store of the trusted chain of certificates, or CAs, to validated the certificate
     /// * `cert` - certificate to validate
-    /// * `cert_chain` - the certificates chain
-    pub fn init(&self, trust: &store::X509StoreRef, cert: &X509Ref, cert_chain: &StackRef<X509>) -> Result<(), ErrorStack> {
+    /// * `cert_chain` - the certificate's chain
+    pub fn init(&mut self, trust: &store::X509StoreRef, cert: &X509Ref, cert_chain: &StackRef<X509>) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_STORE_CTX_init(self.as_ptr(), trust.as_ptr(), cert.as_ptr(), cert_chain.as_ptr()))
                 .map(|_| ())
@@ -90,7 +90,7 @@ impl X509StoreContext {
 
     /// Verifies the certificate associated in the `init()` method
     ///
-    /// This consumes self as the `X509StoreContext` must be reinitialized subsequent to any cally to verify. 
+    /// The context must be re-initialized before each call to this method.
     pub fn verify_cert(&self) -> Result<Option<X509VerifyError>, ErrorStack> {
         unsafe {
             try!(cvt(ffi::X509_verify_cert(self.as_ptr())).map(|_| ()))

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -342,8 +342,5 @@ fn test_verify_cert() {
     store_bldr.add_cert(ca).unwrap();
     let store = store_bldr.build();
 
-    let store_ctx = X509StoreContext::new().unwrap();
-    store_ctx.init(&store, &cert, &Stack::new().unwrap()).unwrap();
-
-    assert!(store_ctx.verify_cert().unwrap().is_none());
+    assert!(X509StoreContext::verify_cert(&store, &cert, &Stack::new().unwrap()).unwrap().is_none());
 }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -342,5 +342,5 @@ fn test_verify_cert() {
     store_bldr.add_cert(ca).unwrap();
     let store = store_bldr.build();
 
-    assert!(X509StoreContext::verify_cert(&store, &cert, &Stack::new().unwrap()).unwrap().is_none());
+    assert!(X509StoreContext::verify_cert(store, cert, Stack::new().unwrap()).unwrap().is_none());
 }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -331,7 +331,6 @@ fn signature() {
     assert_eq!(algorithm.object().to_string(), "sha256WithRSAEncryption");
 }
 
-#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 #[test]
 fn test_verify_cert() {
     let cert = include_bytes!("../../test/cert.pem");
@@ -340,11 +339,11 @@ fn test_verify_cert() {
     let ca = X509::from_pem(ca).unwrap();
 
     let mut store_bldr = X509StoreBuilder::new().unwrap();
-    store_bldr.add_cert(ca);
+    store_bldr.add_cert(ca).unwrap();
     let store = store_bldr.build();
 
     let store_ctx_bldr = X509StoreContext::builder().unwrap();
     let store_ctx = store_ctx_bldr.build(&store, &cert, &Stack::new().unwrap()).unwrap();
 
-    store_ctx.verify_cert().unwrap();
+    assert!(store_ctx.verify_cert().unwrap().is_none());
 }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -343,7 +343,7 @@ fn test_verify_cert() {
     let store = store_bldr.build();
 
     let store_ctx_bldr = X509StoreContext::builder().unwrap();
-    let store_ctx = store_ctx_bldr.build(store, cert, Stack::new().unwrap()).unwrap();
+    let store_ctx = store_ctx_bldr.build(&store, &cert, &Stack::new().unwrap()).unwrap();
 
     store_ctx.verify_cert().unwrap();
 }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -331,6 +331,7 @@ fn signature() {
     assert_eq!(algorithm.object().to_string(), "sha256WithRSAEncryption");
 }
 
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
 #[test]
 fn test_verify_cert() {
     let cert = include_bytes!("../../test/cert.pem");

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -342,5 +342,19 @@ fn test_verify_cert() {
     store_bldr.add_cert(ca).unwrap();
     let store = store_bldr.build();
 
-    assert!(X509StoreContext::verify_cert(store, cert, Stack::new().unwrap()).unwrap().is_none());
+    assert!(X509StoreContext::verify_cert(store, cert, Stack::new().unwrap()).is_ok());
+}
+
+#[test]
+fn test_verify_fails() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let ca = include_bytes!("../../test/alt_name_cert.pem");
+    let ca = X509::from_pem(ca).unwrap();
+
+    let mut store_bldr = X509StoreBuilder::new().unwrap();
+    store_bldr.add_cert(ca).unwrap();
+    let store = store_bldr.build();
+
+    assert!(X509StoreContext::verify_cert(store, cert, Stack::new().unwrap()).is_err());
 }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -342,8 +342,8 @@ fn test_verify_cert() {
     store_bldr.add_cert(ca).unwrap();
     let store = store_bldr.build();
 
-    let store_ctx_bldr = X509StoreContext::builder().unwrap();
-    let store_ctx = store_ctx_bldr.build(&store, &cert, &Stack::new().unwrap()).unwrap();
+    let store_ctx = X509StoreContext::new().unwrap();
+    store_ctx.init(&store, &cert, &Stack::new().unwrap()).unwrap();
 
     assert!(store_ctx.verify_cert().unwrap().is_none());
 }


### PR DESCRIPTION
I believe this is necessary for verifying certificates independently from the SSLContext. Allows for a custom proof chain, with an associated certificate to validate.