### PR TITLE
X509NameRef: Provide an iterator over all entries

### DIFF
--- a/openssl-sys/src/libressl/mod.rs
+++ b/openssl-sys/src/libressl/mod.rs
@@ -592,6 +592,7 @@ extern "C" {
     pub fn X509_NAME_entry_count(n: *mut ::X509_NAME) -> c_int;
     pub fn X509_NAME_get_entry(n: *mut ::X509_NAME, loc: c_int) -> *mut ::X509_NAME_ENTRY;
     pub fn X509_NAME_ENTRY_get_data(ne: *mut ::X509_NAME_ENTRY) -> *mut ::ASN1_STRING;
+    pub fn X509_NAME_ENTRY_get_object(ne: *mut ::X509_NAME_ENTRY) -> *mut ::ASN1_OBJECT;
     pub fn X509_STORE_CTX_get_chain(ctx: *mut ::X509_STORE_CTX) -> *mut stack_st_X509;
     pub fn X509V3_EXT_nconf_nid(
         conf: *mut ::CONF,

--- a/openssl-sys/src/libressl/mod.rs
+++ b/openssl-sys/src/libressl/mod.rs
@@ -589,6 +589,7 @@ extern "C" {
         loc: c_int,
         set: c_int,
     ) -> c_int;
+    pub fn X509_NAME_entry_count(n: *mut ::X509_NAME) -> c_int;
     pub fn X509_NAME_get_entry(n: *mut ::X509_NAME, loc: c_int) -> *mut ::X509_NAME_ENTRY;
     pub fn X509_NAME_ENTRY_get_data(ne: *mut ::X509_NAME_ENTRY) -> *mut ::ASN1_STRING;
     pub fn X509_STORE_CTX_get_chain(ctx: *mut ::X509_STORE_CTX) -> *mut stack_st_X509;

--- a/openssl-sys/src/openssl/v10x.rs
+++ b/openssl-sys/src/openssl/v10x.rs
@@ -959,6 +959,7 @@ extern "C" {
         ppval: *mut *mut c_void,
         alg: *mut ::X509_ALGOR,
     );
+    pub fn X509_NAME_entry_count(n: *mut ::X509_NAME) -> c_int;
     pub fn X509_NAME_get_entry(n: *mut ::X509_NAME, loc: c_int) -> *mut ::X509_NAME_ENTRY;
     pub fn X509_NAME_ENTRY_get_data(ne: *mut ::X509_NAME_ENTRY) -> *mut ::ASN1_STRING;
     pub fn X509_STORE_CTX_get_chain(ctx: *mut ::X509_STORE_CTX) -> *mut stack_st_X509;

--- a/openssl-sys/src/openssl/v10x.rs
+++ b/openssl-sys/src/openssl/v10x.rs
@@ -962,6 +962,7 @@ extern "C" {
     pub fn X509_NAME_entry_count(n: *mut ::X509_NAME) -> c_int;
     pub fn X509_NAME_get_entry(n: *mut ::X509_NAME, loc: c_int) -> *mut ::X509_NAME_ENTRY;
     pub fn X509_NAME_ENTRY_get_data(ne: *mut ::X509_NAME_ENTRY) -> *mut ::ASN1_STRING;
+    pub fn X509_NAME_ENTRY_get_object(ne: *mut ::X509_NAME_ENTRY) -> *mut ::ASN1_OBJECT;
     pub fn X509_STORE_CTX_get_chain(ctx: *mut ::X509_STORE_CTX) -> *mut stack_st_X509;
     pub fn X509V3_EXT_nconf_nid(
         conf: *mut ::CONF,

--- a/openssl-sys/src/openssl/v110.rs
+++ b/openssl-sys/src/openssl/v110.rs
@@ -198,6 +198,7 @@ extern "C" {
         ppval: *mut *const c_void,
         alg: *const ::X509_ALGOR,
     );
+    pub fn X509_NAME_entry_count(n: *const ::X509_NAME) -> c_int;
     pub fn X509_NAME_get_entry(n: *const ::X509_NAME, loc: c_int) -> *mut ::X509_NAME_ENTRY;
     pub fn X509_NAME_ENTRY_get_data(ne: *const ::X509_NAME_ENTRY) -> *mut ::ASN1_STRING;
     pub fn X509V3_EXT_nconf_nid(

--- a/openssl-sys/src/openssl/v110.rs
+++ b/openssl-sys/src/openssl/v110.rs
@@ -201,6 +201,7 @@ extern "C" {
     pub fn X509_NAME_entry_count(n: *const ::X509_NAME) -> c_int;
     pub fn X509_NAME_get_entry(n: *const ::X509_NAME, loc: c_int) -> *mut ::X509_NAME_ENTRY;
     pub fn X509_NAME_ENTRY_get_data(ne: *const ::X509_NAME_ENTRY) -> *mut ::ASN1_STRING;
+    pub fn X509_NAME_ENTRY_get_object(ne: *const ::X509_NAME_ENTRY) -> *mut ::ASN1_OBJECT;
     pub fn X509V3_EXT_nconf_nid(
         conf: *mut ::CONF,
         ctx: *mut ::X509V3_CTX,

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -895,6 +895,19 @@ impl X509NameEntryRef {
             Asn1StringRef::from_ptr(data)
         }
     }
+
+    /// Returns the `Asn1Object` value of an `X509NameEntry`.
+    /// This is useful for finding out about the actual `Nid` when iterating over all `X509NameEntries`.
+    ///
+    /// This corresponds to [`X509_NAME_ENTRY_get_object`].
+    ///
+    /// [`X509_NAME_ENTRY_get_object`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_NAME_ENTRY_get_object.html
+    pub fn object(&self) -> &Asn1ObjectRef {
+        unsafe {
+            let object = ffi::X509_NAME_ENTRY_get_object(self.as_ptr());
+            Asn1ObjectRef::from_ptr(object)
+        }
+    }
 }
 
 /// A builder used to construct an `X509Req`.

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -847,8 +847,6 @@ impl<'a> Iterator for X509NameEntries<'a> {
 
     fn next(&mut self) -> Option<&'a X509NameEntryRef> {
         unsafe {
-            let entry_count = ffi::X509_NAME_entry_count(self.name.as_ptr());
-
             match self.nid {
                 Some(nid) => {
                     // There is a `Nid` specified to search for
@@ -861,7 +859,7 @@ impl<'a> Iterator for X509NameEntries<'a> {
                 None => {
                     // Iterate over all `Nid`s
                     self.loc += 1;
-                    if self.loc >= entry_count {
+                    if self.loc >= ffi::X509_NAME_entry_count(self.name.as_ptr()) {
                         return None;
                     }
                 }

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -826,7 +826,7 @@ impl X509NameRef {
     }
 
     /// Returns an iterator over all `X509NameEntry` values
-    pub fn all_entries<'a>(&'a self) -> X509NameEntries<'a> {
+    pub fn entries<'a>(&'a self) -> X509NameEntries<'a> {
         X509NameEntries {
             name: self,
             nid: None,
@@ -854,15 +854,17 @@ impl<'a> Iterator for X509NameEntries<'a> {
                     // There is a `Nid` specified to search for
                     self.loc =
                         ffi::X509_NAME_get_index_by_NID(self.name.as_ptr(), nid.as_raw(), self.loc);
+                    if self.loc == -1 {
+                        return None;
+                    }
                 }
                 None => {
                     // Iterate over all `Nid`s
                     self.loc += 1;
+                    if self.loc >= entry_count {
+                        return None;
+                    }
                 }
-            }
-
-            if self.loc == -1 || self.loc >= entry_count {
-                return None;
             }
 
             let entry = ffi::X509_NAME_get_entry(self.name.as_ptr(), self.loc);

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -80,6 +80,27 @@ fn test_nid_values() {
 }
 
 #[test]
+fn test_nameref_iterator() {
+    let cert = include_bytes!("../../test/nid_test_cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let subject = cert.subject_name();
+    let mut all_entries = subject.all_entries();
+
+    let email = all_entries.next().unwrap();
+    assert_eq!(email.data().as_slice(), b"test@example.com");
+
+    let cn = all_entries.next().unwrap();
+    assert_eq!(cn.data().as_slice(), b"example.com");
+
+    let friendly = all_entries.next().unwrap();
+    assert_eq!(&**friendly.data().as_utf8().unwrap(), "Example");
+
+    if let Some(_) = all_entries.next() {
+        assert!(false);
+    }
+}
+
+#[test]
 fn test_nid_uid_value() {
     let cert = include_bytes!("../../test/nid_uid_test_cert.pem");
     let cert = X509::from_pem(cert).unwrap();

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -87,12 +87,15 @@ fn test_nameref_iterator() {
     let mut all_entries = subject.all_entries();
 
     let email = all_entries.next().unwrap();
+    assert_eq!(email.object().nid().as_raw(), Nid::PKCS9_EMAILADDRESS.as_raw());
     assert_eq!(email.data().as_slice(), b"test@example.com");
 
     let cn = all_entries.next().unwrap();
+    assert_eq!(cn.object().nid().as_raw(), Nid::COMMONNAME.as_raw());
     assert_eq!(cn.data().as_slice(), b"example.com");
 
     let friendly = all_entries.next().unwrap();
+    assert_eq!(friendly.object().nid().as_raw(), Nid::FRIENDLYNAME.as_raw());
     assert_eq!(&**friendly.data().as_utf8().unwrap(), "Example");
 
     if let Some(_) = all_entries.next() {

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -84,7 +84,7 @@ fn test_nameref_iterator() {
     let cert = include_bytes!("../../test/nid_test_cert.pem");
     let cert = X509::from_pem(cert).unwrap();
     let subject = cert.subject_name();
-    let mut all_entries = subject.all_entries();
+    let mut all_entries = subject.entries();
 
     let email = all_entries.next().unwrap();
     assert_eq!(email.object().nid().as_raw(), Nid::PKCS9_EMAILADDRESS.as_raw());


### PR DESCRIPTION
Hello,

as I'm still planning to present a certificate to a user, I needed a way to fetch all `X509NameEntry`s to be able to present them somehow.

Previously, if you got an `X509NameRef`, you could only fetch `X509NameEntry`s if you already knew exactly what you wanted. There was no way to fetch all NameEntries (and neither a way to get all known `Nid`s to search for them one-by-one).

In order to do something useful with the obtained `X509NameEntry`, I extended `X509NameEntryRef`, which can now also query for the `Asn1Object` behind it in addition to the `Asn1String` data it contains.

I hope someone else may find this useful as well :-) Feedback is, as always, highly appreciated.