### PR TITLE
if_has_alpn macro to detect if rust-openssl is compiled with ALPN.

### DIFF
--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -23,6 +23,8 @@ use error::ErrorStack;
 
 #[macro_use]
 mod macros;
+#[macro_use]
+mod macros_exported;
 
 mod bio;
 mod util;

--- a/openssl/src/macros_exported.rs
+++ b/openssl/src/macros_exported.rs
@@ -1,0 +1,24 @@
+/// Macro which expands to one or another expression depending
+/// on whether rust-openssl is compiled with ALPN support.
+#[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
+#[macro_export]
+macro_rules! if_has_alpn {
+    ($th:block else $el:block) => (
+        $th
+    );
+    ($th:block) => (
+        $th
+    );
+}
+
+/// Macro which expands to one or another expression depending
+/// on whether rust-openssl is compiled with ALPN support.
+#[macro_export]
+#[cfg(not(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110))))]
+macro_rules! if_has_alpn {
+    ($th:block else $el:block) => (
+        $el
+    );
+    ($th:block) => (
+    );
+}

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -916,6 +916,8 @@ impl SslContextBuilder {
     /// Note that ordering of the protocols controls the priority with which they are chosen.
     ///
     /// Requires the `v102` or `v110` features and OpenSSL 1.0.2 or OpenSSL 1.1.0.
+    ///
+    /// `if_has_alpn!` macro can be used to check if rust-openssl is compiled with ALPN.
     #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
     pub fn set_alpn_protocols(&mut self, protocols: &[&[u8]]) -> Result<(), ErrorStack> {
         let protocols: Box<Vec<u8>> = Box::new(ssl_encode_byte_strings(protocols));
@@ -1439,6 +1441,8 @@ impl SslRef {
     /// to interpret it.
     ///
     /// Requires the `v102` or `v110` features and OpenSSL 1.0.2 or OpenSSL 1.1.0.
+    ///
+    /// `if_has_alpn!` macro can be used to check if rust-openssl is compiled with ALPN.
     #[cfg(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)))]
     pub fn selected_alpn_protocol(&self) -> Option<&[u8]> {
         unsafe {

--- a/openssl/src/ssl/tests/mod.rs
+++ b/openssl/src/ssl/tests/mod.rs
@@ -777,6 +777,39 @@ fn test_alpn_server_select_none() {
 }
 
 #[test]
+fn test_if_has_alpn() {
+    let cfg_has_alpn = cfg!(any(all(feature = "v102", ossl102), all(feature = "v110", ossl110)));
+
+    // as expression
+    {
+        assert_eq!(cfg_has_alpn, if_has_alpn!({ true } else { false }));
+    }
+
+    // as block
+    {
+
+        let v;
+        if_has_alpn!({
+            v = true;
+        } else {
+            v = false;
+        });
+
+        assert_eq!(cfg_has_alpn, v);
+    }
+
+    // as block without else
+    {
+        let mut _v = false;
+        if_has_alpn!({
+            _v = true;
+        });
+
+        assert_eq!(cfg_has_alpn, _v);
+    }
+}
+
+#[test]
 #[cfg_attr(any(libressl, windows, target_arch = "arm"), ignore)] // FIXME(#467)
 fn test_read_dtlsv1() {
     let (_s, stream) = Server::new_dtlsv1(Some("hello"));

--- a/openssl/tests/if_has_alpn.rs
+++ b/openssl/tests/if_has_alpn.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate openssl;
+
+/// Check macro is visible outside of crate.
+/// Macro correctness is checked in tests inside of crate.
+#[test]
+fn test() {
+    let v = if_has_alpn!({ 10 } else { 20 });
+    assert!(v == 10 || v == 20);
+}


### PR DESCRIPTION
Another approach to check if rust-openssl is present.

Previous: https://github.com/sfackler/rust-openssl/pull/643

Now rust-openssl does not panic if ALPN is not present, and client code can do whichever behavior it needs.