### PR TITLE
Fix build with openssl 1.1.1 and no-psk

### DIFF
--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -1,12 +1,12 @@
 use ffi;
 use foreign_types::ForeignType;
 use foreign_types::ForeignTypeRef;
-#[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+#[cfg(any(ossl111, not(osslconf = "OPENSSL_NO_PSK")))]
 use libc::c_char;
 #[cfg(ossl111)]
 use libc::size_t;
 use libc::{c_int, c_uchar, c_uint, c_void};
-#[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+#[cfg(any(ossl111, not(osslconf = "OPENSSL_NO_PSK")))]
 use std::ffi::CStr;
 use std::mem;
 use std::ptr;


### PR DESCRIPTION
I used this as build flags for openssl 1.1.1:

```
/usr/bin/perl ./Configure linux-x86_64 no-shared no-zlib no-psk no-srp no-weak-ssl-ciphers no-idea
```

rust-openssl crashed with this error:

```
   Compiling openssl v0.10.10                                                                                                                                                                                      
error[E0433]: failed to resolve. Use of undeclared type or module `CStr`                                                                                                                                           
   --> /home/stefan/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.10/src/ssl/callbacks.rs:386:16                                                                                                    
    |                                                                                                                                                                                                              
386 |     let line = CStr::from_ptr(line).to_bytes();                                                                                                                                                              
    |                ^^^^ Use of undeclared type or module `CStr`                                                                                                                                                  
                                                                                                                                                                                                                   
error[E0412]: cannot find type `c_char` in this scope                                                                                                                                                              
   --> /home/stefan/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.10/src/ssl/callbacks.rs:377:75                                                                                                    
    |                                                                                                                                                                                                              
377 | pub unsafe extern "C" fn raw_keylog<F>(ssl: *const ffi::SSL, line: *const c_char)                                                                                                                            
    |                                                                           ^^^^^^ did you mean `c_uchar`?                                                                                                     
help: possible candidates are found in other modules, you can import them into scope                                                                                                                               
    |                                                                                                                                                                                                              
1   | use libc::c_char;                                                                                                                                                                                            
    |                                                                                                                                                                                                              
1   | use std::os::raw::c_char;                                                                                                                                                                                    
    |                                                                                                                                                                                                              
                                                                                                                                                                                                                   
error: aborting due to 2 previous errors                                                                                                                                                                           
                                                                                                                                                                                                                   
Some errors occurred: E0412, E0433.                                                                                                                                                                                
For more information about an error, try `rustc --explain E0412`.                                                                                                                                                  
error: Could not compile `openssl`.                                                                                                                                                                                
warning: build failed, waiting for other jobs to finish... 
```

this patch fixes the problem