### PR TITLE
Add support for LibreSSL 2.7.1, 2.7.2 and for OpenBSD -current

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,9 @@ openssl_101: &OPENSSL_101
 libressl_250: &LIBRESSL_250
   LIBRARY: libressl
   VERSION: 2.5.0
-libressl_263: &LIBRESSL_270
+libressl_270: &LIBRESSL_272
   LIBRARY: libressl
-  VERSION: 2.7.0
+  VERSION: 2.7.2
 
 x86_64: &X86_64
   TARGET: x86_64-unknown-linux-gnu
@@ -171,10 +171,10 @@ jobs:
     <<: *JOB
     environment:
       <<: [*LIBRESSL_250, *X86_64, *BASE]
-  x86_64-libressl-2.7.0:
+  x86_64-libressl-2.7.2:
     <<: *JOB
     environment:
-      <<: [*LIBRESSL_270, *X86_64, *BASE]
+      <<: [*LIBRESSL_272, *X86_64, *BASE]
   macos:
     <<: *MACOS_JOB
 workflows:
@@ -192,5 +192,5 @@ workflows:
     - armhf-openssl-1.1.0
     - armhf-openssl-1.0.2
     - x86_64-libressl-2.5.0
-    - x86_64-libressl-2.7.0
+    - x86_64-libressl-2.7.2
     - macos

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -323,8 +323,12 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
 #include <openssl/opensslv.h>
 #include <openssl/opensslconf.h>
 
-#if LIBRESSL_VERSION_NUMBER >= 0x20701000
+#if LIBRESSL_VERSION_NUMBER >= 0x20800000
 RUST_LIBRESSL_NEW
+#elif LIBRESSL_VERSION_NUMBER >= 0x20702000
+RUST_LIBRESSL_27X
+#elif LIBRESSL_VERSION_NUMBER >= 0x20701000
+RUST_LIBRESSL_271
 #elif LIBRESSL_VERSION_NUMBER >= 0x20700000
 RUST_LIBRESSL_270
 #elif LIBRESSL_VERSION_NUMBER >= 0x20603000
