### PR TITLE
Bump hex to 0.3

### DIFF
--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -27,5 +27,5 @@ openssl-sys = { version = "0.9.23", path = "../openssl-sys" }
 
 [dev-dependencies]
 tempdir = "0.3"
-hex = "0.2"
+hex = "0.3"
 data-encoding = "2.0"

--- a/openssl/src/aes.rs
+++ b/openssl/src/aes.rs
@@ -27,7 +27,7 @@
 //! extern crate hex;
 //! use openssl::aes::{AesKey, KeyError, aes_ige};
 //! use openssl::symm::Mode;
-//! use hex::{FromHex, ToHex};
+//! use hex::FromHex;
 //!
 //! fn decrypt() -> Result<(), KeyError> {
 //!   let raw_key = "000102030405060708090A0B0C0D0E0F";
@@ -38,7 +38,7 @@
 //!     let key = AesKey::new_encrypt(&key_as_u8)?;
 //!     let mut output = vec![0u8; cipher_as_u8.len()];
 //!     aes_ige(&cipher_as_u8, &mut output, &key, &mut iv_as_u8, Mode::Encrypt);
-//!     assert_eq!(output.to_hex(), "a6ad974d5cea1d36d2f367980907ed32");
+//!     assert_eq!(hex::encode(output), "a6ad974d5cea1d36d2f367980907ed32");
 //!   }
 //!   Ok(())
 //! }

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -265,20 +265,20 @@ pub fn hash(t: MessageDigest, data: &[u8]) -> Result<DigestBytes, ErrorStack> {
 
 #[cfg(test)]
 mod tests {
-    use hex::{FromHex, ToHex};
+    use hex::{self, FromHex};
     use std::io::prelude::*;
 
     use super::*;
 
     fn hash_test(hashtype: MessageDigest, hashtest: &(&str, &str)) {
         let res = hash(hashtype, &Vec::from_hex(hashtest.0).unwrap()).unwrap();
-        assert_eq!(res.to_hex(), hashtest.1);
+        assert_eq!(hex::encode(res), hashtest.1);
     }
 
     fn hash_recycle_test(h: &mut Hasher, hashtest: &(&str, &str)) {
         let _ = h.write_all(&Vec::from_hex(hashtest.0).unwrap()).unwrap();
         let res = h.finish().unwrap();
-        assert_eq!(res.to_hex(), hashtest.1);
+        assert_eq!(hex::encode(res), hashtest.1);
     }
 
     // Test vectors from http://www.nsrl.nist.gov/testdata/
@@ -344,18 +344,18 @@ mod tests {
             let mut h2 = h1.clone();
             h2.write_all(&inp[p..]).unwrap();
             let res = h2.finish().unwrap();
-            assert_eq!(res.to_hex(), md5_tests[i].1);
+            assert_eq!(hex::encode(res), md5_tests[i].1);
         }
         h1.write_all(&inp[p..]).unwrap();
         let res = h1.finish().unwrap();
-        assert_eq!(res.to_hex(), md5_tests[i].1);
+        assert_eq!(hex::encode(res), md5_tests[i].1);
 
         println!("Clone a finished hasher");
         let mut h3 = h1.clone();
         h3.write_all(&Vec::from_hex(md5_tests[i + 1].0).unwrap())
             .unwrap();
         let res = h3.finish().unwrap();
-        assert_eq!(res.to_hex(), md5_tests[i + 1].1);
+        assert_eq!(hex::encode(res), md5_tests[i + 1].1);
     }
 
     #[test]

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -186,7 +186,7 @@ impl Pkcs12Builder {
 #[cfg(test)]
 mod test {
     use hash::MessageDigest;
-    use hex::ToHex;
+    use hex;
 
     use asn1::Asn1Time;
     use rsa::Rsa;
@@ -204,21 +204,19 @@ mod test {
         let parsed = pkcs12.parse("mypass").unwrap();
 
         assert_eq!(
-            parsed
+            hex::encode(parsed
                 .cert
                 .fingerprint(MessageDigest::sha1())
-                .unwrap()
-                .to_hex(),
+                .unwrap()),
             "59172d9313e84459bcff27f967e79e6e9217e584"
         );
 
         let chain = parsed.chain.unwrap();
         assert_eq!(chain.len(), 1);
         assert_eq!(
-            chain[0]
+            hex::encode(chain[0]
                 .fingerprint(MessageDigest::sha1())
-                .unwrap()
-                .to_hex(),
+                .unwrap()),
             "c0cbdf7cdd03c9773e5468e1f6d2da7d5cbb1875"
         );
     }

--- a/openssl/src/pkcs5.rs
+++ b/openssl/src/pkcs5.rs
@@ -548,7 +548,7 @@ mod tests {
     #[test]
     #[cfg(all(feature = "v110", ossl110))]
     fn scrypt() {
-        use hex::ToHex;
+        use hex;
 
         let pass = "pleaseletmein";
         let salt = "SodiumChloride";
@@ -565,6 +565,6 @@ mod tests {
             0,
             &mut actual,
         ).unwrap();
-        assert_eq!((&actual[..]).to_hex(), expected);
+        assert_eq!(hex::encode(&actual[..]), expected);
     }
 }

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -18,7 +18,6 @@
 //! extern crate hex;
 //! 
 //! use openssl::sha;
-//! use hex::ToHex;
 //! 
 //! fn main() {
 //!     let mut hasher = sha::Sha256::new();
@@ -27,7 +26,7 @@
 //!     hasher.update(b"world");
 //! 
 //!     let hash = hasher.finish();
-//!     println!("Hashed \"Hello, world\" to {}", hash.to_hex());
+//!     println!("Hashed \"Hello, world\" to {}", hex::encode(hash));
 //! }
 //! ```
 //!
@@ -40,11 +39,10 @@
 //! extern crate hex;
 //!
 //! use openssl::sha::sha256;
-//! use hex::ToHex;
 //!
 //! fn main() {
 //!     let hash = sha256(b"your data or message");
-//!     println!("Hash = {}", hash.to_hex());
+//!     println!("Hash = {}", hex::encode(hash));
 //! }
 //! ```
 use libc::c_void;
@@ -288,7 +286,7 @@ impl Sha512 {
 
 #[cfg(test)]
 mod test {
-    use hex::ToHex;
+    use hex;
 
     use super::*;
 
@@ -297,7 +295,7 @@ mod test {
         let data = b"abc";
         let expected = "a9993e364706816aba3e25717850c26c9cd0d89d";
 
-        assert_eq!(sha1(data).to_hex(), expected);
+        assert_eq!(hex::encode(sha1(data)), expected);
     }
 
     #[test]
@@ -307,7 +305,7 @@ mod test {
         let mut hasher = Sha1::new();
         hasher.update(b"a");
         hasher.update(b"bc");
-        assert_eq!(hasher.finish().to_hex(), expected);
+        assert_eq!(hex::encode(hasher.finish()), expected);
     }
 
     #[test]
@@ -315,7 +313,7 @@ mod test {
         let data = b"abc";
         let expected = "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7";
 
-        assert_eq!(sha224(data).to_hex(), expected);
+        assert_eq!(hex::encode(sha224(data)), expected);
     }
 
     #[test]
@@ -325,7 +323,7 @@ mod test {
         let mut hasher = Sha224::new();
         hasher.update(b"a");
         hasher.update(b"bc");
-        assert_eq!(hasher.finish().to_hex(), expected);
+        assert_eq!(hex::encode(hasher.finish()), expected);
     }
 
     #[test]
@@ -333,7 +331,7 @@ mod test {
         let data = b"abc";
         let expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
 
-        assert_eq!(sha256(data).to_hex(), expected);
+        assert_eq!(hex::encode(sha256(data)), expected);
     }
 
     #[test]
@@ -343,7 +341,7 @@ mod test {
         let mut hasher = Sha256::new();
         hasher.update(b"a");
         hasher.update(b"bc");
-        assert_eq!(hasher.finish().to_hex(), expected);
+        assert_eq!(hex::encode(hasher.finish()), expected);
     }
 
     #[test]
@@ -352,7 +350,7 @@ mod test {
         let expected = "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e\
                         7cc2358baeca134c825a7";
 
-        assert_eq!((&sha384(data)[..]).to_hex(), expected);
+        assert_eq!(hex::encode(&sha384(data)[..]), expected);
     }
 
     #[test]
@@ -363,7 +361,7 @@ mod test {
         let mut hasher = Sha384::new();
         hasher.update(b"a");
         hasher.update(b"bc");
-        assert_eq!((&hasher.finish()[..]).to_hex(), expected);
+        assert_eq!(hex::encode(&hasher.finish()[..]), expected);
     }
 
     #[test]
@@ -372,7 +370,7 @@ mod test {
         let expected = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274\
                         fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f";
 
-        assert_eq!((&sha512(data)[..]).to_hex(), expected);
+        assert_eq!(hex::encode(&sha512(data)[..]), expected);
     }
 
     #[test]
@@ -383,6 +381,6 @@ mod test {
         let mut hasher = Sha512::new();
         hasher.update(b"a");
         hasher.update(b"bc");
-        assert_eq!((&hasher.finish()[..]).to_hex(), expected);
+        assert_eq!(hex::encode(&hasher.finish()[..]), expected);
     }
 }

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -382,7 +382,7 @@ unsafe fn EVP_DigestVerifyFinal(
 
 #[cfg(test)]
 mod test {
-    use hex::{FromHex, ToHex};
+    use hex::{self, FromHex};
     use std::iter;
 
     use hash::MessageDigest;
@@ -418,7 +418,7 @@ mod test {
         signer.update(&Vec::from_hex(INPUT).unwrap()).unwrap();
         let result = signer.sign_to_vec().unwrap();
 
-        assert_eq!(result.to_hex(), SIGNATURE);
+        assert_eq!(hex::encode(result), SIGNATURE);
     }
 
     #[test]

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -615,7 +615,7 @@ use self::compat::*;
 
 #[cfg(test)]
 mod tests {
-    use hex::{FromHex, ToHex};
+    use hex::{self, FromHex};
     use super::*;
 
     // Test vectors from FIPS-197:
@@ -703,7 +703,7 @@ mod tests {
         let count = c.update(&p0, &mut r0).unwrap();
         let rest = c.finalize(&mut r0[count..]).unwrap();
         r0.truncate(count + rest);
-        assert_eq!(r0.to_hex(), c0.to_hex());
+        assert_eq!(hex::encode(&r0), hex::encode(c0));
 
         let mut c = super::Crypter::new(
             super::Cipher::aes_256_ecb(),
@@ -716,7 +716,7 @@ mod tests {
         let count = c.update(&r0, &mut p1).unwrap();
         let rest = c.finalize(&mut p1[count..]).unwrap();
         p1.truncate(count + rest);
-        assert_eq!(p1.to_hex(), p0.to_hex());
+        assert_eq!(hex::encode(p1), hex::encode(p0));
     }
 
     #[test]
@@ -818,8 +818,8 @@ mod tests {
         let expected = pt;
 
         if computed != expected {
-            println!("Computed: {}", computed.to_hex());
-            println!("Expected: {}", expected.to_hex());
+            println!("Computed: {}", hex::encode(&computed));
+            println!("Expected: {}", hex::encode(&expected));
             if computed.len() != expected.len() {
                 println!(
                     "Lengths differ: {} in computed vs {} expected",
@@ -849,8 +849,8 @@ mod tests {
         let expected = pt;
 
         if computed != expected {
-            println!("Computed: {}", computed.to_hex());
-            println!("Expected: {}", expected.to_hex());
+            println!("Computed: {}", hex::encode(&computed));
+            println!("Expected: {}", hex::encode(&expected));
             if computed.len() != expected.len() {
                 println!(
                     "Lengths differ: {} in computed vs {} expected",
@@ -1061,8 +1061,8 @@ mod tests {
             &Vec::from_hex(pt).unwrap(),
             &mut actual_tag,
         ).unwrap();
-        assert_eq!(ct, out.to_hex());
-        assert_eq!(tag, actual_tag.to_hex());
+        assert_eq!(ct, hex::encode(out));
+        assert_eq!(tag, hex::encode(actual_tag));
 
         let out = decrypt_aead(
             Cipher::aes_128_gcm(),
@@ -1072,7 +1072,7 @@ mod tests {
             &Vec::from_hex(ct).unwrap(),
             &Vec::from_hex(tag).unwrap(),
         ).unwrap();
-        assert_eq!(pt, out.to_hex());
+        assert_eq!(pt, hex::encode(out));
     }
 
     #[test]
@@ -1111,8 +1111,8 @@ mod tests {
             &Vec::from_hex(pt).unwrap(),
             &mut actual_tag,
         ).unwrap();
-        assert_eq!(ct, out.to_hex());
-        assert_eq!(tag, actual_tag.to_hex());
+        assert_eq!(ct, hex::encode(out));
+        assert_eq!(tag, hex::encode(actual_tag));
 
         let out = decrypt_aead(
             Cipher::chacha20_poly1305(),
@@ -1122,6 +1122,6 @@ mod tests {
             &Vec::from_hex(ct).unwrap(),
             &Vec::from_hex(tag).unwrap(),
         ).unwrap();
-        assert_eq!(pt, out.to_hex());
+        assert_eq!(pt, hex::encode(out));
     }
 }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -1,4 +1,4 @@
-use hex::{FromHex, ToHex};
+use hex::{self, FromHex};
 
 use asn1::Asn1Time;
 use bn::{BigNum, MsbOption};
@@ -231,17 +231,15 @@ fn test_stack_from_pem() {
 
     assert_eq!(certs.len(), 2);
     assert_eq!(
-        certs[0]
+        hex::encode(certs[0]
             .fingerprint(MessageDigest::sha1())
-            .unwrap()
-            .to_hex(),
+            .unwrap()),
         "59172d9313e84459bcff27f967e79e6e9217e584"
     );
     assert_eq!(
-        certs[1]
+        hex::encode(certs[1]
             .fingerprint(MessageDigest::sha1())
-            .unwrap()
-            .to_hex(),
+            .unwrap()),
         "c0cbdf7cdd03c9773e5468e1f6d2da7d5cbb1875"
     );
 }
@@ -263,7 +261,7 @@ fn signature() {
     let cert = X509::from_pem(cert).unwrap();
     let signature = cert.signature();
     assert_eq!(
-        signature.as_slice().to_hex(),
+        hex::encode(signature.as_slice()),
         "4af607b889790b43470442cfa551cdb8b6d0b0340d2958f76b9e3ef6ad4992230cead6842587f0ecad5\
          78e6e11a221521e940187e3d6652de14e84e82f6671f097cc47932e022add3c0cb54a26bf27fa84c107\
          4971caa6bee2e42d34a5b066c427f2d452038082b8073993399548088429de034fdd589dcfb0dd33be7\


### PR DESCRIPTION
The `to_hex` method has been removed and `hex::encode` should be used
instead.