### PR TITLE
Hide deprecated crypto module from docs

### DIFF
--- a/openssl/src/crypto.rs
+++ b/openssl/src/crypto.rs
@@ -1,3 +1,4 @@
+#![doc(hidden)]
 use string::OpensslString;
 
 #[deprecated(note = "renamed to OpensslString", since = "0.9.7")]

--- a/openssl/src/crypto.rs
+++ b/openssl/src/crypto.rs
@@ -1,4 +1,5 @@
 #![doc(hidden)]
+#![deprecated(since = "0.9.20")]
 use string::OpensslString;
 
 #[deprecated(note = "renamed to OpensslString", since = "0.9.7")]


### PR DESCRIPTION
At least partially addresses #703

@sfackler @alexcrichton Should I also add `#![deprecated ]` for the module?