### PR TITLE
Update SslConnector cipher list

### DIFF
--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -7,13 +7,6 @@ use ssl::{HandshakeError, Ssl, SslContext, SslContextBuilder, SslMethod, SslMode
           SslRef, SslStream, SslVerifyMode};
 use version;
 
-// From https://github.com/python/cpython/blob/a170fa162dc03f0a014373349e548954fff2e567/Lib/ssl.py#L193
-#[cfg(ossl101)]
-const CLIENT_CIPHERS: &'static str =
-    "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+HIGH:DH+HIGH:RSA+AESGCM:\
-     RSA+AES:RSA+HIGH:!aNULL:!eNULL:!MD5:!3DES";
-// From https://github.com/python/cpython/blob/892d66e422d5367673163d62ba40cd70a37d5cf7/Modules/_ssl.c#L254
-#[cfg(not(ossl101))]
 const CLIENT_CIPHERS: &'static str =
     "DEFAULT:!aNULL:!eNULL:!MD5:!3DES:!DES:!RC4:!IDEA:!SEED:!aDSS:!SRP:!PSK";
 


### PR DESCRIPTION
Based off of python/cpython#3532, we use OpenSSL's default cipher list
and turn of things we don't like. This can't be used with 1.0.1,
however, which had a poor default set. There, we use the old defaults,
with the bits that aren't implemented in 1.0.1 removed (namely TLSv1.3
suites and ChaCha).