### PR TITLE
Mention Debian for apt-get instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ regular development utilities, like `pkg-config`, as the custom build script rel
 on them.
 
 ```bash
-# On Ubuntu
+# On Debian and Ubuntu
 sudo apt-get install pkg-config libssl-dev
 # On Arch Linux
 sudo pacman -S openssl


### PR DESCRIPTION
Since Debian is the upstream for Ubuntu (and many other distributions), I think it makes sense to mention it explicitly.