### PR TITLE
Support for LibreSSL 2.5.5

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -264,6 +264,8 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
 RUST_LIBRESSL_NEW
 #elif LIBRESSL_VERSION_NUMBER >= 0x20600000
 RUST_LIBRESSL_260
+#elif LIBRESSL_VERSION_NUMBER >= 0x20505000
+RUST_LIBRESSL_255
 #elif LIBRESSL_VERSION_NUMBER >= 0x20504000
 RUST_LIBRESSL_254
 #elif LIBRESSL_VERSION_NUMBER >= 0x20503000
@@ -375,6 +377,12 @@ See rust-openssl README for more information:
     } else if expanded.contains("RUST_LIBRESSL_254") {
         println!("cargo:rustc-cfg=libressl");
         println!("cargo:rustc-cfg=libressl254");
+        println!("cargo:libressl=true");
+        println!("cargo:version=101");
+        Version::Libressl
+    } else if expanded.contains("RUST_LIBRESSL_255") {
+        println!("cargo:rustc-cfg=libressl");
+        println!("cargo:rustc-cfg=libressl255");
         println!("cargo:libressl=true");
         println!("cargo:version=101");
         Version::Libressl


### PR DESCRIPTION
As described in #665, this adds support for LibreSSL 2.5.5. Compiles fine, tests in the `openssl` crate pass.