### PR TITLE
Libressl v2.6.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,9 @@ libressl_250: &LIBRESSL_250
 libressl_261: &LIBRESSL_262
   LIBRARY: libressl
   VERSION: 2.6.2
+libressl_263: &LIBRESSL_263
+  LIBRARY: libressl
+  VERSION: 2.6.3
 
 x86_64: &X86_64
   TARGET: x86_64-unknown-linux-gnu
@@ -144,6 +147,10 @@ jobs:
     <<: *JOB
     environment:
       <<: [*LIBRESSL_262, *X86_64, *BASE]
+  x86_64-libressl-2.6.3:
+    <<: *JOB
+    environment:
+      <<: [*LIBRESSL_263, *X86_64, *BASE]
 workflows:
   version: 2
   tests:
@@ -159,3 +166,4 @@ workflows:
     - armhf-openssl-1.0.1
     - x86_64-libressl-2.5.0
     - x86_64-libressl-2.6.2
+    - x86_64-libressl-2.6.3

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -316,8 +316,10 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
 #include <openssl/opensslv.h>
 #include <openssl/opensslconf.h>
 
-#if LIBRESSL_VERSION_NUMBER >= 0x20603000
+#if LIBRESSL_VERSION_NUMBER >= 0x20604000
 RUST_LIBRESSL_NEW
+#elif LIBRESSL_VERSION_NUMBER >= 0x20603000
+RUST_LIBRESSL_263
 #elif LIBRESSL_VERSION_NUMBER >= 0x20602000
 RUST_LIBRESSL_262
 #elif LIBRESSL_VERSION_NUMBER >= 0x20601000
@@ -473,6 +475,13 @@ See rust-openssl README for more information:
         println!("cargo:rustc-cfg=libressl262");
         println!("cargo:libressl=true");
         println!("cargo:libressl_version=262");
