### PR TITLE
Include information about openssl development packages

### DIFF
--- a/openssl-sys/build.rs
+++ b/openssl-sys/build.rs
@@ -133,6 +133,9 @@ Could not find directory of OpenSSL installation, and this `-sys` crate cannot
 proceed without this knowledge. If OpenSSL is installed and this crate had
 trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
 compilation process.
+        
+Make sure you also have the development packages of openssl installed.
+For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.
 
 If you're in a situation where you think the directory *should* be found
 automatically, please open a bug at https://github.com/sfackler/rust-openssl


### PR DESCRIPTION
I just ran into the problem described in issue #649.

In order to help future folks, I figured we could include the solution described in that ticket in the error message itself.