### PR TITLE
Custom extensions

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1203,6 +1203,12 @@ pub const RSA_X931_PADDING: c_int = 5;
 
 pub const SHA_LBLOCK: c_int = 16;
 
+pub const SSL3_AD_ILLEGAL_PARAMETER: c_int = 47;
+pub const SSL_AD_ILLEGAL_PARAMETER: c_int = SSL3_AD_ILLEGAL_PARAMETER;
+
+pub const TLS1_AD_DECODE_ERROR: c_int = 50;
+pub const SSL_AD_DECODE_ERROR: c_int = TLS1_AD_DECODE_ERROR;
+
 pub const TLS1_AD_UNRECOGNIZED_NAME: c_int = 112;
 pub const SSL_AD_UNRECOGNIZED_NAME: c_int = TLS1_AD_UNRECOGNIZED_NAME;
 

--- a/openssl-sys/src/ossl10x.rs
+++ b/openssl-sys/src/ossl10x.rs
@@ -969,4 +969,7 @@ extern "C" {
 
     pub fn SSLeay() -> c_ulong;
     pub fn SSLeay_version(key: c_int) -> *const c_char;
+
+    #[cfg(ossl102)]
+    pub fn SSL_extension_supported(ext_type: c_uint) -> c_int;
 }

--- a/openssl-sys/src/ossl110.rs
+++ b/openssl-sys/src/ossl110.rs
@@ -363,4 +363,5 @@ extern "C" {
     ) -> *mut PKCS12;
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> c_long;
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut ::X509_NAME;
+    pub fn SSL_extension_supported(ext_type: c_uint) -> c_int;
 }

--- a/openssl-sys/src/ossl111.rs
+++ b/openssl-sys/src/ossl111.rs
@@ -1,7 +1,29 @@
-use libc::{c_char, c_int, c_ulong};
+use libc::{c_char, c_uchar, c_int, c_uint, c_ulong, size_t, c_void};
 
 pub type SSL_CTX_keylog_cb_func =
     Option<unsafe extern "C" fn(ssl: *const ::SSL, line: *const c_char)>;
+
+pub type SSL_custom_ext_add_cb_ex =
+    Option<unsafe extern "C" fn(ssl: *mut ::SSL, ext_type: c_uint,
+                                context: c_uint,
+                                out: *mut *const c_uchar,
+                                outlen: *mut size_t, x: *mut ::X509,
+                                chainidx: size_t, al: *mut c_int,
+                                add_arg: *mut c_void) -> c_int>;
+
+pub type SSL_custom_ext_free_cb_ex =
+    Option<unsafe extern "C" fn(ssl: *mut ::SSL, ext_type: c_uint,
+                                context: c_uint,
+                                out: *mut *const c_uchar,
+                                add_arg: *mut c_void)>;
+
+pub type SSL_custom_ext_parse_cb_ex =
+    Option<unsafe extern "C" fn(ssl: *mut ::SSL, ext_type: c_uint,
+                                context: c_uint,
+                                input: *const c_uchar,
+                                inlen: size_t, x: *mut ::X509,
+                                chainidx: size_t, al: *mut c_int,
+                                parse_arg: *mut c_void) -> c_int>;
 
 pub const SSL_COOKIE_LENGTH: c_int = 255;
 
@@ -9,7 +31,37 @@ pub const SSL_OP_ENABLE_MIDDLEBOX_COMPAT: c_ulong = 0x00100000;
 
 pub const TLS1_3_VERSION: c_int = 0x304;
 
