### PR TITLE
Fix symm decrypt documentation example

### DIFF
--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -505,7 +505,7 @@ pub fn encrypt(
 ///
 /// # Examples
 ///
-/// Decrypt data in AES256 ECB mode
+/// Decrypt data in AES128 CBC mode
 ///
 /// ```
 /// use openssl::symm::{decrypt, Cipher};


### PR DESCRIPTION
Referring to issue #723.

There is a small inconsistency in the openssl::symm::decrypt function documentation example.
The doc says "Decrypt data in AES256 ECB mode" while using AES128 CBC in the example.