### PR TITLE
Update to 1.1.1-pre7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ macos_job: &MACOS_JOB
 
 openssl_111: &OPENSSL_111
   LIBRARY: openssl
-  VERSION: 1.1.1-pre3
+  VERSION: 1.1.1-pre7
 openssl_110: &OPENSSL_110
   LIBRARY: openssl
   VERSION: 1.1.0h

--- a/openssl-sys/src/openssl/v111.rs
+++ b/openssl-sys/src/openssl/v111.rs
@@ -1,29 +1,45 @@
-use libc::{c_char, c_uchar, c_int, c_uint, c_ulong, size_t, c_void};
+use libc::{c_char, c_int, c_uchar, c_uint, c_ulong, c_void, size_t};
 
 pub type SSL_CTX_keylog_cb_func =
     Option<unsafe extern "C" fn(ssl: *const ::SSL, line: *const c_char)>;
 
-pub type SSL_custom_ext_add_cb_ex =
-    Option<unsafe extern "C" fn(ssl: *mut ::SSL, ext_type: c_uint,
-                                context: c_uint,
-                                out: *mut *const c_uchar,
-                                outlen: *mut size_t, x: *mut ::X509,
-                                chainidx: size_t, al: *mut c_int,
-                                add_arg: *mut c_void) -> c_int>;
+pub type SSL_custom_ext_add_cb_ex = Option<
+    unsafe extern "C" fn(
+        ssl: *mut ::SSL,
+        ext_type: c_uint,
+        context: c_uint,
+        out: *mut *const c_uchar,
+        outlen: *mut size_t,
+        x: *mut ::X509,
+        chainidx: size_t,
+        al: *mut c_int,
+        add_arg: *mut c_void,
+    ) -> c_int,
+>;
 
-pub type SSL_custom_ext_free_cb_ex =
-    Option<unsafe extern "C" fn(ssl: *mut ::SSL, ext_type: c_uint,
-                                context: c_uint,
-                                out: *mut *const c_uchar,
-                                add_arg: *mut c_void)>;
+pub type SSL_custom_ext_free_cb_ex = Option<
+    unsafe extern "C" fn(
+        ssl: *mut ::SSL,
+        ext_type: c_uint,
+        context: c_uint,
+        out: *mut *const c_uchar,
+        add_arg: *mut c_void,
+    ),
+>;
 
-pub type SSL_custom_ext_parse_cb_ex =
-    Option<unsafe extern "C" fn(ssl: *mut ::SSL, ext_type: c_uint,
-                                context: c_uint,
-                                input: *const c_uchar,
-                                inlen: size_t, x: *mut ::X509,
-                                chainidx: size_t, al: *mut c_int,
-                                parse_arg: *mut c_void) -> c_int>;
+pub type SSL_custom_ext_parse_cb_ex = Option<
+    unsafe extern "C" fn(
+        ssl: *mut ::SSL,
+        ext_type: c_uint,
+        context: c_uint,
+        input: *const c_uchar,
+        inlen: size_t,
+        x: *mut ::X509,
+        chainidx: size_t,
+        al: *mut c_int,
+        parse_arg: *mut c_void,
+    ) -> c_int,
+>;
 
 pub const SSL_COOKIE_LENGTH: c_int = 4096;
 
