### PR TITLE
[WIP] Expose bindings needed for TLS1.3 stateless handshakes

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -18,6 +18,11 @@ mod ossl110;
 #[cfg(ossl110)]
 pub use ossl110::*;
 
+#[cfg(ossl111)]
+mod ossl111;
+#[cfg(ossl111)]
+pub use ossl111::*;
+
 #[cfg(libressl)]
 mod libressl;
 #[cfg(libressl)]
@@ -1430,6 +1435,8 @@ pub const GEN_URI: c_int = 6;
 pub const GEN_IPADD: c_int = 7;
 pub const GEN_RID: c_int = 8;
 
+pub const DTLS1_COOKIE_LENGTH: c_uint = 256;
+
 // macros
 pub unsafe fn BIO_get_mem_data(b: *mut BIO, pp: *mut *mut c_char) -> c_long {
     BIO_ctrl(b, BIO_CTRL_INFO, 0, pp as *mut c_void)
@@ -2762,4 +2769,33 @@ extern "C" {
     pub fn FIPS_mode_set(onoff: c_int) -> c_int;
     #[cfg(not(libressl))]
     pub fn FIPS_mode() -> c_int;
+
+    pub fn SSL_CTX_set_cookie_generate_cb(
+        s: *mut SSL_CTX,
+        cb: Option<extern "C" fn(
+            ssl: *mut SSL,
+            cookie: *mut c_uchar,
+            cookie_len: *mut c_uint
+        ) -> c_int>
+    );
+
+    #[cfg(ossl110)]
+    pub fn SSL_CTX_set_cookie_verify_cb(
+        s: *mut SSL_CTX,
+        cb: Option<extern "C" fn(
+            ssl: *mut SSL,
+            cookie: *const c_uchar,
+            cookie_len: c_uint
+        ) -> c_int>
+    );
+
+    #[cfg(not(ossl110))]
+    pub fn SSL_CTX_set_cookie_verify_cb(
+        s: *mut SSL_CTX,
+        cb: Option<extern "C" fn(
+            ssl: *mut SSL,
+            cookie: *mut c_uchar,
+            cookie_len: c_uint
+        ) -> c_int>
+    );
 }

--- a/openssl-sys/src/ossl111.rs
+++ b/openssl-sys/src/ossl111.rs
@@ -1,0 +1,11 @@
+use libc::{c_int, c_ulong};
+
+use ossl110::*;
+
+pub const SSL_COOKIE_LENGTH: c_int = 255;
+
+pub const SSL_OP_ENABLE_MIDDLEBOX_COMPAT: c_ulong = 0x00100000;
+
+extern "C" {
+    pub fn SSL_stateless(s: *mut SSL) -> c_int;
+}

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -361,3 +361,53 @@ where
 
     callback(ssl, line);
 }
+
+pub extern "C" fn raw_cookie_generate<F>(
+    ssl: *mut ffi::SSL,
+    cookie: *mut c_uchar,
+    cookie_len: *mut c_uint
+) -> c_int
+where
+    F: Fn(&mut SslRef, &mut [u8]) -> Result<usize, ErrorStack> + 'static + Sync + Send
+{
+    unsafe {
+        let ssl_ctx = ffi::SSL_get_SSL_CTX(ssl as *const _);
+        let callback = ffi::SSL_CTX_get_ex_data(ssl_ctx, get_callback_idx::<F>());
+        let ssl = SslRef::from_ptr_mut(ssl);
+        let callback = &*(callback as *mut F);
+        // We subtract 1 from DTLS1_COOKIE_LENGTH as the ostensible value, 256, is erroneous but retained for
+        // compatibility. See comments in dtls1.h.
+        let slice = slice::from_raw_parts_mut(cookie as *mut u8, ffi::DTLS1_COOKIE_LENGTH as usize - 1);
+        match callback(ssl, slice) {
+            Ok(len) => {
+                *cookie_len = len as c_uint;
+                1
+            }
+            Err(_) => 0,
+        }
+    }
+}
+
+#[cfg(ossl110)]
+type CookiePtr = *const c_uchar;
+
+#[cfg(not(ossl110))]
+type CookiePtr = *mut c_uchar;
+
+pub extern "C" fn raw_cookie_verify<F>(
+    ssl: *mut ffi::SSL,
+    cookie: CookiePtr,
+    cookie_len: c_uint
+) -> c_int
+where
+    F: Fn(&mut SslRef, &[u8]) -> bool + 'static + Sync + Send
+{
+    unsafe {
+        let ssl_ctx = ffi::SSL_get_SSL_CTX(ssl as *const _);
+        let callback = ffi::SSL_CTX_get_ex_data(ssl_ctx, get_callback_idx::<F>());
+        let ssl = SslRef::from_ptr_mut(ssl);
+        let callback = &*(callback as *mut F);
+        let slice = slice::from_raw_parts(cookie as *const c_uchar as *const u8, cookie_len as usize);
+        callback(ssl, slice) as c_int
+    }
+}


### PR DESCRIPTION
This is necessary for some non-TCP applications of TLS, e.g. QUIC implementations.

I have only a vague idea what I'm doing here, and this hasn't been well tested yet, but it's a beginning.

For some reason I can't get the new bindings to actually be compiled with any feature flags other than `--all-features`.