### PR TITLE
Link all needed system libraries on Windows, when building statically

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-sys"
-version = "0.9.33"
+version = "0.9.34"
 authors = ["Alex Crichton <alex@alexcrichton.com>",
            "Steven Fackler <sfackler@gmail.com>"]
 license = "MIT"

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -103,6 +103,10 @@ fn main() {
 
     if kind == "static" && target.contains("windows") {
         println!("cargo:rustc-link-lib=dylib=gdi32");
+        println!("cargo:rustc-link-lib=dylib=user32");
+        println!("cargo:rustc-link-lib=dylib=crypt32");
+        println!("cargo:rustc-link-lib=dylib=ws2_32");
+        println!("cargo:rustc-link-lib=dylib=advapi32");
     }
 }
 


### PR DESCRIPTION
When linking OpenSSL statically on Windows, `openssl-sys` doesn't declare all of system dependencies that OpenSSL has, as stated [here](https://github.com/openssl/openssl/blob/master/NOTES.WIN#L116-L118). This PR fixes that.

If this is by design, I can update the README and state so. Debugging this is quite time-intensive as a big enough project will link against a subset of these libraries independently of OpenSSL, but an example project might only require just one of them. Maybe these linker flags should be feature gated to avoid spreading bloat?