### PR TITLE
Expose PSK via a SslContextBuilder::set_psk_callback method

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -2252,14 +2252,15 @@ extern "C" {
                                                               arg: *mut c_void)
                                                               -> c_int,
                                             arg: *mut c_void);
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
     pub fn SSL_CTX_set_psk_client_callback(ssl: *mut SSL_CTX,
-                                           psk_client_cb: extern "C" fn(*mut SSL,
-                                                                        *const c_char,
-                                                                        *mut c_char,
-                                                                        c_uint,
-                                                                        *mut c_uchar,
-                                                                        c_uint)
-                                                                        -> c_uint);
+                                           psk_client_cb: Option<extern "C" fn(*mut SSL,
+                                                                               *const c_char,
+                                                                               *mut c_char,
+                                                                               c_uint,
+                                                                               *mut c_uchar,
+                                                                               c_uint)
+                                                                               -> c_uint>);
     pub fn SSL_select_next_proto(out: *mut *mut c_uchar,
                                  outlen: *mut c_uchar,
                                  inbuf: *const c_uchar,

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -2252,6 +2252,14 @@ extern "C" {
                                                               arg: *mut c_void)
                                                               -> c_int,
                                             arg: *mut c_void);
+    pub fn SSL_CTX_set_psk_client_callback(ssl: *mut SSL_CTX,
+                                           psk_client_cb: extern "C" fn(*mut SSL,
+                                                                        *const c_char,
+                                                                        *mut c_char,
+                                                                        c_uint,
+                                                                        *mut c_uchar,
+                                                                        c_uint)
+                                                                        -> c_uint);
     pub fn SSL_select_next_proto(out: *mut *mut c_uchar,
                                  outlen: *mut c_uchar,
                                  inbuf: *const c_uchar,

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -73,10 +73,10 @@
 use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_void, c_long, c_ulong};
-use libc::{c_uchar, c_uint};
+use libc::{c_char, c_uchar, c_uint};
 use std::any::Any;
 use std::any::TypeId;
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 use std::cmp;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
@@ -304,6 +304,39 @@ extern "C" fn raw_verify<F>(preverify_ok: c_int, x509_ctx: *mut ffi::X509_STORE_
         let ctx = X509StoreContextRef::from_ptr(x509_ctx);
 
         verify(preverify_ok != 0, ctx) as c_int
+    }
+}
+
+extern "C" fn raw_psk<F>(ssl: *mut ffi::SSL,
+                         hint: *const c_char,
+                         identity: *mut c_char,
+                         _max_identity_len: c_uint,
+                         psk: *mut c_uchar,
+                         _max_psk_len: c_uint) -> c_uint
+    where F: Fn(&mut SslRef, &str) -> Result<(String, Vec<u8>), ErrorStack> + Any + 'static + Sync + Send
+{
+    unsafe {
+        let ssl_ctx = ffi::SSL_get_SSL_CTX(ssl as *const _);
+        let callback = ffi::SSL_CTX_get_ex_data(ssl_ctx, get_callback_idx::<F>());
+        let ssl = SslRef::from_ptr_mut(ssl);
+        let callback = &*(callback as *mut F);
+        let cstr_hint = if hint != ptr::null() { Cow::Borrowed(CStr::from_ptr(hint)) } else { Cow::Owned(CString::new("").unwrap()) };
+        if let Ok(s) = cstr_hint.to_str() {
+            match callback(ssl, s) {
+                Ok((identity_out, psk_out)) => {
+                    if let Ok(id) = CString::new(identity_out) {
+                        //TODO: validate max_identity_len, max_psk_len
+                        let id = id.into_bytes_with_nul();
+                        ptr::copy(id.as_ptr() as *mut i8, identity, id.len());
+                        ptr::copy(psk_out.as_ptr(), psk, psk_out.len());
+                        psk_out.len() as u32
+                    } else { 0 }
+                }
+                Err(_) => 0,
+            }
+        } else {
+            0
+        }
     }
 }
 
@@ -974,6 +1007,18 @@ impl SslContextBuilder {
                                      Box::into_raw(callback) as *mut c_void);
             let f: unsafe extern fn (_, _) -> _ = raw_tlsext_status::<F>;
             cvt(ffi::SSL_CTX_set_tlsext_status_cb(self.as_ptr(), Some(f)) as c_int).map(|_| ())
+        }
+    }
+
+    pub fn set_psk_callback<F>(&mut self, callback: F)
+        where F: Fn(&mut SslRef, &str) -> Result<(String, Vec<u8>), ErrorStack> + Any + 'static + Sync + Send
+    {
+        unsafe {
+            let callback = Box::new(callback);
+            ffi::SSL_CTX_set_ex_data(self.as_ptr(),
+                                     get_callback_idx::<F>(),
+                                     mem::transmute(callback));
+            ffi::SSL_CTX_set_psk_client_callback(self.as_ptr(), raw_psk::<F>)
         }
     }
 


### PR DESCRIPTION
This patch is definitely not in a state to be landed, but I figured I'd submit it for feedback. I needed TLS-PSK for a little side project I'm working on, and OpenSSL seemed to be the only thing I could use from Rust at the moment, but I needed to expose an API to set the PSK identity and key. This was fairly straightforward to do by adding a `SslContextBuilder::set_psk_callback` method. I'm not entirely sure if I covered all the necessary bases with the `openssl-sys` bits, and I didn't yet add documentation for the new method. I'm also not confident that the code I wrote in the `raw_psk` callback to fill the out parameters is written in the most sensible way.

I was able to get this to work for my use case, but I did have to explicitly call `set_cipher_list("PSK-AES128-CBC-SHA")`, which was annoying to track down, so maybe the API could be better designed to allow those ciphers in this case? Also I wound up calling `danger_connect_without_providing_domain_for_certificate_verification_and_server_name_indication`, which is not really the nicest thing, but I understand why it's named that. :)

If we wanted to make this friendlier I guess we could give `SslConnector` something like `fn connect_psk(&self, psk_identity: &str, psk: &[u8], stream: S) -> ...` and have it handle setting the callback and such internally? That might be more effort than is worthwhile for such a niche feature.