### PR TITLE
Fix spelling in symm docs

### DIFF
--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -23,7 +23,7 @@
 //!     &ciphertext[..]);
 //! ```
 //!
-//! Encrypting an assymetric key with a symmetric cipher
+//! Encrypting an asymmetric key with a symmetric cipher
 //!
 //! ```
 //! use openssl::rsa::{Padding, Rsa};


### PR DESCRIPTION
Small fix, noticed this while reading the rust-openssl docs.