### PR TITLE
Switch to accessors in libressl where possible

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -13,6 +13,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x2_07_00_00_0 {
             cfgs.push("libressl270");
         }
+        if libressl_version >= 0x2_07_03_00_0 {
+            cfgs.push("libressl273");
+        }
     } else {
         let openssl_version = openssl_version.unwrap();
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -2616,7 +2616,7 @@ extern "C" {
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int;
     #[cfg(all(ossl102, not(ossl110f)))]
     pub fn SSL_is_server(s: *mut SSL) -> c_int;
-    #[cfg(ossl110f)]
+    #[cfg(any(ossl110f, libressl273))]
     pub fn SSL_is_server(s: *const SSL) -> c_int;
     pub fn SSL_get_finished(s: *const SSL, buf: *mut c_void, count: size_t) -> size_t;
     pub fn SSL_get_peer_finished(s: *const SSL, buf: *mut c_void, count: size_t) -> size_t;

--- a/openssl-sys/src/libressl/mod.rs
+++ b/openssl-sys/src/libressl/mod.rs
@@ -8,11 +8,15 @@ use std::sync::{Once, ONCE_INIT};
 pub use libressl::v250::*;
 #[cfg(libressl251)]
 pub use libressl::v251::*;
+#[cfg(libressl273)]
+pub use libressl::v273::*;
 
 #[cfg(not(libressl251))]
 mod v250;
 #[cfg(libressl251)]
 mod v251;
+#[cfg(libressl273)]
+mod v273;
 
 #[repr(C)]
 pub struct stack_st_ASN1_OBJECT {

--- a/openssl-sys/src/libressl/v273.rs
+++ b/openssl-sys/src/libressl/v273.rs
@@ -1,0 +1,106 @@
+use libc::{c_char, c_int, c_long, c_uchar, c_void, size_t};
+
+extern "C" {
+    pub fn ASN1_STRING_get0_data(x: *const ::ASN1_STRING) -> *const c_uchar;
+
+    pub fn BIO_set_init(a: *mut ::BIO, init: c_int);
+    pub fn BIO_set_data(a: *mut ::BIO, data: *mut c_void);
+    pub fn BIO_get_data(a: *mut ::BIO) -> *mut c_void;
+    pub fn BIO_meth_new(type_: c_int, name: *const c_char) -> *mut ::BIO_METHOD;
+    pub fn BIO_meth_free(biom: *mut ::BIO_METHOD);
+    // FIXME should wrap in Option
+    pub fn BIO_meth_set_write(
+        biom: *mut ::BIO_METHOD,
+        write: unsafe extern "C" fn(*mut ::BIO, *const c_char, c_int) -> c_int,
+    ) -> c_int;
+    pub fn BIO_meth_set_read(
+        biom: *mut ::BIO_METHOD,
+        read: unsafe extern "C" fn(*mut ::BIO, *mut c_char, c_int) -> c_int,
+    ) -> c_int;
+    pub fn BIO_meth_set_puts(
+        biom: *mut ::BIO_METHOD,
+        read: unsafe extern "C" fn(*mut ::BIO, *const c_char) -> c_int,
+    ) -> c_int;
+    pub fn BIO_meth_set_ctrl(
+        biom: *mut ::BIO_METHOD,
+        read: unsafe extern "C" fn(*mut ::BIO, c_int, c_long, *mut c_void) -> c_long,
+    ) -> c_int;
+    pub fn BIO_meth_set_create(
+        biom: *mut ::BIO_METHOD,
+        create: unsafe extern "C" fn(*mut ::BIO) -> c_int,
+    ) -> c_int;
+    pub fn BIO_meth_set_destroy(
+        biom: *mut ::BIO_METHOD,
+        destroy: unsafe extern "C" fn(*mut ::BIO) -> c_int,
+    ) -> c_int;
+
+    pub fn DH_set0_pqg(
+        dh: *mut ::DH,
+        p: *mut ::BIGNUM,
+        q: *mut ::BIGNUM,
+        g: *mut ::BIGNUM,
+    ) -> c_int;
+
+    pub fn DSA_get0_pqg(
+        d: *const ::DSA,
+        p: *mut *const ::BIGNUM,
+        q: *mut *const ::BIGNUM,
+        q: *mut *const ::BIGNUM,
+    );
+
+    pub fn ECDSA_SIG_get0(
+        sig: *const ::ECDSA_SIG,
+        pr: *mut *const ::BIGNUM,
+        ps: *mut *const ::BIGNUM,
+    );
+    pub fn ECDSA_SIG_set0(sig: *mut ::ECDSA_SIG, pr: *mut ::BIGNUM, ps: *mut ::BIGNUM) -> c_int;
+
+    pub fn EVP_CIPHER_key_length(cipher: *const ::EVP_CIPHER) -> c_int;
+    pub fn EVP_CIPHER_block_size(cipher: *const ::EVP_CIPHER) -> c_int;
+    pub fn EVP_CIPHER_iv_length(cipher: *const ::EVP_CIPHER) -> c_int;
+
+    pub fn RSA_get0_key(
+        r: *const ::RSA,
+        n: *mut *const ::BIGNUM,
+        e: *mut *const ::BIGNUM,
+        d: *mut *const ::BIGNUM,
+    );
+    pub fn RSA_get0_factors(r: *const ::RSA, p: *mut *const ::BIGNUM, q: *mut *const ::BIGNUM);
+    pub fn RSA_get0_crt_params(
+        r: *const ::RSA,
+        dmp1: *mut *const ::BIGNUM,
+        dmq1: *mut *const ::BIGNUM,
+        iqmp: *mut *const ::BIGNUM,
+    );
+    pub fn RSA_set0_key(
+        r: *mut ::RSA,
+        n: *mut ::BIGNUM,
+        e: *mut ::BIGNUM,
+        d: *mut ::BIGNUM,
+    ) -> c_int;
+    pub fn RSA_set0_factors(r: *mut ::RSA, p: *mut ::BIGNUM, q: *mut ::BIGNUM) -> c_int;
+    pub fn RSA_set0_crt_params(
+        r: *mut ::RSA,
+        dmp1: *mut ::BIGNUM,
+        dmq1: *mut ::BIGNUM,
+        iqmp: *mut ::BIGNUM,
+    ) -> c_int;
+
+    pub fn SSL_CTX_up_ref(x: *mut ::SSL_CTX) -> c_int;
+
+    pub fn SSL_SESSION_get_master_key(
+        session: *const ::SSL_SESSION,
+        out: *mut c_uchar,
+        outlen: size_t,
+    ) -> size_t;
+    pub fn SSL_SESSION_up_ref(ses: *mut ::SSL_SESSION) -> c_int;
+
+    pub fn X509_getm_notAfter(x: *const ::X509) -> *mut ::ASN1_TIME;
+    pub fn X509_getm_notBefore(x: *const ::X509) -> *mut ::ASN1_TIME;
+    pub fn X509_get0_signature(
+        psig: *mut *const ::ASN1_BIT_STRING,
+        palg: *mut *const ::X509_ALGOR,
+        x: *const ::X509,
+    );
+    pub fn X509_up_ref(x: *mut ::X509) -> c_int;
+}

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -45,5 +45,9 @@ fn main() {
         if version >= 0x2_07_00_00_0 {
             println!("cargo:rustc-cfg=libressl270");
         }
+
+        if version >= 0x2_07_03_00_0 {
+            println!("cargo:rustc-cfg=libressl273");
+        }
     }
 }

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -297,7 +297,7 @@ impl fmt::Display for Asn1ObjectRef {
 }
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl273))] {
         use ffi::ASN1_STRING_get0_data;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -107,7 +107,7 @@ impl Dh<Params> {
 }
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl273))] {
         use ffi::DH_set0_pqg;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -188,7 +188,7 @@ impl<T> fmt::Debug for Dsa<T> {
 }
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl273))] {
         use ffi::DSA_get0_pqg;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/ecdsa.rs
+++ b/openssl/src/ecdsa.rs
@@ -105,7 +105,7 @@ impl EcdsaSig {
 }
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl273))] {
         use ffi::{ECDSA_SIG_set0, ECDSA_SIG_get0};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -645,7 +645,7 @@ impl<T> fmt::Debug for Rsa<T> {
 }
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl273))] {
         use ffi::{
             RSA_get0_key, RSA_get0_factors, RSA_get0_crt_params, RSA_set0_key, RSA_set0_factors,
             RSA_set0_crt_params,

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -175,7 +175,7 @@ unsafe extern "C" fn destroy<S>(bio: *mut BIO) -> c_int {
 }
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl273))] {
         use ffi::{BIO_get_data, BIO_set_data, BIO_set_flags, BIO_set_init};
 
         #[allow(bad_style)]

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3307,44 +3307,9 @@ pub enum ShutdownResult {
 }
 
 cfg_if! {
-    if #[cfg(ossl110)] {
-        use ffi::{
-            SSL_CTX_up_ref,
-            SSL_SESSION_get_master_key, SSL_SESSION_up_ref, SSL_is_server, TLS_method, DTLS_method,
-        };
-
-        pub unsafe fn get_new_idx(f: ffi::CRYPTO_EX_free) -> c_int {
-            ffi::CRYPTO_get_ex_new_index(
-                ffi::CRYPTO_EX_INDEX_SSL_CTX,
-                0,
-                ptr::null_mut(),
-                None,
-                None,
-                Some(f),
-            )
-        }
-
-        pub unsafe fn get_new_ssl_idx(f: ffi::CRYPTO_EX_free) -> c_int {
-            ffi::CRYPTO_get_ex_new_index(
-                ffi::CRYPTO_EX_INDEX_SSL,
-                0,
-                ptr::null_mut(),
-                None,
-                None,
-                Some(f),
-            )
-        }
+    if #[cfg(any(ossl110, libressl273))] {
+        use ffi::{SSL_CTX_up_ref, SSL_SESSION_get_master_key, SSL_SESSION_up_ref, SSL_is_server};
     } else {
-        use ffi::{SSLv23_method as TLS_method, DTLSv1_method as DTLS_method};
-
-        pub unsafe fn get_new_idx(f: ffi::CRYPTO_EX_free) -> c_int {
-            ffi::SSL_CTX_get_ex_new_index(0, ptr::null_mut(), None, None, Some(f))
-        }
-
-        pub unsafe fn get_new_ssl_idx(f: ffi::CRYPTO_EX_free) -> c_int {
-            ffi::SSL_get_ex_new_index(0, ptr::null_mut(), None, None, Some(f))
-        }
-
         #[allow(bad_style)]
         pub unsafe fn SSL_CTX_up_ref(ssl: *mut ffi::SSL_CTX) -> c_int {
             ffi::CRYPTO_add_lock(
@@ -3388,6 +3353,44 @@ cfg_if! {
                 line!() as c_int,
             );
             0
+        }
+    }
+}
+
+cfg_if! {
+    if #[cfg(ossl110)] {
+        use ffi::{TLS_method, DTLS_method};
+
+        pub unsafe fn get_new_idx(f: ffi::CRYPTO_EX_free) -> c_int {
+            ffi::CRYPTO_get_ex_new_index(
+                ffi::CRYPTO_EX_INDEX_SSL_CTX,
+                0,
+                ptr::null_mut(),
+                None,
+                None,
+                Some(f),
+            )
+        }
+
+        pub unsafe fn get_new_ssl_idx(f: ffi::CRYPTO_EX_free) -> c_int {
+            ffi::CRYPTO_get_ex_new_index(
+                ffi::CRYPTO_EX_INDEX_SSL,
+                0,
+                ptr::null_mut(),
+                None,
+                None,
+                Some(f),
+            )
+        }
+    } else {
+        use ffi::{SSLv23_method as TLS_method, DTLSv1_method as DTLS_method};
+
+        pub unsafe fn get_new_idx(f: ffi::CRYPTO_EX_free) -> c_int {
+            ffi::SSL_CTX_get_ex_new_index(0, ptr::null_mut(), None, None, Some(f))
+        }
+
+        pub unsafe fn get_new_ssl_idx(f: ffi::CRYPTO_EX_free) -> c_int {
+            ffi::SSL_get_ex_new_index(0, ptr::null_mut(), None, None, Some(f))
         }
     }
 }

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -719,7 +719,7 @@ pub fn decrypt_aead(
 }
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl273))] {
         use ffi::{EVP_CIPHER_block_size, EVP_CIPHER_iv_length, EVP_CIPHER_key_length};
     } else {
         #[allow(bad_style)]


### PR DESCRIPTION
Some accessors are mysteriously still macros so we can't make everything
opaque yet, unfortunately.

cc #909