### PR TITLE
Get Nid string representations

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -2106,6 +2106,7 @@ extern "C" {
         a: *const ASN1_OBJECT,
         no_name: c_int,
     ) -> c_int;
+    pub fn OBJ_nid2ln(nid: c_int) -> *const c_char;
     pub fn OBJ_nid2sn(nid: c_int) -> *const c_char;
     pub fn OBJ_find_sigid_algs(signid: c_int, pdig_nid: *mut c_int, ppkey_nid: *mut c_int)
         -> c_int;


### PR DESCRIPTION
Hello,

I'm currently building an application which needs to read X509 certificates at some point. To be able to display the certificate's attributes in a nice fashion to the user, I wanted to utilize OpenSSL's `OBJ_nid2ln`/`OBJ_nid2sn API`, as they obviously already keep a nice database of human readable names for their NIDs.

I'm pretty sure this PR is not perfect yet. For example, I'm not sure whether returning an `Option` fits nicely into rust-openssl's API. On the other side, the functions only return `NULL` in case of an error and I'm not sure it's possible to get more information about the cause, which would be needed to make a meaningful Result out of it. Another option would be to promise to always return something as the predefined NIDs should actually always return something and write a nice test case for it.

Another problem I see with this, is the 'static lifetime for the returned string. For the predefined NIDs this should always be right (as they're hardcoded inside the header files) but apparently it is possible to register new OBJs with OpenSSL. Note that I couldn't find code in rust-openssl which actually does this or can do this. The `OBJ_add_object` function seems to copy the given data (see below) and the "Find usages" function of my IDE only finds `oid_module_finish` and `EVP_cleanup` as callers for the cleanup function, which rust-openssl doesn't seem to use - but who knows if it's going to happen in the future. Additionally, comments like

```C
/* XXX: ugh! Why? What kind of
					     duplication is this??? */
```

in `OBJ_dup` do not really make me trust its functionality - but who am I to tell... Maybe someone else has an idea how we can annotate the lifetimes to be, sometimes, tied to an object.