### PR TITLE
Add access to private/public components of DSA key pairs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+* Added `DsaRef::pub_key` and `DsaRef::priv_key`.
+* Added `Dsa::from_private_components` and `Dsa::from_public_components`.
+
 ## [v0.10.10] - 2018-06-06
 
 ### Added

--- a/openssl-sys/src/libressl/v273.rs
+++ b/openssl-sys/src/libressl/v273.rs
@@ -47,6 +47,22 @@ extern "C" {
         q: *mut *const ::BIGNUM,
         q: *mut *const ::BIGNUM,
     );
+    pub fn DSA_set0_pqg(
+        d: *mut ::DSA,
+        p: *mut ::BIGNUM,
+        q: *mut ::BIGNUM,
+        q: *mut ::BIGNUM,
+    ) -> c_int;
+    pub fn DSA_get0_key(
+        d: *const ::DSA,
+        pub_key: *mut *const ::BIGNUM,
+        priv_key: *mut *const ::BIGNUM,
+    );
+    pub fn DSA_set0_key(
+        d: *mut ::DSA,
+        pub_key: *mut ::BIGNUM,
+        priv_key: *mut ::BIGNUM,
+    ) -> c_int;
 
     pub fn ECDSA_SIG_get0(
         sig: *const ::ECDSA_SIG,

--- a/openssl-sys/src/openssl/v110.rs
+++ b/openssl-sys/src/openssl/v110.rs
@@ -235,11 +235,22 @@ extern "C" {
         q: *mut *const ::BIGNUM,
         q: *mut *const ::BIGNUM,
     );
+    pub fn DSA_set0_pqg(
+        d: *mut ::DSA,
+        p: *mut ::BIGNUM,
+        q: *mut ::BIGNUM,
+        q: *mut ::BIGNUM,
+    ) -> c_int;
     pub fn DSA_get0_key(
         d: *const ::DSA,
         pub_key: *mut *const ::BIGNUM,
         priv_key: *mut *const ::BIGNUM,
     );
+    pub fn DSA_set0_key(
+        d: *mut ::DSA,
+        pub_key: *mut ::BIGNUM,
+        priv_key: *mut ::BIGNUM,
+    ) -> c_int;
     pub fn RSA_get0_key(
         r: *const ::RSA,
         n: *mut *const ::BIGNUM,

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -280,7 +280,7 @@ cfg_if! {
         }
 
         #[allow(bad_style)]
-        unsafe fn DSA_get0_pqg(
+        unsafe fn DSA_get0_key(
             d: *mut ffi::DSA,
             pub_key: *mut *const ffi::BIGNUM,
             priv_key: *mut *const ffi::BIGNUM)
@@ -299,8 +299,8 @@ cfg_if! {
             pub_key: *mut ffi::BIGNUM,
             priv_key: *mut ffi::BIGNUM) -> c_int
         {
-            (*d).pub_key = *pub_key;
-            (*d).priv_key = *priv_key;
+            (*d).pub_key = pub_key;
+            (*d).priv_key = priv_key;
             1
         }
 
@@ -311,9 +311,9 @@ cfg_if! {
             q: *mut ffi::BIGNUM,
             g: *mut ffi::BIGNUM) -> c_int
         {
-            (*d).p = *p;
-            (*d).q = *q;
-            (*d).g = *g;
+            (*d).p = p;
+            (*d).q = q;
+            (*d).g = g;
             1
         }
     }


### PR DESCRIPTION
While working on a SSH-Agent implementation I noticed that there was no way to construct or get the private and public components from a DSA key. 

I added them here, in the style of similiar functionality in the RSA and EC key implementations.