### PR TITLE
Document conf module

### DIFF
--- a/openssl/src/conf.rs
+++ b/openssl/src/conf.rs
@@ -8,14 +8,11 @@ pub struct ConfMethod(*mut ffi::CONF_METHOD);
 
 impl ConfMethod {
     /// Retrieve handle to the default OpenSSL configuration file processing function.
-    ///
-    /// # OpenSSL Implementation Details
-    ///
-    /// `NCONF` stands for "New Conf", as described in crypto/conf/conf_lib.c. This is
-    /// a newer API than the "CONF classic" functions.
     pub fn default() -> ConfMethod {
         unsafe {
             ffi::init();
+            // `NCONF` stands for "New Conf", as described in crypto/conf/conf_lib.c. This is
+            // a newer API than the "CONF classic" functions.
             ConfMethod(ffi::NCONF_default())
         }
     }

--- a/openssl/src/conf.rs
+++ b/openssl/src/conf.rs
@@ -1,3 +1,4 @@
+//! Interface for processing OpenSSL configuration files.
 use ffi;
 
 use cvt_p;
@@ -6,6 +7,12 @@ use error::ErrorStack;
 pub struct ConfMethod(*mut ffi::CONF_METHOD);
 
 impl ConfMethod {
+    /// Retrieve handle to the default OpenSSL configuration file processing function.
+    ///
+    /// # OpenSSL Implementation Details
+    ///
+    /// `NCONF` stands for "New Conf", as described in crypto/conf/conf_lib.c. This is
+    /// a newer API than the "CONF classic" functions.
     pub fn default() -> ConfMethod {
         unsafe {
             ffi::init();
@@ -13,10 +20,12 @@ impl ConfMethod {
         }
     }
 
+    /// Construct from raw pointer.
     pub unsafe fn from_ptr(ptr: *mut ffi::CONF_METHOD) -> ConfMethod {
         ConfMethod(ptr)
     }
 
+    /// Convert to raw pointer.
     pub fn as_ptr(&self) -> *mut ffi::CONF_METHOD {
         self.0
     }
@@ -31,6 +40,15 @@ foreign_type! {
 }
 
 impl Conf {
+    /// Create a configuration parser.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use openssl::conf::{Conf, ConfMethod};
+    ///
+    /// let conf = Conf::new(ConfMethod::default());
+    /// ```
     pub fn new(method: ConfMethod) -> Result<Conf, ErrorStack> {
         unsafe { cvt_p(ffi::NCONF_new(method.as_ptr())).map(Conf) }
     }


### PR DESCRIPTION
@sfackler When learning about this module, it seems like the `CONF` system can do more than what is exposed in the Rust API. For example, there are `NCONF_load` and `NCONF_get_string` functions to actually parse things from a configuration file.

Are these intentionally left out? I'm having a hard time coming up with examples in Rust as it doesn't seem to me you can actually do much with the `Conf` objects in Rust, unless I'm missing something.

If these were left out intentionally, we should add a note about that in the docs.