+pub const SSL_EXT_TLS_ONLY: c_uint = 0x0001;
+/* This extension is only allowed in DTLS */
+pub const SSL_EXT_DTLS_ONLY: c_uint = 0x0002;
+/* Some extensions may be allowed in DTLS but we don't implement them for it */
+pub const SSL_EXT_TLS_IMPLEMENTATION_ONLY: c_uint = 0x0004;
+/* Most extensions are not defined for SSLv3 but EXT_TYPE_renegotiate is */
+pub const SSL_EXT_SSL3_ALLOWED: c_uint = 0x0008;
+/* Extension is only defined for TLS1.2 and below */
+pub const SSL_EXT_TLS1_2_AND_BELOW_ONLY: c_uint = 0x0010;
+/* Extension is only defined for TLS1.3 and above */
+pub const SSL_EXT_TLS1_3_ONLY: c_uint = 0x0020;
+/* Ignore this extension during parsing if we are resuming */
+pub const SSL_EXT_IGNORE_ON_RESUMPTION: c_uint = 0x0040;
+pub const SSL_EXT_CLIENT_HELLO: c_uint = 0x0080;
+/* Really means TLS1.2 or below */
+pub const SSL_EXT_TLS1_2_SERVER_HELLO: c_uint = 0x0100;
+pub const SSL_EXT_TLS1_3_SERVER_HELLO: c_uint = 0x0200;
+pub const SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS: c_uint = 0x0400;
+pub const SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST: c_uint = 0x0800;
+pub const SSL_EXT_TLS1_3_CERTIFICATE: c_uint = 0x1000;
+pub const SSL_EXT_TLS1_3_NEW_SESSION_TICKET: c_uint = 0x2000;
+pub const SSL_EXT_TLS1_3_CERTIFICATE_REQUEST: c_uint = 0x4000;
+
+
 extern "C" {
     pub fn SSL_CTX_set_keylog_callback(ctx: *mut ::SSL_CTX, cb: SSL_CTX_keylog_cb_func);
+    pub fn SSL_CTX_add_custom_ext(ctx: *mut ::SSL_CTX, ext_type: c_uint, context: c_uint,
+                                  add_cb: SSL_custom_ext_add_cb_ex,
+                                  free_cb: SSL_custom_ext_free_cb_ex,
+                                  add_arg: *mut c_void,
+                                  parse_cb: SSL_custom_ext_parse_cb_ex,
+                                  parse_arg: *mut c_void) -> c_int;
     pub fn SSL_stateless(s: *mut ::SSL) -> c_int;
 }

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -1,5 +1,9 @@
 use ffi;
 use libc::{c_char, c_int, c_uchar, c_uint, c_void};
+#[cfg(all(feature = "v111", ossl111))]
+use libc::size_t;
+#[cfg(all(feature = "v111", ossl111))]
+use std::borrow::Cow;
 use std::ffi::CStr;
 use std::ptr;
 use std::slice;
@@ -20,6 +24,10 @@ use ssl::{get_callback_idx, get_ssl_callback_idx, SniError, SslAlert, SslContext
           all(feature = "v111", ossl111)))]
 use ssl::AlpnError;
 use x509::X509StoreContextRef;
+#[cfg(all(feature = "v111", ossl111))]
+use ssl::ExtensionContext;
+#[cfg(all(feature = "v111", ossl111))]
+use x509::X509Ref;
 
 pub extern "C" fn raw_verify<F>(preverify_ok: c_int, x509_ctx: *mut ffi::X509_STORE_CTX) -> c_int
 where
@@ -414,5 +422,90 @@ where
         let slice =
             slice::from_raw_parts(cookie as *const c_uchar as *const u8, cookie_len as usize);
         callback(ssl, slice) as c_int
