### PR TITLE
avoid interactive prompts when setting up vcpkg in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ install:
   - if defined VCPKG_DEFAULT_TRIPLET git clone https://github.com/Microsoft/vcpkg c:\projects\vcpkg
   - if defined VCPKG_DEFAULT_TRIPLET c:\projects\vcpkg\bootstrap-vcpkg.bat
   - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET echo yes > %VCPKG_ROOT%\Downloads\AlwaysAllowDownloads
   - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install openssl
 
 build: false


### PR DESCRIPTION
Fixes https://github.com/sfackler/rust-openssl/issues/678. Thanks!