### PR TITLE
remove unused dependencies on windows

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -18,10 +18,6 @@ libc = "0.2"
 pkg-config = "0.3.9"
 gcc = "0.3.42"
 
-[target.'cfg(windows)'.dependencies]
-user32-sys = "0.2"
-gdi32-sys = "0.2"
-
 # We don't actually use metadeps for annoying reasons but this is still here for tooling
 [package.metadata.pkg-config]
 openssl = "1.0.1"


### PR DESCRIPTION
These are never pulled in with `extern crate` so I don't think they are required.