### PR TITLE
try to find openssl libraries in a vcpkg ports tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ automatically detected.
 
 ### Windows MSVC
 
-On MSVC it's unfortunately not always a trivial process acquiring OpenSSL.
+On MSVC it's unfortunately not always a trivial process acquiring OpenSSL. A couple of possibilities
+are downloading precompiled binaries for OpenSSL 1.1.0, or installing OpenSSL 1.0.2 using vcpkg.
+
+#### Installing OpenSSL 1.1.0 using precompiiled binaries
+
 Perhaps the easiest way to do this right now is to download [precompiled
 binaries] and install them on your system. Currently it's recommended to
 install the 1.1.0 (non-light) installation if you're choosing this route.
@@ -84,7 +88,24 @@ installation via an environment variable:
 set OPENSSL_DIR=C:\OpenSSL-Win64
 ```
 
-Note that this OpenSSL distribution does not ship with any root certificates.
+Now you will need to [install root certificates.](#acquiring-root-certificates)
+
+#### Installing OpenSSL 1.0.2 using vcpkg
+
+Install [vcpkg](https://github.com/Microsoft/vcpkg), and install the OpenSSL port like this:
+
+```Batchfile
+vcpkg install openssl:x64-windows
+set VCPKG_ROOT=c:\path\to\vcpkg\installation
+cargo build
+```
+
+For more information see the vcpkg build helper [documentation](http://docs.rs/vcpkg).
+To finsh setting up OpenSSL you will need to [install root certificates.](#acquiring-root-certificates)
+
+#### Acquiring Root Certificates
+
+Neither of the above OpenSSL distributions ship with any root certificates.
 So to make requests to servers on the internet, you have to install them
 manually. Download the [cacert.pem file from here], copy it somewhere safe
 (`C:\OpenSSL-Win64\certs` is a good place) and point the `SSL_CERT_FILE`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ environment:
       OPENSSL_DIR: C:\OpenSSL
     - TARGET: x86_64-pc-windows-msvc
       VCPKG_DEFAULT_TRIPLET: x64-windows
+      VCPKGRS_DYNAMIC: 1
 install:
   # install OpenSSL
   - mkdir C:\OpenSSL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,10 +20,13 @@ environment:
       BITS: 32
       OPENSSL_VERSION: 1_0_2L
       OPENSSL_DIR: C:\OpenSSL
+    - TARGET: x86_64-pc-windows-msvc
+      VCPKG_DEFAULT_TRIPLET: x64-windows
 install:
   # install OpenSSL
-  - ps: Start-FileDownload "http://slproweb.com/download/Win${env:BITS}OpenSSL-${env:OPENSSL_VERSION}.exe"
-  - Win%BITS%OpenSSL-%OPENSSL_VERSION%.exe /SILENT /VERYSILENT /SP- /DIR="C:\OpenSSL"
+  - mkdir C:\OpenSSL
+  - ps: if (Test-Path env:OPENSSL_VERSION) { Start-FileDownload "http://slproweb.com/download/Win${env:BITS}OpenSSL-${env:OPENSSL_VERSION}.exe" }
+  - if defined OPENSSL_VERSION Win%BITS%OpenSSL-%OPENSSL_VERSION%.exe /SILENT /VERYSILENT /SP- /DIR="C:\OpenSSL"
   - appveyor DownloadFile https://curl.haxx.se/ca/cacert.pem -FileName C:\OpenSSL\cacert.pem
 
   # Install Rust
@@ -33,6 +36,10 @@ install:
   - if defined MSYS2 set PATH=C:\msys64\mingw%BITS%\bin;%PATH%
   - rustc -V
   - cargo -V
+  - if defined VCPKG_DEFAULT_TRIPLET git clone https://github.com/Microsoft/vcpkg c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET c:\projects\vcpkg\bootstrap-vcpkg.bat
+  - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install openssl
 
 build: false
 

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -18,6 +18,9 @@ libc = "0.2"
 pkg-config = "0.3.9"
 gcc = "0.3.42"
 
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+vcpkg = "0.2"
+
 # We don't actually use metadeps for annoying reasons but this is still here for tooling
 [package.metadata.pkg-config]
 openssl = "1.0.1"


### PR DESCRIPTION
Optionally find libs/dlls for MSVC ABI builds in a ports tree built by Microsoft's newish [vcpkg](https://github.com/Microsoft/vcpkg)

I'll send you a PR for curl-sys shortly which is a little less straightforward, and we can discuss there.

cc @alexcrichton 