### PR TITLE
Make set_ecdh_auto available when using OpenSSL 1.1.0

### DIFF
--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -1,4 +1,5 @@
 use libc::{c_int, c_void, c_char, c_uchar, c_ulong, c_long, c_uint, size_t};
+use std::ptr;
 
 pub enum BIGNUM {}
 pub enum BIO {}
@@ -53,6 +54,19 @@ pub const CRYPTO_EX_INDEX_SSL_CTX: c_int = 1;
 pub const X509_CHECK_FLAG_NEVER_CHECK_SUBJECT: c_uint = 0x20;
 
 pub fn init() {}
+
+#[cfg(ossl110)]
+pub const SSL_CTRL_SET_ECDH_AUTO: c_int = 94;
+
+#[cfg(ossl110)]
+pub unsafe fn SSL_CTX_set_ecdh_auto(ctx: *mut SSL_CTX, onoff: c_int) -> c_int {
+    ::SSL_CTX_ctrl(ctx, SSL_CTRL_SET_ECDH_AUTO, onoff as c_long, ptr::null_mut()) as c_int
+}
+
+#[cfg(ossl110)]
+pub unsafe fn SSL_set_ecdh_auto(ssl: *mut ::SSL, onoff: c_int) -> c_int {
+    ::SSL_ctrl(ssl, SSL_CTRL_SET_ECDH_AUTO, onoff as c_long, ptr::null_mut()) as c_int
+}
 
 extern {
     pub fn BIO_new(type_: *const BIO_METHOD) -> *mut BIO;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -846,12 +846,12 @@ impl SslContextBuilder {
     /// Enables ECDHE key exchange with an automatically chosen curve list.
     ///
     /// Requires the `v102` feature and OpenSSL 1.0.2.
-    #[cfg(all(feature = "v102", any(ossl102, libressl)))]
+    #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110), all(feature = "v102", libressl)))]
     pub fn set_ecdh_auto(&mut self, onoff: bool) -> Result<(), ErrorStack> {
         self._set_ecdh_auto(onoff)
     }
 
-    #[cfg(any(ossl102,libressl))]
+    #[cfg(any(ossl102,ossl110,libressl))]
     fn _set_ecdh_auto(&mut self, onoff: bool) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::SSL_CTX_set_ecdh_auto(self.as_ptr(), onoff as c_int)).map(|_| ()) }
     }


### PR DESCRIPTION
I tried compiling [sozu and failed due to having OpenSSL 1.1.0 locally](https://github.com/sozu-proxy/sozu/issues/178).

With these minimal fixes I was able to build sozu against OpenSSL 1.1.0.
I just copied over the necessary definitions from `ossl10x.rs`.

I am no expert in OpenSSL or this Rust wrapper, so I wonder if we need to bring `ossl10x.rs` and `ossl110.rs` closer together again to avoid such problems, where APIs are available in both versions.

I run `cargo test` locally.

Happy  to help working this out correctly.