### PR TITLE
Don't build openssl in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ tar xf openssl-1.1.0f.tar.gz
 cd openssl-1.1.0f
 export CC=...
 ./Configure --prefix=... linux-x86_64 -fPIC
-make -j$(nproc)
+make -j1 # OpenSSL has historically not supported parallel builds
 make install
 ```
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/41563 - historically it's caused problems, and although it should be better in 1.1 I'm still not sure I'd recommend it. Up to you.