### PR TITLE
show help message when pkg-config is missing

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -197,10 +197,15 @@ fn try_pkg_config() {
         return
     }
 
-    let lib = pkg_config::Config::new()
+    let lib = match pkg_config::Config::new()
         .print_system_libs(false)
-        .find("openssl")
-        .unwrap();
+        .find("openssl") {
+        Ok(lib) => lib,
+        Err(e) => {
+            println!("run pkg_config fail: {:?}", e);
+            return;
+        }
+    };
 
     validate_headers(&lib.include_paths);
 


### PR DESCRIPTION
The [error message](https://github.com/sfackler/rust-openssl/blob/42ad50ae670397fae9db956e931ed935301f713b/openssl-sys/build.rs#L144) is supposed to be displayed when pkg-config is missing, but now it never shows up because the result is unwrapped directly when running pkg-config.