### PR TITLE
Add the CMS_sign and i2d_CMS_ContentInfo function bindings

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -2848,9 +2848,9 @@ extern "C" {
     pub fn CMS_ContentInfo_free(cms: *mut CMS_ContentInfo);
     #[cfg(not(libressl))]
     pub fn CMS_sign(
-        signcert: *const X509,
-        pkey: *const EVP_PKEY,
-        certs: *const stack_st_X509,
+        signcert: *mut X509,
+        pkey: *mut EVP_PKEY,
+        certs: *mut stack_st_X509,
         data: *mut BIO,
         flags: c_uint,
     ) -> *mut CMS_ContentInfo;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -5,8 +5,8 @@
 extern crate libc;
 
 use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void, size_t, FILE};
-use std::ptr;
 use std::mem;
+use std::ptr;
 
 #[cfg(any(ossl101, ossl102))]
 mod ossl10x;
@@ -2846,6 +2846,16 @@ extern "C" {
     pub fn SMIME_read_CMS(bio: *mut BIO, bcont: *mut *mut BIO) -> *mut CMS_ContentInfo;
     #[cfg(not(libressl))]
     pub fn CMS_ContentInfo_free(cms: *mut CMS_ContentInfo);
+    #[cfg(not(libressl))]
+    pub fn CMS_sign(
+        signcert: *const X509,
+        pkey: *const EVP_PKEY,
+        certs: *const stack_st_X509,
+        data: *mut BIO,
+        flags: c_uint,
+    ) -> *mut CMS_ContentInfo;
+    #[cfg(not(libressl))]
+    pub fn i2d_CMS_ContentInfo(a: *mut CMS_ContentInfo, pp: *mut *mut c_uchar) -> c_int;
 
     #[cfg(not(libressl))]
     pub fn FIPS_mode_set(onoff: c_int) -> c_int;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1465,6 +1465,30 @@ pub const GEN_RID: c_int = 8;
 
 pub const DTLS1_COOKIE_LENGTH: c_uint = 256;
 
+#[cfg(not(libressl))]
+pub const CMS_TEXT: c_uint = 0x1;
+pub const CMS_NOCERTS: c_uint = 0x2;
+pub const CMS_NO_CONTENT_VERIFY: c_uint = 0x4;
+pub const CMS_NO_ATTR_VERIFY: c_uint = 0x8;
+pub const CMS_NOSIGS: c_uint = 0x4 | 0x8;
+pub const CMS_NOINTERN: c_uint = 0x10;
+pub const CMS_NO_SIGNER_CERT_VERIFY: c_uint = 0x20;
+pub const CMS_NOVERIFY: c_uint = 0x20;
+pub const CMS_DETACHED: c_uint = 0x40;
+pub const CMS_BINARY: c_uint = 0x80;
+pub const CMS_NOATTR: c_uint = 0x100;
+pub const CMS_NOSMIMECAP: c_uint = 0x200;
+pub const CMS_NOOLDMIMETYPE: c_uint = 0x400;
+pub const CMS_CRLFEOL: c_uint = 0x800;
+pub const CMS_STREAM: c_uint = 0x1000;
+pub const CMS_NOCRL: c_uint = 0x2000;
+pub const CMS_PARTIAL: c_uint = 0x4000;
+pub const CMS_REUSE_DIGEST: c_uint = 0x8000;
+pub const CMS_USE_KEYID: c_uint = 0x10000;
+pub const CMS_DEBUG_DECRYPT: c_uint = 0x20000;
+pub const CMS_KEY_PARAM: c_uint = 0x40000;
+pub const CMS_ASCIICRLF: c_uint = 0x80000;
+
 // macros
 pub unsafe fn BIO_get_mem_data(b: *mut BIO, pp: *mut *mut c_char) -> c_long {
     BIO_ctrl(b, BIO_CTRL_INFO, 0, pp as *mut c_void)

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1505,7 +1505,7 @@ pub const CMS_REUSE_DIGEST: c_uint = 0x8000;
 pub const CMS_USE_KEYID: c_uint = 0x10000;
 #[cfg(not(libressl))]
 pub const CMS_DEBUG_DECRYPT: c_uint = 0x20000;
-#[cfg(not(libressl))]
+#[cfg(all(not(libressl), not(ossl101)))]
 pub const CMS_KEY_PARAM: c_uint = 0x40000;
 #[cfg(all(not(libressl), not(ossl101), not(ossl102)))]
 pub const CMS_ASCIICRLF: c_uint = 0x80000;

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1467,26 +1467,47 @@ pub const DTLS1_COOKIE_LENGTH: c_uint = 256;
 
 #[cfg(not(libressl))]
 pub const CMS_TEXT: c_uint = 0x1;
+#[cfg(not(libressl))]
 pub const CMS_NOCERTS: c_uint = 0x2;
+#[cfg(not(libressl))]
 pub const CMS_NO_CONTENT_VERIFY: c_uint = 0x4;
+#[cfg(not(libressl))]
 pub const CMS_NO_ATTR_VERIFY: c_uint = 0x8;
+#[cfg(not(libressl))]
 pub const CMS_NOSIGS: c_uint = 0x4 | 0x8;
+#[cfg(not(libressl))]
 pub const CMS_NOINTERN: c_uint = 0x10;
+#[cfg(not(libressl))]
 pub const CMS_NO_SIGNER_CERT_VERIFY: c_uint = 0x20;
+#[cfg(not(libressl))]
 pub const CMS_NOVERIFY: c_uint = 0x20;
+#[cfg(not(libressl))]
 pub const CMS_DETACHED: c_uint = 0x40;
+#[cfg(not(libressl))]
 pub const CMS_BINARY: c_uint = 0x80;
+#[cfg(not(libressl))]
 pub const CMS_NOATTR: c_uint = 0x100;
+#[cfg(not(libressl))]
 pub const CMS_NOSMIMECAP: c_uint = 0x200;
+#[cfg(not(libressl))]
 pub const CMS_NOOLDMIMETYPE: c_uint = 0x400;
+#[cfg(not(libressl))]
 pub const CMS_CRLFEOL: c_uint = 0x800;
+#[cfg(not(libressl))]
 pub const CMS_STREAM: c_uint = 0x1000;
+#[cfg(not(libressl))]
 pub const CMS_NOCRL: c_uint = 0x2000;
+#[cfg(not(libressl))]
 pub const CMS_PARTIAL: c_uint = 0x4000;
+#[cfg(not(libressl))]
 pub const CMS_REUSE_DIGEST: c_uint = 0x8000;
+#[cfg(not(libressl))]
 pub const CMS_USE_KEYID: c_uint = 0x10000;
+#[cfg(not(libressl))]
 pub const CMS_DEBUG_DECRYPT: c_uint = 0x20000;
+#[cfg(not(libressl))]
 pub const CMS_KEY_PARAM: c_uint = 0x40000;
+#[cfg(all(not(libressl), not(ossl101), not(ossl102)))]
 pub const CMS_ASCIICRLF: c_uint = 0x80000;
 
 // macros

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -40,6 +40,7 @@ bitflags! {
         const USE_KEYID = ffi::CMS_USE_KEYID;
         const DEBUG_DECRYPT = ffi::CMS_DEBUG_DECRYPT;
         const KEY_PARAM = ffi::CMS_KEY_PARAM;
+        #[cfg(all(not(libressl), any(ossl101, ossl102)))]
         const ASCIICRLF = ffi::CMS_ASCIICRLF;
     }
 }

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -11,35 +11,36 @@ use std::ptr;
 
 use bio::{MemBio, MemBioSlice};
 use error::ErrorStack;
+use libc::c_uint;
 use pkey::{HasPrivate, PKeyRef};
 use stack::Stack;
 use x509::X509;
 use {cvt, cvt_p};
 
 bitflags! {
-    pub struct CMSOptions : u32 {
-        const CMS_TEXT = 0x1;
-        const CMS_NOCERTS = 0x2;
-        const CMS_NO_CONTENT_VERIFY = 0x4;
-        const CMS_NO_ATTR_VERIFY = 0x8;
-        const CMS_NOSIGS = 0x4 | 0x8;
-        const CMS_NOINTERN = 0x10;
-        const CMS_NO_SIGNER_CERT_VERIFY = 0x20;
-        const CMS_NOVERIFY = 0x20;
-        const CMS_DETACHED = 0x40;
-        const CMS_BINARY = 0x80;
-        const CMS_NOATTR = 0x100;
-        const CMS_NOSMIMECAP = 0x200;
-        const CMS_NOOLDMIMETYPE = 0x400;
-        const CMS_CRLFEOL = 0x800;
-        const CMS_STREAM = 0x1000;
-        const CMS_NOCRL = 0x2000;
-        const CMS_PARTIAL = 0x4000;
-        const CMS_REUSE_DIGEST = 0x8000;
-        const CMS_USE_KEYID = 0x10000;
-        const CMS_DEBUG_DECRYPT = 0x20000;
-        const CMS_KEY_PARAM = 0x40000;
-        const CMS_ASCIICRLF = 0x80000;
+    pub struct CMSOptions : c_uint {
+        const TEXT = ffi::CMS_TEXT;
+        const CMS_NOCERTS = ffi::CMS_NOCERTS;
+        const NO_CONTENT_VERIFY = ffi::CMS_NO_CONTENT_VERIFY;
+        const NO_ATTR_VERIFY = ffi::CMS_NO_ATTR_VERIFY;
+        const NOSIGS = ffi::CMS_NOSIGS;
+        const NOINTERN = ffi::CMS_NOINTERN;
+        const NO_SIGNER_CERT_VERIFY = ffi::CMS_NO_SIGNER_CERT_VERIFY;
+        const NOVERIFY = ffi::CMS_NOVERIFY;
+        const DETACHED = ffi::CMS_DETACHED;
+        const BINARY = ffi::CMS_BINARY;
+        const NOATTR = ffi::CMS_NOATTR;
+        const NOSMIMECAP = ffi::CMS_NOSMIMECAP;
+        const NOOLDMIMETYPE = ffi::CMS_NOOLDMIMETYPE;
+        const CRLFEOL = ffi::CMS_CRLFEOL;
+        const STREAM = ffi::CMS_STREAM;
+        const NOCRL = ffi::CMS_NOCRL;
+        const PARTIAL = ffi::CMS_PARTIAL;
+        const REUSE_DIGEST = ffi::CMS_REUSE_DIGEST;
+        const USE_KEYID = ffi::CMS_USE_KEYID;
+        const DEBUG_DECRYPT = ffi::CMS_DEBUG_DECRYPT;
+        const KEY_PARAM = ffi::CMS_KEY_PARAM;
+        const ASCIICRLF = ffi::CMS_ASCIICRLF;
     }
 }
 
@@ -152,7 +153,13 @@ impl CmsContentInfo {
                 None => ptr::null_mut(),
             };
 
-            let cms = cvt_p(ffi::CMS_sign(signcert, pkey, certs, data_bio_ptr, flags.bits()))?;
+            let cms = cvt_p(ffi::CMS_sign(
+                signcert,
+                pkey,
+                certs,
+                data_bio_ptr,
+                flags.bits(),
+            ))?;
 
             Ok(CmsContentInfo::from_ptr(cms))
         }

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -16,6 +16,33 @@ use stack::Stack;
 use x509::X509;
 use {cvt, cvt_p};
 
+bitflags! {
+    pub struct CMSOptions : u32 {
+        const CMS_TEXT = 0x1;
+        const CMS_NOCERTS = 0x2;
+        const CMS_NO_CONTENT_VERIFY = 0x4;
+        const CMS_NO_ATTR_VERIFY = 0x8;
+        const CMS_NOSIGS = 0x4 | 0x8;
+        const CMS_NOINTERN = 0x10;
+        const CMS_NO_SIGNER_CERT_VERIFY = 0x20;
+        const CMS_NOVERIFY = 0x20;
+        const CMS_DETACHED = 0x40;
+        const CMS_BINARY = 0x80;
+        const CMS_NOATTR = 0x100;
+        const CMS_NOSMIMECAP = 0x200;
+        const CMS_NOOLDMIMETYPE = 0x400;
+        const CMS_CRLFEOL = 0x800;
+        const CMS_STREAM = 0x1000;
+        const CMS_NOCRL = 0x2000;
+        const CMS_PARTIAL = 0x4000;
+        const CMS_REUSE_DIGEST = 0x8000;
+        const CMS_USE_KEYID = 0x10000;
+        const CMS_DEBUG_DECRYPT = 0x20000;
+        const CMS_KEY_PARAM = 0x40000;
+        const CMS_ASCIICRLF = 0x80000;
+    }
+}
+
 foreign_type_and_impl_send_sync! {
     type CType = ffi::CMS_ContentInfo;
     fn drop = ffi::CMS_ContentInfo_free;
@@ -105,7 +132,7 @@ impl CmsContentInfo {
         pkey: Option<&PKeyRef<T>>,
         certs: Option<&Stack<X509>>,
         data: Option<&[u8]>,
-        flags: u32,
+        flags: CMSOptions,
     ) -> Result<CmsContentInfo, ErrorStack> {
         unsafe {
             let signcert = match signcert {
@@ -125,7 +152,7 @@ impl CmsContentInfo {
                 None => ptr::null_mut(),
             };
 
-            let cms = cvt_p(ffi::CMS_sign(signcert, pkey, certs, data_bio_ptr, flags))?;
+            let cms = cvt_p(ffi::CMS_sign(signcert, pkey, certs, data_bio_ptr, flags.bits()))?;
 
             Ok(CmsContentInfo::from_ptr(cms))
         }

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -39,8 +39,9 @@ bitflags! {
         const REUSE_DIGEST = ffi::CMS_REUSE_DIGEST;
         const USE_KEYID = ffi::CMS_USE_KEYID;
         const DEBUG_DECRYPT = ffi::CMS_DEBUG_DECRYPT;
+        #[cfg(all(not(libressl), not(ossl101)))]
         const KEY_PARAM = ffi::CMS_KEY_PARAM;
-        #[cfg(all(not(libressl), any(ossl101, ossl102)))]
+        #[cfg(all(not(libressl), not(ossl101), not(ossl102)))]
         const ASCIICRLF = ffi::CMS_ASCIICRLF;
     }
 }


### PR DESCRIPTION
This adds the `CMS_sign` and `i2d_CMS_ContentInfo` bindings in the `openssl-sys` crate and Rusty wrappers in the `openssl` crate.