+    }
+}
+
+#[cfg(all(feature = "v111", ossl111))]
+pub struct CustomExtAddState(Option<Cow<'static, [u8]>>);
+
+#[cfg(all(feature = "v111", ossl111))]
+pub extern "C" fn raw_custom_ext_add<F>(ssl: *mut ffi::SSL, _: c_uint,
+                                        context: c_uint,
+                                        out: *mut *const c_uchar,
+                                        outlen: *mut size_t, x: *mut ffi::X509,
+                                        chainidx: size_t, al: *mut c_int,
+                                        _: *mut c_void)
+                                        -> c_int
+    where F: Fn(&mut SslRef, ExtensionContext, Option<(usize, &X509Ref)>) -> Result<Option<Cow<'static, [u8]>>, SslAlert> + 'static
+{
+    unsafe {
+        let ssl_ctx = ffi::SSL_get_SSL_CTX(ssl as *const _);
+        let callback = ffi::SSL_CTX_get_ex_data(ssl_ctx, get_callback_idx::<F>());
+        let callback = &*(callback as *mut F);
+        let ssl = SslRef::from_ptr_mut(ssl);
+        let ectx = ExtensionContext::from_bits_truncate(context);
+        let cert = if ectx.contains(ExtensionContext::TLS1_3_CERTIFICATE) { Some((chainidx, X509Ref::from_ptr(x))) } else { None };
+        match (callback)(ssl, ectx, cert) {
+            Ok(None) => 0,
+            Ok(Some(buf)) => {
+                *outlen = buf.len() as size_t;
+                *out = buf.as_ptr();
+
+                let idx = get_ssl_callback_idx::<CustomExtAddState>();
+                let ptr = ffi::SSL_get_ex_data(ssl.as_ptr(), idx);
+                if ptr.is_null() {
+                    let x = Box::into_raw(Box::<CustomExtAddState>::new(CustomExtAddState(Some(buf)))) as *mut c_void;
+                    ffi::SSL_set_ex_data(ssl.as_ptr(), idx, x);
+                } else {
+                    *(ptr as *mut _) = CustomExtAddState(Some(buf))
+                }
+                1
+            }
+            Err(alert) => {
+                *al = alert.0;
+                -1
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "v111", ossl111))]
+pub extern "C" fn raw_custom_ext_free(ssl: *mut ffi::SSL, _: c_uint,
+                                      _: c_uint,
+                                      _: *mut *const c_uchar,
+                                      _: *mut c_void)
+{
+    unsafe {
+        let state = ffi::SSL_get_ex_data(ssl, get_ssl_callback_idx::<CustomExtAddState>());
+        let state = &mut (*(state as *mut CustomExtAddState)).0;
+        state.take();
+    }
+}
+
+#[cfg(all(feature = "v111", ossl111))]
+pub extern "C" fn raw_custom_ext_parse<F>(ssl: *mut ffi::SSL, _: c_uint,
+                                          context: c_uint,
+                                          input: *const c_uchar,
+                                          inlen: size_t, x: *mut ffi::X509,
+                                          chainidx: size_t, al: *mut c_int,
+                                          _: *mut c_void)
+                                        -> c_int
+    where F: FnMut(&mut SslRef, ExtensionContext, &[u8], Option<(usize, &X509Ref)>) -> Result<(), SslAlert> + 'static
+{
+    unsafe {
+        let ssl_ctx = ffi::SSL_get_SSL_CTX(ssl as *const _);
+        let callback = ffi::SSL_CTX_get_ex_data(ssl_ctx, get_callback_idx::<F>());
+        let ssl = SslRef::from_ptr_mut(ssl);
+        let callback = &mut *(callback as *mut F);
+        let ectx = ExtensionContext::from_bits_truncate(context);
+        let slice = slice::from_raw_parts(input as *const u8, inlen as usize);
+        let cert = if ectx.contains(ExtensionContext::TLS1_3_CERTIFICATE) { Some((chainidx, X509Ref::from_ptr(x))) } else { None };
+        match callback(ssl, ectx, slice, cert) {
+            Ok(()) => 1,
+            Err(alert) => {
+                *al = alert.0;
+                0
+            }
+        }
     }
 }

--- a/openssl/src/ssl/test.rs
+++ b/openssl/src/ssl/test.rs
@@ -1370,7 +1370,7 @@ fn custom_extensions() {
             .unwrap();
         ctx.add_custom_ext(
             12345, ssl::ExtensionContext::CLIENT_HELLO,
-            |_, _, _| unreachable!(),
+            |_, _, _| -> Result<Option<&'static [u8]>, _> { unreachable!() },
             |_, _, data, _| { FOUND_EXTENSION.store(data == b"hello", Ordering::SeqCst); Ok(()) }
         ).unwrap();
         let ssl = Ssl::new(&ctx.build()).unwrap();
@@ -1381,7 +1381,7 @@ fn custom_extensions() {
     let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
     ctx.add_custom_ext(
         12345, ssl::ExtensionContext::CLIENT_HELLO,
-        |_, _, _| Ok(Some(b"hello"[..].into())),
+        |_, _, _| Ok(Some(b"hello")),
         |_, _, _, _| unreachable!()
     ).unwrap();
     let ssl = Ssl::new(&ctx.build()).unwrap();

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -109,7 +109,7 @@ fn main() {
     cfg.skip_signededness(|s| {
         s.ends_with("_cb") || s.ends_with("_CB") || s.ends_with("_cb_fn")
             || s.starts_with("CRYPTO_") || s == "PasswordCallback"
-            || s.ends_with("_cb_func")
+            || s.ends_with("_cb_func") || s.ends_with("_cb_ex")
     });
     cfg.field_name(|_s, field| {
         if field == "type_" {


### PR DESCRIPTION
Needed for QUIC implementation.

Points of particular interest for review:
- Naming of `ssl::ExtensionContext`. I'm really not a fan of stuttering names (`ssl::Ssl*`) but if you prefer consistency, so be it.
- Signature of `SslContextBuilder::add_custom_ext`. In particular, the `Err` types.
- Trickery used to manage the lifetime of the `Cow` returned by the add callback.