### PR TITLE
(issues-600) Avoid compiling ec code against no-ec2m openssl

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -15,6 +15,7 @@ const DEFINES: &'static [&'static str] = &[
     "OPENSSL_NO_BUF_FREELISTS",
     "OPENSSL_NO_COMP",
     "OPENSSL_NO_EC",
+    "OPENSSL_NO_EC2M",
     "OPENSSL_NO_ENGINE",
     "OPENSSL_NO_KRB5",
     "OPENSSL_NO_NEXTPROTONEG",

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1521,13 +1521,16 @@ extern {
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> c_int;
     pub fn EC_KEY_free(key: *mut EC_KEY);
 
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn EC_GF2m_simple_method() -> *const EC_METHOD;
 
     pub fn EC_GROUP_new(meth: *const EC_METHOD) -> *mut EC_GROUP;
     pub fn EC_GROUP_new_curve_GFp(p: *const BIGNUM, a: *const BIGNUM, b: *const BIGNUM, ctx: *mut BN_CTX) -> *mut EC_GROUP;
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn EC_GROUP_new_curve_GF2m(p: *const BIGNUM, a: *const BIGNUM, b: *const BIGNUM, ctx: *mut BN_CTX) -> *mut EC_GROUP;
     pub fn EC_GROUP_new_by_curve_name(nid: c_int) -> *mut EC_GROUP;
     pub fn EC_GROUP_get_curve_GFp(group: *const EC_GROUP, p: *mut BIGNUM, a: *mut BIGNUM, b: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn EC_GROUP_get_curve_GF2m(group: *const EC_GROUP, p: *mut BIGNUM, a: *mut BIGNUM, b: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> c_int;
     pub fn EC_GROUP_get_order(group: *const EC_GROUP, order: *mut BIGNUM, ctx: *mut BN_CTX) -> c_int;

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -66,6 +66,7 @@ impl EcGroupRef {
     }
 
     /// Places the components of a curve over a binary field in the provided `BigNum`s.
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn components_gf2m(&self,
                            p: &mut BigNumRef,
                            a: &mut BigNumRef,


### PR DESCRIPTION
This commit avoids defining code that leads to undefined references when
compiling against an openssl built with no ec2m.