### PR TITLE
 Add wrapper for SSL_CTX_set_psk_server_callback 

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -2576,6 +2576,14 @@ extern "C" {
                 -> c_uint,
         >,
     );
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+    pub fn SSL_CTX_set_psk_server_callback(
+        ssl: *mut SSL_CTX,
+        psk_server_cb: Option<
+            extern "C" fn(*mut SSL, *const c_char, *mut c_uchar, c_uint)
+                -> c_uint,
+        >,
+    );
 
     pub fn SSL_select_next_proto(
         out: *mut *mut c_uchar,

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -74,7 +74,7 @@ where
             .ssl_context()
             .ex_data(callback_idx)
             .expect("BUG: psk callback missing") as *const F;
-        let hint = if hint != ptr::null() {
+        let hint = if !hint.is_null() {
             Some(CStr::from_ptr(hint).to_bytes())
         } else {
             None

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -84,7 +84,10 @@ where
         let psk_sl = slice::from_raw_parts_mut(psk as *mut u8, max_psk_len as usize);
         match (*callback)(ssl, hint, identity_sl, psk_sl) {
             Ok(psk_len) => psk_len as u32,
-            _ => 0,
+            Err(e) => {
+                e.put();
+                0
+            }
         }
     }
 }
@@ -118,7 +121,10 @@ where
         let psk_sl = slice::from_raw_parts_mut(psk as *mut u8, max_psk_len as usize);
         match (*callback)(ssl, identity, psk_sl) {
             Ok(psk_len) => psk_len as u32,
-            _ => 0,
+            Err(e) => {
+                e.put();
+                0
+            }
         }
     }
 }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1240,6 +1240,18 @@ impl SslContextBuilder {
         }
     }
 
+    #[deprecated(since = "0.10.10", note = "renamed to `set_psk_client_callback`")]
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+    pub fn set_psk_callback<F>(&mut self, callback: F)
+    where
+        F: Fn(&mut SslRef, Option<&[u8]>, &mut [u8], &mut [u8]) -> Result<usize, ErrorStack>
+            + 'static
+            + Sync
+            + Send,
+    {
+        self.set_psk_client_callback(callback)
+    }
+
     /// Sets the callback for providing an identity and pre-shared key for a TLS-PSK server.
     ///
     /// The callback will be called with the SSL context, an identity provided by the client,

--- a/openssl/src/ssl/test.rs
+++ b/openssl/src/ssl/test.rs
@@ -1565,6 +1565,13 @@ fn psk_ciphers() {
 
     let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
     let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
+    // TLS 1.3 has no DH suites, and openssl isn't happy if the max version has no suites :(
+    #[cfg(ossl111)]
+    {
+        ctx.set_options(super::SslOptions {
+            bits: ::ffi::SSL_OP_NO_TLSv1_3,
+        });
+    }
     ctx.set_cipher_list(CIPHER).unwrap();
     ctx.set_psk_client_callback(move |_, _, identity, psk| {
         identity[..CLIENT_IDENT.len()].copy_from_slice(&CLIENT_IDENT);

--- a/openssl/src/ssl/test.rs
+++ b/openssl/src/ssl/test.rs
@@ -1540,6 +1540,7 @@ fn stateless() {
 #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
 #[test]
 fn psk_ciphers() {
+    const CIPHER: &'static str = "PSK-AES128-CBC-SHA";
     const PSK: &[u8] = b"thisisaverysecurekey";
     const CLIENT_IDENT: &[u8] = b"thisisaclient";
 
@@ -1549,7 +1550,7 @@ fn psk_ciphers() {
     thread::spawn(move || {
         let stream = listener.accept().unwrap().0;
         let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
-        ctx.set_cipher_list("ECDHE-PSK-CHACHA20-POLY1305").unwrap();
+        ctx.set_cipher_list(CIPHER).unwrap();
         ctx.set_psk_server_callback(move |_, identity, psk| {
             assert!(identity.unwrap_or(&[]) == CLIENT_IDENT);
             psk[..PSK.len()].copy_from_slice(&PSK);
@@ -1561,7 +1562,7 @@ fn psk_ciphers() {
 
     let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
     let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
-    ctx.set_cipher_list("ECDHE-PSK-CHACHA20-POLY1305").unwrap();
+    ctx.set_cipher_list(CIPHER).unwrap();
     ctx.set_psk_client_callback(move |_, _, identity, psk| {
         identity[..CLIENT_IDENT.len()].copy_from_slice(&CLIENT_IDENT);
         identity[CLIENT_IDENT.len()] = 0;


### PR DESCRIPTION
Implements a wrapper for SSL_CTX_set_psk_server_callback, using how SSL_CTX_set_psk_client_callback was used as an example. This function is required for using PSK on a server.