@@ -61,38 +77,38 @@ pub const SSL_READ_EARLY_DATA_FINISH: c_int = 2;
 
 extern "C" {
     pub fn SSL_CTX_set_keylog_callback(ctx: *mut ::SSL_CTX, cb: SSL_CTX_keylog_cb_func);
-    pub fn SSL_CTX_add_custom_ext(ctx: *mut ::SSL_CTX, ext_type: c_uint, context: c_uint,
-                                  add_cb: SSL_custom_ext_add_cb_ex,
-                                  free_cb: SSL_custom_ext_free_cb_ex,
-                                  add_arg: *mut c_void,
-                                  parse_cb: SSL_custom_ext_parse_cb_ex,
-                                  parse_arg: *mut c_void) -> c_int;
-    pub fn SSL_stateless(s: *mut ::SSL) -> c_int;
+    pub fn SSL_CTX_add_custom_ext(
+        ctx: *mut ::SSL_CTX,
+        ext_type: c_uint,
+        context: c_uint,
+        add_cb: SSL_custom_ext_add_cb_ex,
+        free_cb: SSL_custom_ext_free_cb_ex,
+        add_arg: *mut c_void,
+        parse_cb: SSL_custom_ext_parse_cb_ex,
+        parse_arg: *mut c_void,
+    ) -> c_int;
     pub fn SSL_CIPHER_get_handshake_digest(cipher: *const ::SSL_CIPHER) -> *const ::EVP_MD;
     pub fn SSL_CTX_set_stateless_cookie_generate_cb(
         s: *mut ::SSL_CTX,
-        cb: Option<unsafe extern "C" fn(
-            ssl: *mut ::SSL,
-            cookie: *mut c_uchar,
-            cookie_len: *mut size_t
-        ) -> c_int>
+        cb: Option<
+            unsafe extern "C" fn(ssl: *mut ::SSL, cookie: *mut c_uchar, cookie_len: *mut size_t)
+                -> c_int,
+        >,
     );
     pub fn SSL_CTX_set_stateless_cookie_verify_cb(
         s: *mut ::SSL_CTX,
-        cb: Option<unsafe extern "C" fn(
-            ssl: *mut ::SSL,
-            cookie: *const c_uchar,
-            cookie_len: size_t
-        ) -> c_int>
+        cb: Option<
+            unsafe extern "C" fn(ssl: *mut ::SSL, cookie: *const c_uchar, cookie_len: size_t)
+                -> c_int,
+        >,
     );
-
     pub fn SSL_CTX_set_max_early_data(ctx: *mut ::SSL_CTX, max_early_data: u32) -> c_int;
     pub fn SSL_CTX_get_max_early_data(ctx: *const ::SSL_CTX) -> u32;
+    pub fn SSL_CTX_set_ciphersuites(ctx: *mut ::SSL_CTX, str: *const c_char) -> c_int;
+
     pub fn SSL_set_max_early_data(ctx: *mut ::SSL, max_early_data: u32) -> c_int;
     pub fn SSL_get_max_early_data(ctx: *const ::SSL) -> u32;
-    pub fn SSL_SESSION_set_max_early_data(ctx: *mut ::SSL_SESSION, max_early_data: u32) -> c_int;
-    pub fn SSL_SESSION_get_max_early_data(ctx: *const ::SSL_SESSION) -> u32;
-
+    pub fn SSL_stateless(s: *mut ::SSL) -> c_int;
     pub fn SSL_export_keying_material_early(
         s: *mut ::SSL,
         out: *mut c_uchar,
@@ -102,7 +118,20 @@ extern "C" {
         context: *const c_uchar,
         contextlen: size_t,
     ) -> c_int;
+    pub fn SSL_write_early_data(
+        s: *mut ::SSL,
+        buf: *const c_void,
+        num: size_t,
+        written: *mut size_t,
+    ) -> c_int;
+    pub fn SSL_read_early_data(
+        s: *mut ::SSL,
+        buf: *mut c_void,
+        num: size_t,
+        readbytes: *mut size_t,
+    ) -> c_int;
+    pub fn SSL_set_ciphersuites(ssl: *mut ::SSL, str: *const c_char) -> c_int;
 
-    pub fn SSL_write_early_data(s: *mut ::SSL, buf: *const c_void, num: size_t, written: *mut size_t) -> c_int;
-    pub fn SSL_read_early_data(s: *mut ::SSL, buf: *mut c_void, num: size_t, readbytes: *mut size_t) -> c_int;
+    pub fn SSL_SESSION_set_max_early_data(ctx: *mut ::SSL_SESSION, max_early_data: u32) -> c_int;
+    pub fn SSL_SESSION_get_max_early_data(ctx: *const ::SSL_SESSION) -> u32;
 }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -952,7 +952,9 @@ impl SslContextBuilder {
         unsafe { cvt(ffi::SSL_CTX_use_PrivateKey(self.as_ptr(), key.as_ptr())).map(|_| ()) }
     }
 
-    /// Sets the list of supported ciphers.
+    /// Sets the list of supported ciphers for protocols before TLSv1.3.
+    ///
+    /// The `set_ciphersuites` method controls the cipher suites for TLSv1.3.
     ///
     /// See [`ciphers`] for details on the format.
     ///
@@ -964,6 +966,29 @@ impl SslContextBuilder {
         let cipher_list = CString::new(cipher_list).unwrap();
         unsafe {
             cvt(ffi::SSL_CTX_set_cipher_list(
+                self.as_ptr(),
+                cipher_list.as_ptr() as *const _,
+            )).map(|_| ())
+        }
+    }
+
+    /// Sets the list of supported ciphers for the TLSv1.3 protocol.
+    ///
+    /// The `set_cipher_list` method controls lthe cipher suites for protocols before TLSv1.3.
+    ///
+    /// The format consists of TLSv1.3 ciphersuite names separated by `:` characters in order of
+    /// preference.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    ///
+    /// This corresponds to [`SSL_CTX_set_ciphersuites`].
+    ///
+    /// [`SSL_CTX_set_ciphersuites`]: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_ciphersuites.html
+    #[cfg(ossl111)]
+    pub fn set_ciphersuites(&mut self, cipher_list: &str) -> Result<(), ErrorStack> {
+        let cipher_list = CString::new(cipher_list).unwrap();
+        unsafe {
+            cvt(ffi::SSL_CTX_set_ciphersuites(
                 self.as_ptr(),
                 cipher_list.as_ptr() as *const _,
             )).map(|_| ())


### PR DESCRIPTION
The initial session ticket is now sent as part of SSL_accept, so some
tests need to write a single byte through the stream to make sure that
both ends have fully completed to avoid test flakes.

TLSv1.3 cipher suite control has been extracted from the normal cipher
list into a separate method: SslContextBuilder::set_ciphersuites.