### PR TITLE
TLS1.3 early data support

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -2832,4 +2832,7 @@ extern "C" {
 
     pub fn EVP_MD_size(md: *const EVP_MD) -> c_int;
     pub fn EVP_get_cipherbyname(name: *const c_char) -> *const EVP_CIPHER;
+
+    pub fn SSL_set_connect_state(s: *mut SSL);
+    pub fn SSL_set_accept_state(s: *mut SSL);
 }

--- a/openssl-sys/src/openssl/v111.rs
+++ b/openssl-sys/src/openssl/v111.rs
@@ -82,4 +82,11 @@ extern "C" {
             cookie_len: size_t
         ) -> c_int>
     );
+
+    pub fn SSL_CTX_set_max_early_data(ctx: *mut ::SSL_CTX, max_early_data: u32) -> c_int;
+    pub fn SSL_CTX_get_max_early_data(ctx: *const ::SSL_CTX) -> u32;
+    pub fn SSL_set_max_early_data(ctx: *mut ::SSL, max_early_data: u32) -> c_int;
+    pub fn SSL_get_max_early_data(ctx: *const ::SSL) -> u32;
+    pub fn SSL_SESSION_set_max_early_data(ctx: *mut ::SSL_SESSION, max_early_data: u32) -> c_int;
+    pub fn SSL_SESSION_get_max_early_data(ctx: *const ::SSL_SESSION) -> u32;
 }

--- a/openssl-sys/src/openssl/v111.rs
+++ b/openssl-sys/src/openssl/v111.rs
@@ -55,6 +55,9 @@ pub const SSL_EXT_TLS1_3_CERTIFICATE: c_uint = 0x1000;
 pub const SSL_EXT_TLS1_3_NEW_SESSION_TICKET: c_uint = 0x2000;
 pub const SSL_EXT_TLS1_3_CERTIFICATE_REQUEST: c_uint = 0x4000;
 
+pub const SSL_READ_EARLY_DATA_ERROR: c_int = 0;
+pub const SSL_READ_EARLY_DATA_SUCCESS: c_int = 1;
+pub const SSL_READ_EARLY_DATA_FINISH: c_int = 2;
 
 extern "C" {
     pub fn SSL_CTX_set_keylog_callback(ctx: *mut ::SSL_CTX, cb: SSL_CTX_keylog_cb_func);
@@ -99,4 +102,7 @@ extern "C" {
         context: *const c_uchar,
         contextlen: size_t,
     ) -> c_int;
+
+    pub fn SSL_write_early_data(s: *mut ::SSL, buf: *const c_void, num: size_t, written: *mut size_t) -> c_int;
+    pub fn SSL_read_early_data(s: *mut ::SSL, buf: *mut c_void, num: size_t, readbytes: *mut size_t) -> c_int;
 }

--- a/openssl-sys/src/openssl/v111.rs
+++ b/openssl-sys/src/openssl/v111.rs
@@ -89,4 +89,14 @@ extern "C" {
     pub fn SSL_get_max_early_data(ctx: *const ::SSL) -> u32;
     pub fn SSL_SESSION_set_max_early_data(ctx: *mut ::SSL_SESSION, max_early_data: u32) -> c_int;
     pub fn SSL_SESSION_get_max_early_data(ctx: *const ::SSL_SESSION) -> u32;
+
+    pub fn SSL_export_keying_material_early(
+        s: *mut ::SSL,
+        out: *mut c_uchar,
+        olen: size_t,
+        label: *const c_char,
+        llen: size_t,
+        context: *const c_uchar,
+        contextlen: size_t,
+    ) -> c_int;
 }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -2498,6 +2498,33 @@ impl SslRef {
         }
     }
 
+    /// Derives keying material for application use in accordance to RFC 5705.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    ///
+    /// This corresponds to [`SSL_export_keying_material_early`].
+    ///
+    /// [`SSL_export_keying_material_early`]: https://www.openssl.org/docs/manmaster/man3/SSL_export_keying_material_early.html
+    #[cfg(ossl111)]
+    pub fn export_keying_material_early(
+        &self,
+        out: &mut [u8],
+        label: &str,
+        context: &[u8],
+    ) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::SSL_export_keying_material_early(
+                self.as_ptr(),
+                out.as_mut_ptr() as *mut c_uchar,
+                out.len(),
+                label.as_ptr() as *const c_char,
+                label.len(),
+                context.as_ptr() as *const c_uchar,
+                context.len(),
+            )).map(|_| ())
+        }
+    }
+
     /// Sets the session to be used.
     ///
     /// This should be called before the handshake to attempt to reuse a previously established

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1489,6 +1489,24 @@ impl SslContextBuilder {
         }
     }
 