@@ -477,9 +481,23 @@ See rust-openssl README for more information:
         Version::Libressl
     } else if expanded.contains("RUST_LIBRESSL_270") {
         println!("cargo:rustc-cfg=libressl");
-        println!("cargo:rustc-cfg=libressl270");
+        println!("cargo:rustc-cfg=libressl27");
         println!("cargo:libressl=true");
         println!("cargo:libressl_version=270");
+        println!("cargo:version=101");
+        Version::Libressl
+    } else if expanded.contains("RUST_LIBRESSL_271") {
+        println!("cargo:rustc-cfg=libressl");
+        println!("cargo:rustc-cfg=libressl27");
+        println!("cargo:libressl=true");
+        println!("cargo:libressl_version=271");
+        println!("cargo:version=101");
+        Version::Libressl
+    } else if expanded.contains("RUST_LIBRESSL_27X") {
+        println!("cargo:rustc-cfg=libressl");
+        println!("cargo:rustc-cfg=libressl27");
+        println!("cargo:libressl=true");
+        println!("cargo:libressl_version=27x");
         println!("cargo:version=101");
         Version::Libressl
     } else if expanded.contains("RUST_OPENSSL_111") {
@@ -510,7 +528,7 @@ See rust-openssl README for more information:
             "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-and 2.6, but a different version of OpenSSL was found. The build is now aborting
+through 2.7, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -325,14 +325,8 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
 
 #if LIBRESSL_VERSION_NUMBER >= 0x20800000
 RUST_LIBRESSL_NEW
-#elif LIBRESSL_VERSION_NUMBER >= 0x20703000
-RUST_LIBRESSL_27X
-#elif LIBRESSL_VERSION_NUMBER >= 0x20702000
-RUST_LIBRESSL_272
-#elif LIBRESSL_VERSION_NUMBER >= 0x20701000
-RUST_LIBRESSL_271
 #elif LIBRESSL_VERSION_NUMBER >= 0x20700000
-RUST_LIBRESSL_270
+RUST_LIBRESSL_27X
 #elif LIBRESSL_VERSION_NUMBER >= 0x20603000
 RUST_LIBRESSL_26X
 #elif LIBRESSL_VERSION_NUMBER >= 0x20602000
@@ -479,27 +473,6 @@ See rust-openssl README for more information:
         println!("cargo:rustc-cfg=libressl26x");
         println!("cargo:libressl=true");
         println!("cargo:libressl_version=26x");
-        println!("cargo:version=101");
-        Version::Libressl
-    } else if expanded.contains("RUST_LIBRESSL_270") {
-        println!("cargo:rustc-cfg=libressl");
-        println!("cargo:rustc-cfg=libressl27");
-        println!("cargo:libressl=true");
-        println!("cargo:libressl_version=270");
-        println!("cargo:version=101");
-        Version::Libressl
-    } else if expanded.contains("RUST_LIBRESSL_271") {
-        println!("cargo:rustc-cfg=libressl");
-        println!("cargo:rustc-cfg=libressl27");
-        println!("cargo:libressl=true");
-        println!("cargo:libressl_version=271");
-        println!("cargo:version=101");
-        Version::Libressl
-    } else if expanded.contains("RUST_LIBRESSL_272") {
-        println!("cargo:rustc-cfg=libressl");
-        println!("cargo:rustc-cfg=libressl27");
-        println!("cargo:libressl=true");
-        println!("cargo:libressl_version=272");
         println!("cargo:version=101");
         Version::Libressl
     } else if expanded.contains("RUST_LIBRESSL_27X") {

--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -325,8 +325,10 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
 
 #if LIBRESSL_VERSION_NUMBER >= 0x20800000
 RUST_LIBRESSL_NEW
-#elif LIBRESSL_VERSION_NUMBER >= 0x20702000
+#elif LIBRESSL_VERSION_NUMBER >= 0x20703000
 RUST_LIBRESSL_27X
+#elif LIBRESSL_VERSION_NUMBER >= 0x20702000
+RUST_LIBRESSL_272
 #elif LIBRESSL_VERSION_NUMBER >= 0x20701000
 RUST_LIBRESSL_271
 #elif LIBRESSL_VERSION_NUMBER >= 0x20700000
@@ -491,6 +493,13 @@ See rust-openssl README for more information:
         println!("cargo:rustc-cfg=libressl27");
         println!("cargo:libressl=true");
         println!("cargo:libressl_version=271");
+        println!("cargo:version=101");
+        Version::Libressl
+    } else if expanded.contains("RUST_LIBRESSL_272") {
+        println!("cargo:rustc-cfg=libressl");
+        println!("cargo:rustc-cfg=libressl27");
+        println!("cargo:libressl=true");
+        println!("cargo:libressl_version=272");
         println!("cargo:version=101");
         Version::Libressl
     } else if expanded.contains("RUST_LIBRESSL_27X") {

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1277,14 +1277,14 @@ pub const SSL_VERIFY_NONE: c_int = 0;
 pub const SSL_VERIFY_PEER: c_int = 1;
 pub const SSL_VERIFY_FAIL_IF_NO_PEER_CERT: c_int = 2;
 
-#[cfg(not(any(libressl261, libressl262, libressl26x, libressl270, ossl101)))]
+#[cfg(not(any(libressl261, libressl262, libressl26x, libressl27, ossl101)))]
 pub const SSL_OP_TLSEXT_PADDING: c_ulong = 0x00000010;
-#[cfg(any(libressl261, libressl262, libressl26x, libressl270))]
+#[cfg(any(libressl261, libressl262, libressl26x, libressl27))]
 pub const SSL_OP_TLSEXT_PADDING: c_ulong = 0x0;
 pub const SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS: c_ulong = 0x00000800;
-#[cfg(not(any(libressl261, libressl262, libressl26x, libressl270)))]
+#[cfg(not(any(libressl261, libressl262, libressl26x, libressl27)))]
 pub const SSL_OP_CRYPTOPRO_TLSEXT_BUG: c_ulong = 0x80000000;
-#[cfg(any(libressl261, libressl262, libressl26x, libressl270))]
+#[cfg(any(libressl261, libressl262, libressl26x, libressl27))]
 pub const SSL_OP_CRYPTOPRO_TLSEXT_BUG: c_ulong = 0x0;
 pub const SSL_OP_LEGACY_SERVER_CONNECT: c_ulong = 0x00000004;
 #[cfg(not(libressl))]

--- a/openssl-sys/src/libressl/mod.rs
+++ b/openssl-sys/src/libressl/mod.rs
@@ -337,9 +337,9 @@ pub const SSL_CTRL_OPTIONS: c_int = 32;
 pub const SSL_CTRL_CLEAR_OPTIONS: c_int = 77;
 pub const SSL_CTRL_SET_ECDH_AUTO: c_int = 94;
 
-#[cfg(any(libressl261, libressl262, libressl26x, libressl270))]
+#[cfg(any(libressl261, libressl262, libressl26x, libressl27))]
 pub const SSL_OP_ALL: c_ulong = 0x4;
-#[cfg(not(any(libressl261, libressl262, libressl26x, libressl270)))]
+#[cfg(not(any(libressl261, libressl262, libressl26x, libressl27)))]
 pub const SSL_OP_ALL: c_ulong = 0x80000014;
 pub const SSL_OP_CISCO_ANYCONNECT: c_ulong = 0x0;
 pub const SSL_OP_NO_COMPRESSION: c_ulong = 0x0;
@@ -352,9 +352,9 @@ pub const SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER: c_ulong = 0x0;
 pub const SSL_OP_SSLEAY_080_CLIENT_DH_BUG: c_ulong = 0x0;
 pub const SSL_OP_TLS_D5_BUG: c_ulong = 0x0;
 pub const SSL_OP_TLS_BLOCK_PADDING_BUG: c_ulong = 0x0;
-#[cfg(any(libressl261, libressl262, libressl26x, libressl270))]
+#[cfg(any(libressl261, libressl262, libressl26x, libressl27))]
 pub const SSL_OP_SINGLE_ECDH_USE: c_ulong = 0x0;
-#[cfg(not(any(libressl261, libressl262, libressl26x, libressl270)))]
+#[cfg(not(any(libressl261, libressl262, libressl26x, libressl27)))]
 pub const SSL_OP_SINGLE_ECDH_USE: c_ulong = 0x00080000;
 pub const SSL_OP_SINGLE_DH_USE: c_ulong = 0x00100000;
 pub const SSL_OP_NO_SSLv2: c_ulong = 0x0;


### PR DESCRIPTION
Support for LibreSSL 2.7.1 and 2.7.2. And while there, support also future LibreSSL 2.7 versions out of the box. This fixes compiling this crate in OpenBSD -current.

I also took the liberty to shorten the cargo feature flag `libressl270` into `libressl27` to signify the LibreSSL 2.7.x versions instead of adding two new ones.

OpenBSD -current (2018-03-23):

```console
$ fgrep LIBRESSL_VERSION_NUMBER /usr/include/openssl/opensslv.h                                                                                                            
#define LIBRESSL_VERSION_NUMBER 0x2070200fL
```