### PR TITLE
Upgrade foreign-types

### DIFF
--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -20,7 +20,7 @@ v110 = []
 
 [dependencies]
 bitflags = "0.9"
-foreign-types = "0.2"
+foreign-types = "0.3.1"
 lazy_static = "0.2"
 libc = "0.2"
 openssl-sys = { version = "0.9.21", path = "../openssl-sys" }

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -1090,12 +1090,6 @@ impl BigNum {
     }
 }
 
-impl AsRef<BigNumRef> for BigNum {
-    fn as_ref(&self) -> &BigNumRef {
-        self.deref()
-    }
-}
-
 impl fmt::Debug for BigNumRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.to_dec_str() {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -76,7 +76,6 @@ use libc::{c_int, c_long, c_ulong, c_void};
 use libc::{c_uchar, c_uint};
 use std::any::Any;
 use std::any::TypeId;
-use std::borrow::Borrow;
 use std::cmp;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
@@ -777,8 +776,7 @@ impl SslContextBuilder {
     #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
     pub fn set_psk_callback<F>(&mut self, callback: F)
     where
-        F: Fn(&mut SslRef, Option<&[u8]>, &mut [u8], &mut [u8])
-            -> Result<usize, ErrorStack>
+        F: Fn(&mut SslRef, Option<&[u8]>, &mut [u8], &mut [u8]) -> Result<usize, ErrorStack>
             + Any
             + 'static
             + Sync
@@ -1023,12 +1021,6 @@ unsafe impl Send for SslSession {}
 impl Clone for SslSession {
     fn clone(&self) -> SslSession {
         self.to_owned()
-    }
-}
-
-impl Borrow<SslSessionRef> for SslSession {
-    fn borrow(&self) -> &SslSessionRef {
-        &self
     }
 }
 

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -2,7 +2,6 @@
 use libc::{c_int, c_long};
 use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
-use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::error::Error;
 use std::ffi::{CStr, CString};
@@ -620,21 +619,9 @@ impl Clone for X509 {
     }
 }
 
-impl AsRef<X509Ref> for X509 {
-    fn as_ref(&self) -> &X509Ref {
-        &*self
-    }
-}
-
 impl AsRef<X509Ref> for X509Ref {
     fn as_ref(&self) -> &X509Ref {
         self
-    }
-}
-
-impl Borrow<X509Ref> for X509 {
-    fn borrow(&self) -> &X509Ref {
-        &*self
     }
 }
 


### PR DESCRIPTION
foreign-types 0.3 and 0.2 now share the same types and traits, so this
is backwards compatible.

cc @nox