+        println!("cargo:version=101");
+        Version::Libressl
+    } else if expanded.contains("RUST_LIBRESSL_263") {
+        println!("cargo:rustc-cfg=libressl");
+        println!("cargo:rustc-cfg=libressl263");
+        println!("cargo:libressl=true");
+        println!("cargo:libressl_version=263");
         println!("cargo:version=101");
         Version::Libressl
     } else if expanded.contains("RUST_OPENSSL_110F") {

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1250,14 +1250,14 @@ pub const SSL_VERIFY_NONE: c_int = 0;
 pub const SSL_VERIFY_PEER: c_int = 1;
 pub const SSL_VERIFY_FAIL_IF_NO_PEER_CERT: c_int = 2;
 
-#[cfg(not(any(libressl261, libressl262, ossl101)))]
+#[cfg(not(any(libressl261, libressl262, libressl263, ossl101)))]
 pub const SSL_OP_TLSEXT_PADDING: c_ulong = 0x00000010;
-#[cfg(any(libressl261, libressl262))]
+#[cfg(any(libressl261, libressl262, libressl263))]
 pub const SSL_OP_TLSEXT_PADDING: c_ulong = 0x0;
 pub const SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS: c_ulong = 0x00000800;
-#[cfg(not(any(libressl261, libressl262)))]
+#[cfg(not(any(libressl261, libressl262, libressl263)))]
 pub const SSL_OP_CRYPTOPRO_TLSEXT_BUG: c_ulong = 0x80000000;
-#[cfg(any(libressl261, libressl262))]
+#[cfg(any(libressl261, libressl262, libressl263))]
 pub const SSL_OP_CRYPTOPRO_TLSEXT_BUG: c_ulong = 0x0;
 pub const SSL_OP_LEGACY_SERVER_CONNECT: c_ulong = 0x00000004;
 #[cfg(not(libressl))]

--- a/openssl-sys/src/libressl/mod.rs
+++ b/openssl-sys/src/libressl/mod.rs
@@ -345,9 +345,9 @@ pub const SSL_CTRL_OPTIONS: c_int = 32;
 pub const SSL_CTRL_CLEAR_OPTIONS: c_int = 77;
 pub const SSL_CTRL_SET_ECDH_AUTO: c_int = 94;
 
-#[cfg(any(libressl261, libressl262))]
+#[cfg(any(libressl261, libressl262, libressl263))]
 pub const SSL_OP_ALL: c_ulong = 0x4;
-#[cfg(not(any(libressl261, libressl262)))]
+#[cfg(not(any(libressl261, libressl262, libressl263)))]
 pub const SSL_OP_ALL: c_ulong = 0x80000014;
 pub const SSL_OP_CISCO_ANYCONNECT: c_ulong = 0x0;
 pub const SSL_OP_NO_COMPRESSION: c_ulong = 0x0;
@@ -360,9 +360,9 @@ pub const SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER: c_ulong = 0x0;
 pub const SSL_OP_SSLEAY_080_CLIENT_DH_BUG: c_ulong = 0x0;
 pub const SSL_OP_TLS_D5_BUG: c_ulong = 0x0;
 pub const SSL_OP_TLS_BLOCK_PADDING_BUG: c_ulong = 0x0;
-#[cfg(any(libressl261, libressl262))]
+#[cfg(any(libressl261, libressl262, libressl263))]
 pub const SSL_OP_SINGLE_ECDH_USE: c_ulong = 0x0;
-#[cfg(not(any(libressl261, libressl262)))]
+#[cfg(not(any(libressl261, libressl262, libressl263)))]
 pub const SSL_OP_SINGLE_ECDH_USE: c_ulong = 0x00080000;
 pub const SSL_OP_SINGLE_DH_USE: c_ulong = 0x00100000;
 pub const SSL_OP_NO_SSLv2: c_ulong = 0x0;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -649,7 +649,7 @@ impl SslContextBuilder {
 
     /// Set the protocols to be used during Next Protocol Negotiation (the protocols
     /// supported by the application).
-    #[cfg(not(any(libressl261, libressl262)))]
+    #[cfg(not(any(libressl261, libressl262, libressl263)))]
     pub fn set_npn_protocols(&mut self, protocols: &[&[u8]]) -> Result<(), ErrorStack> {
         // Firstly, convert the list of protocols to a byte-array that can be passed to OpenSSL
         // APIs -- a list of length-prefixed strings.
@@ -1307,7 +1307,7 @@ impl SslRef {
     ///
     /// The protocol's name is returned is an opaque sequence of bytes. It is up to the client
     /// to interpret it.
-    #[cfg(not(any(libressl261, libressl262)))]
+    #[cfg(not(any(libressl261, libressl262, libressl263)))]
     pub fn selected_npn_protocol(&self) -> Option<&[u8]> {
         unsafe {
             let mut data: *const c_uchar = ptr::null();

--- a/openssl/src/ssl/tests/mod.rs
+++ b/openssl/src/ssl/tests/mod.rs
@@ -503,7 +503,7 @@ fn test_connect_with_unilateral_alpn() {
 /// Tests that connecting with the client using NPN, but the server not does not
 /// break the existing connection behavior.
 #[test]
-#[cfg(not(any(libressl261, libressl262)))]
+#[cfg(not(any(libressl261, libressl262, libressl263)))]
 fn test_connect_with_unilateral_npn() {
     let (_s, stream) = Server::new();
     let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
@@ -616,7 +616,7 @@ fn test_connect_with_npn_successful_single_match() {
 /// Tests that when the `SslStream` is created as a server stream, the protocols
 /// are correctly advertised to the client.
 #[test]
-#[cfg(not(any(libressl261, libressl262)))]
+#[cfg(not(any(libressl261, libressl262, libressl263)))]
 fn test_npn_server_advertise_multiple() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let localhost = listener.local_addr().unwrap();
@@ -1241,7 +1241,7 @@ fn tmp_dh_callback() {
 }
 
 #[test]
-#[cfg(any(all(feature = "v101", ossl101, not(any(libressl261, libressl262))), all(feature = "v102", ossl102)))]
+#[cfg(any(all(feature = "v101", ossl101, not(any(libressl261, libressl262, libressl263))), all(feature = "v102", ossl102)))]
 fn tmp_ecdh_callback() {
     use ec::EcKey;
     use nid;
@@ -1308,7 +1308,7 @@ fn tmp_dh_callback_ssl() {
 }
 
 #[test]
-#[cfg(any(all(feature = "v101", ossl101, not(any(libressl261, libressl262))), all(feature = "v102", ossl102)))]
+#[cfg(any(all(feature = "v101", ossl101, not(any(libressl261, libressl262, libressl263))), all(feature = "v102", ossl102)))]
 fn tmp_ecdh_callback_ssl() {
     use ec::EcKey;
     use nid;


### PR DESCRIPTION
this adds support for LibreSSL 2.6.3. tests look good on my local machine.

i based this commit off of:

commit e0efd1d438fbf426a7e1006e4983b0f352c630f6
commit 1308cb2b526355c66854ee22ea03de93bae326c1
commit 701d3781dd8febcc582c801ba63527fcb5c328fb