### PR TITLE
 Add des_ede3_cbc cipher and more tests/examples

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1889,6 +1889,7 @@ extern "C" {
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
+    pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 
     pub fn EVP_BytesToKey(
         typ: *const EVP_CIPHER,

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -137,6 +137,10 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_des_ede3()) }
     }
 
+    pub fn des_ede3_cbc() -> Cipher {
+        unsafe { Cipher(ffi::EVP_des_ede3_cbc()) }
+    }
+
     pub fn rc4() -> Cipher {
         unsafe { Cipher(ffi::EVP_rc4()) }
     }
@@ -1048,6 +1052,17 @@ mod tests {
         let iv = "5cc118306dc702e4";
 
         cipher_test(super::Cipher::des_ede3(), pt, ct, key, iv);
+    }
+
+    #[test]
+    fn test_des_ede3_cbc() {
+
+        let pt = "54686973206973206120746573742e";
+        let ct = "6f2867cfefda048a4046ef7e556c7132";
+        let key = "7cb66337f3d3c0fe7cb66337f3d3c0fe7cb66337f3d3c0fe";
+        let iv = "0001020304050607";
+
+        cipher_test(super::Cipher::des_ede3_cbc(), pt, ct, key, iv);
     }
 
     #[test]

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -22,6 +22,36 @@
 //!       \xFB\x3C\x5E\xC4\x59\x72\x4A\xF4\x7C\xA1",
 //!     &ciphertext[..]);
 //! ```
+//!
+//! Encrypting an assymetric key with a symmetric cipher
+//!
+//! ```
+//! use openssl::rsa::{Padding, Rsa};
+//! use openssl::symm::Cipher;
+//!
+//! // Generate keypair and encrypt private key:
+//! let keypair = Rsa::generate(2048).unwrap();
+//! let cipher = Cipher::aes_256_cbc();
+//! let pubkey_pem = keypair.public_key_to_pem_pkcs1().unwrap();
+//! let privkey_pem = keypair.private_key_to_pem_passphrase(cipher, b"Rust").unwrap();
+//! // pubkey_pem and privkey_pem could be written to file here.
+//!
+//! // Load private and public key from string:
+//! let pubkey = Rsa::public_key_from_pem_pkcs1(&pubkey_pem).unwrap();
+//! let privkey = Rsa::private_key_from_pem_passphrase(&privkey_pem, b"Rust").unwrap();
+//!
+//! // Use the asymmetric keys to encrypt and decrypt a short message:
+//! let msg = b"Foo bar";
+//! let mut encrypted = vec![0; pubkey.size() as usize];
+//! let mut decrypted = vec![0; privkey.size() as usize];
+//! let len = pubkey.public_encrypt(msg, &mut encrypted, Padding::PKCS1).unwrap();
+//! assert!(len > msg.len());
+//! let len = privkey.private_decrypt(&encrypted, &mut decrypted, Padding::PKCS1).unwrap();
+//! let output_string = String::from_utf8(decrypted[..len].to_vec()).unwrap();
+//! assert_eq!("Foo bar", output_string);
+//! println!("Decrypted: '{}'", output_string);
+//! ```
+
 use std::cmp;
 use std::ptr;
 use libc::c_int;


### PR DESCRIPTION
For the record, this cipher is deprecated and shouldn't be used in new stuff. It's still in C API, and nice to have access to in rust as well, in my case for maintaining compatibility with old code and versions.