### PR TITLE
Add recent LibreSSL versions

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -468,6 +468,13 @@ See rust-openssl README for more information:
         println!("cargo:libressl_version=263");
         println!("cargo:version=101");
         Version::Libressl
+    } else if expanded.contains("RUST_LIBRESSL_264") {
+        println!("cargo:rustc-cfg=libressl");
+        println!("cargo:rustc-cfg=libressl264");
+        println!("cargo:libressl=true");
+        println!("cargo:libressl_version=264");
+        println!("cargo:version=101");
+        Version::Libressl
     } else if expanded.contains("RUST_LIBRESSL_26X") {
         println!("cargo:rustc-cfg=libressl");
         println!("cargo:rustc-cfg=libressl26x");

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -316,10 +316,14 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
 #include <openssl/opensslv.h>
 #include <openssl/opensslconf.h>
 
-#if LIBRESSL_VERSION_NUMBER >= 0x20700000
+#if LIBRESSL_VERSION_NUMBER >= 0x20800000
 RUST_LIBRESSL_NEW
+#elif LIBRESSL_VERSION_NUMBER >= 0x20700000
+RUST_LIBRESSL_270
+#elif LIBRESSL_VERSION_NUMBER >= 0x20604000
+RUST_LIBRESSL_264
 #elif LIBRESSL_VERSION_NUMBER >= 0x20603000
-RUST_LIBRESSL_26X
+RUST_LIBRESSL_263
 #elif LIBRESSL_VERSION_NUMBER >= 0x20602000
 RUST_LIBRESSL_262
 #elif LIBRESSL_VERSION_NUMBER >= 0x20601000
@@ -457,11 +461,25 @@ See rust-openssl README for more information:
         println!("cargo:libressl_version=262");
         println!("cargo:version=101");
         Version::Libressl
+    } else if expanded.contains("RUST_LIBRESSL_263") {
+        println!("cargo:rustc-cfg=libressl");
+        println!("cargo:rustc-cfg=libressl263");
+        println!("cargo:libressl=true");
+        println!("cargo:libressl_version=263");
+        println!("cargo:version=101");
+        Version::Libressl
     } else if expanded.contains("RUST_LIBRESSL_26X") {
         println!("cargo:rustc-cfg=libressl");
         println!("cargo:rustc-cfg=libressl26x");
         println!("cargo:libressl=true");
         println!("cargo:libressl_version=26x");
+        println!("cargo:version=101");
+        Version::Libressl
+    } else if expanded.contains("RUST_LIBRESSL_270") {
+        println!("cargo:rustc-cfg=libressl");
+        println!("cargo:rustc-cfg=libressl270");
+        println!("cargo:libressl=true");
+        println!("cargo:libressl_version=270");
         println!("cargo:version=101");
         Version::Libressl
     } else if expanded.contains("RUST_OPENSSL_110F") {


### PR DESCRIPTION
* added 2.6.4 release
* added 2.7.0 version which is running on OpenBSD-current.
* added 2.8.0 as RUST_LIBRESSL_NEW

2.6.4 was [released](https://www.libressl.org/releases.html) on December 19th

OpenBSD-current:

```
$ cat /usr/include/openssl/opensslv.h
/* $OpenBSD: opensslv.h,v 1.44 2017/12/11 11:04:04 bcook Exp $ */
#ifndef HEADER_OPENSSLV_H
#define HEADER_OPENSSLV_H

/* These will change with each release of LibreSSL-portable */
#define LIBRESSL_VERSION_NUMBER 0x2070000fL
#define LIBRESSL_VERSION_TEXT   "LibreSSL 2.7.0"
```
```
$ openssl version
LibreSSL 2.7.0
```