+    /// Sets the maximum amount of early data that will be accepted on incoming connections.
+    ///
+    /// Defaults to 0.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    ///
+    /// This corresponds to [`SSL_CTX_set_max_early_data`].
+    ///
+    /// [`SSL_CTX_set_max_early_data`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_max_early_data.html
+    #[cfg(ossl111)]
+    pub fn set_max_early_data(&mut self, bytes: u32) -> Result<(), ErrorStack> {
+        if unsafe { ffi::SSL_CTX_set_max_early_data(self.as_ptr(), bytes) } == 1 {
+            Ok(())
+        } else {
+            Err(ErrorStack::get())
+        }
+    }
+
     /// Consumes the builder, returning a new `SslContext`.
     pub fn build(self) -> SslContext {
         self.0
@@ -1642,6 +1660,18 @@ impl SslContextRef {
                 Some(&*(data as *const T))
             }
         }
+    }
+
+    /// Gets the maximum amount of early data that will be accepted on incoming connections.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    ///
+    /// This corresponds to [`SSL_CTX_get_max_early_data`].
+    ///
+    /// [`SSL_CTX_get_max_early_data`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_get_max_early_data.html
+    #[cfg(ossl111)]
+    pub fn max_early_data(&self) -> u32 {
+        unsafe { ffi::SSL_CTX_get_max_early_data(self.as_ptr()) }
     }
 }
 
@@ -1871,6 +1901,18 @@ impl SslSessionRef {
     /// [`SSL_SESSION_get_master_key`]: https://www.openssl.org/docs/man1.1.0/ssl/SSL_SESSION_get_master_key.html
     pub fn master_key(&self, buf: &mut [u8]) -> usize {
         unsafe { compat::SSL_SESSION_get_master_key(self.as_ptr(), buf.as_mut_ptr(), buf.len()) }
+    }
+
+    /// Gets the maximum amount of early data that can be sent on this session.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    ///
+    /// This corresponds to [`SSL_SESSION_get_max_early_data`].
+    ///
+    /// [`SSL_SESSION_get_max_early_data`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_get_max_early_data.html
+    #[cfg(ossl111)]
+    pub fn max_early_data(&self) -> u32 {
+        unsafe { ffi::SSL_SESSION_get_max_early_data(self.as_ptr()) }
     }
 
     to_der! {
@@ -2593,6 +2635,34 @@ impl SslRef {
                 Some(&mut *(data as *mut T))
             }
         }
+    }
+
+    /// Sets the maximum amount of early data that will be accepted on this connection.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    ///
+    /// This corresponds to [`SSL_set_max_early_data`].
+    ///
+    /// [`SSL_set_max_early_data`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_set_max_early_data.html
+    #[cfg(ossl111)]
+    pub fn set_max_early_data(&mut self, bytes: u32) -> Result<(), ErrorStack> {
+        if unsafe { ffi::SSL_set_max_early_data(self.as_ptr(), bytes) } == 1 {
+            Ok(())
+        } else {
+            Err(ErrorStack::get())
+        }
+    }
+
+    /// Gets the maximum amount of early data that can be sent on this connection.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    ///
+    /// This corresponds to [`SSL_get_max_early_data`].
+    ///
+    /// [`SSL_get_max_early_data`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_get_max_early_data.html
+    #[cfg(ossl111)]
+    pub fn max_early_data(&self) -> u32 {
+        unsafe { ffi::SSL_get_max_early_data(self.as_ptr()) }
     }
 }
 


### PR DESCRIPTION
Not yet tested; planning on doing so as soon as I hunt down some unrelated bugs in quicr.

I didn't see any support for mutating `SSL_SESSION` objects, so `SSL_SESSION_set_max_early_data` remains absent from the high level API for now.