### PR TITLE
Always include something in ErrorStack's Display

### DIFF
--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -59,6 +59,10 @@ impl ErrorStack {
 
 impl fmt::Display for ErrorStack {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        if self.0.is_empty() {
+            return fmt.write_str("OpenSSL error");
+        }
+
         let mut first = true;
         for err in &self.0 {
             if !first {


### PR DESCRIPTION
The error stack can be empty after a some kinds of errors (AEAD
validation failure in Crypter is one example), and we don't want to
display as an empty string in that case.