### PR TITLE
Add pkg-config to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ on them.
 
 ```bash
 # On Ubuntu
-sudo apt-get install libssl-dev
+sudo apt-get install pkg-config libssl-dev
 # On Arch Linux
 sudo pacman -S openssl
 # On Fedora


### PR DESCRIPTION
error: failed to run custom build command for `openssl-sys v0.9.13`
run pkg_config fail: "Failed to run `\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"`: No such file or directory (os error 2)"

Problem encountered on WSL (Ubuntu on windows).
Fixed by installing pkg-config