### PR TITLE
Impl Send and Sync for all types which are created by `foreign_type` !

### DIFF
--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -38,7 +38,7 @@ use error::ErrorStack;
 use nid::Nid;
 use string::OpensslString;
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_GENERALIZEDTIME;
     fn drop = ffi::ASN1_GENERALIZEDTIME_free;
 
@@ -73,7 +73,7 @@ impl fmt::Display for Asn1GeneralizedTimeRef {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_TIME;
     fn drop = ffi::ASN1_TIME_free;
     /// Time storage and comparison
@@ -119,7 +119,7 @@ impl Asn1Time {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_STRING;
     fn drop = ffi::ASN1_STRING_free;
     /// Primary ASN.1 type used by OpenSSL
@@ -170,7 +170,7 @@ impl Asn1StringRef {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_INTEGER;
     fn drop = ffi::ASN1_INTEGER_free;
 
@@ -211,7 +211,7 @@ impl Asn1IntegerRef {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_BIT_STRING;
     fn drop = ffi::ASN1_BIT_STRING_free;
     /// Sequence of bytes
@@ -238,7 +238,7 @@ impl Asn1BitStringRef {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_OBJECT;
     fn drop = ffi::ASN1_OBJECT_free;
 

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -67,7 +67,7 @@ pub const MSB_ONE: MsbOption = MsbOption(0);
 /// of bits in the original numbers.
 pub const TWO_MSB_ONE: MsbOption = MsbOption(1);
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::BN_CTX;
     fn drop = ffi::BN_CTX_free;
 
@@ -99,7 +99,7 @@ impl BigNumContext {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::BIGNUM;
     fn drop = ffi::BN_free;
 

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -18,7 +18,7 @@ use pkey::PKeyRef;
 use cvt;
 use cvt_p;
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::CMS_ContentInfo;
     fn drop = ffi::CMS_ContentInfo_free;
 

--- a/openssl/src/conf.rs
+++ b/openssl/src/conf.rs
@@ -28,7 +28,7 @@ impl ConfMethod {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::CONF;
     fn drop = ffi::NCONF_free;
 

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -7,7 +7,7 @@ use std::ptr;
 use {cvt, cvt_p};
 use bn::BigNum;
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::DH;
     fn drop = ffi::DH_free;
 

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -17,7 +17,7 @@ use bn::BigNumRef;
 use error::ErrorStack;
 use util::{CallbackState, invoke_passwd_cb_old};
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::DSA;
     fn drop = ffi::DSA_free;
 

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -98,7 +98,7 @@ pub struct PointConversionForm(ffi::point_conversion_form_t);
 #[derive(Copy, Clone)]
 pub struct Asn1Flag(c_int);
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::EC_GROUP;
     fn drop = ffi::EC_GROUP_free;
 
@@ -233,7 +233,7 @@ impl EcGroupRef {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::EC_POINT;
     fn drop = ffi::EC_POINT_free;
 
@@ -498,7 +498,7 @@ impl EcPoint {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::EC_KEY;
     fn drop = ffi::EC_KEY_free;
 
@@ -646,7 +646,7 @@ impl EcKey {
 }
 
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::EC_KEY;
     fn drop = ffi::EC_KEY_free;
 

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -27,6 +27,7 @@ use error::ErrorStack;
 mod macros;
 
 mod bio;
+#[macro_use]
 mod util;
 pub mod aes;
 pub mod asn1;

--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -214,3 +214,35 @@ macro_rules! from_pem {
             from_pem, $t, $f);
     }
 }
+
+
+macro_rules! foreign_type_and_impl_send_sync {
+    (
+        $(#[$impl_attr:meta])*
+        type CType = $ctype:ty;
+        fn drop = $drop:expr;
+        $(fn clone = $clone:expr;)*
+
+        $(#[$owned_attr:meta])*
+        pub struct $owned:ident;
+        $(#[$borrowed_attr:meta])*
+        pub struct $borrowed:ident;
+    )
+        => {
+            foreign_type! {
+                $(#[$impl_attr])*
+                type CType = $ctype;
+                fn drop = $drop;
+                $(fn clone = $clone;)*
+                $(#[$owned_attr])*
+                pub struct $owned;
+                $(#[$borrowed_attr])*
+                pub struct $borrowed;
+            }
+
+            unsafe impl Send for $owned{}
+            unsafe impl Send for $borrowed{}
+            unsafe impl Sync for $owned{}
+            unsafe impl Sync for $borrowed{}
+        };
+}

--- a/openssl/src/ocsp.rs
+++ b/openssl/src/ocsp.rs
@@ -136,7 +136,7 @@ impl<'a> Status<'a> {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::OCSP_BASICRESP;
     fn drop = ffi::OCSP_BASICRESP_free;
 
@@ -203,7 +203,7 @@ impl OcspBasicResponseRef {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::OCSP_CERTID;
     fn drop = ffi::OCSP_CERTID_free;
 
@@ -228,7 +228,7 @@ impl OcspCertId {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::OCSP_RESPONSE;
     fn drop = ffi::OCSP_RESPONSE_free;
 
@@ -273,7 +273,7 @@ impl OcspResponseRef {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::OCSP_REQUEST;
     fn drop = ffi::OCSP_REQUEST_free;
 
@@ -305,7 +305,7 @@ impl OcspRequestRef {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::OCSP_ONEREQ;
     fn drop = ffi::OCSP_ONEREQ_free;
 

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -13,7 +13,7 @@ use x509::X509;
 use stack::Stack;
 use nid;
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::PKCS12;
     fn drop = ffi::PKCS12_free;
 

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -14,7 +14,7 @@ use rsa::{Rsa, Padding};
 use error::ErrorStack;
 use util::{CallbackState, invoke_passwd_cb, invoke_passwd_cb_old};
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::EVP_PKEY;
     fn drop = ffi::EVP_PKEY_free;
 
@@ -74,9 +74,6 @@ impl PKeyRef {
         unsafe { ffi::EVP_PKEY_cmp(self.as_ptr(), other.as_ptr()) == 1 }
     }
 }
-
-unsafe impl Send for PKey {}
-unsafe impl Sync for PKey {}
 
 impl PKey {
     /// Creates a new `PKey` containing an RSA key.
@@ -226,16 +223,13 @@ impl PKey {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::EVP_PKEY_CTX;
     fn drop = ffi::EVP_PKEY_CTX_free;
 
     pub struct PKeyCtx;
     pub struct PKeyCtxRef;
 }
-
-unsafe impl Send for PKeyCtx {}
-unsafe impl Sync for PKeyCtx {}
 
 impl PKeyCtx {
     pub fn from_pkey(pkey: &PKeyRef) -> Result<PKeyCtx, ErrorStack> {

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -29,7 +29,7 @@ pub const NO_PADDING: Padding = Padding(ffi::RSA_NO_PADDING);
 pub const PKCS1_PADDING: Padding = Padding(ffi::RSA_PKCS1_PADDING);
 pub const PKCS1_OAEP_PADDING: Padding = Padding(ffi::RSA_PKCS1_OAEP_PADDING);
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::RSA;
     fn drop = ffi::RSA_free;
 

--- a/openssl/src/string.rs
+++ b/openssl/src/string.rs
@@ -8,7 +8,7 @@ use std::str;
 
 use stack::Stackable;
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = c_char;
     fn drop = free;
 

--- a/openssl/src/verify.rs
+++ b/openssl/src/verify.rs
@@ -20,7 +20,7 @@ bitflags! {
     }
 }
 
-foreign_type! {
+foreign_type_and_impl_send_sync! {
     type CType = ffi::X509_VERIFY_PARAM;
     fn drop = ffi::X509_VERIFY_PARAM_free;
 


### PR DESCRIPTION
Hello, 
This PR follows #772. I have a few problems while implementing the changes.
First of all, I can't seem to figure how the `foreign_type!` macro uses the provided (or not) `clone` function. It just seems to ignore it when I give it a function. This is the reason why the wrapper is missing the `$(fn clone = $clone:expr;)*` line. Can you explain to me how should it work, and how to wrap correctly `foreign_type!` ?

Next, the compiler is complaining about missing doc, and I can't figure why. For more details, take a look at the [output of the compiler.](https://gist.github.com/gbip/ed6d8aa46ecb7bfeca8e7b11a901d73b)