### PR TITLE
Add methods for DTLS/SRTP key handshake

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -184,6 +184,22 @@ pub struct ERR_STRING_DATA {
     pub string: *const c_char,
 }
 
+pub const SRTP_AES128_CM_SHA1_80: c_ulong = 0x0001;
+pub const SRTP_AES128_CM_SHA1_32: c_ulong = 0x0002;
+pub const SRTP_AES128_F8_SHA1_80: c_ulong = 0x0003;
+pub const SRTP_AES128_F8_SHA1_32: c_ulong = 0x0004;
+pub const SRTP_NULL_SHA1_80: c_ulong = 0x0005;
+pub const SRTP_NULL_SHA1_32: c_ulong = 0x0006;
+
+#[repr(C)]
+pub struct SRTP_PROTECTION_PROFILE {
+    pub name: *const c_char,
+    pub id: c_ulong,
+}
+
+/// fake free method, since SRTP_PROTECTION_PROFILE is static
+pub unsafe fn SRTP_PROTECTION_PROFILE_free(_profile: *mut SRTP_PROTECTION_PROFILE) {}
+
 pub type SHA_LONG = c_uint;
 pub type SHA_LONG64 = u64;
 

--- a/openssl-sys/src/libressl/mod.rs
+++ b/openssl-sys/src/libressl/mod.rs
@@ -10,6 +10,7 @@ pub use libressl::v250::*;
 pub use libressl::v251::*;
 #[cfg(libressl273)]
 pub use libressl::v273::*;
+use SRTP_PROTECTION_PROFILE;
 
 #[cfg(not(libressl251))]
 mod v250;
@@ -62,6 +63,11 @@ pub struct stack_st_SSL_CIPHER {
 pub struct stack_st_OPENSSL_STRING {
     pub stack: _STACK,
 }
+#[repr(C)]
+pub struct stack_st_SRTP_PROTECTION_PROFILE {
+    pub stack: _STACK,
+}
+
 
 #[repr(C)]
 pub struct _STACK {
@@ -633,4 +639,9 @@ extern "C" {
 
     pub fn SSLeay() -> c_ulong;
     pub fn SSLeay_version(key: c_int) -> *const c_char;
+
+    pub fn SSL_set_tlsext_use_srtp(ssl: *mut ::SSL, profiles: *const c_char) -> c_int;
+    pub fn SSL_CTX_set_tlsext_use_srtp(ctx: *mut ::SSL_CTX, profiles: *const c_char) -> c_int;
+    pub fn SSL_get_srtp_profiles(ssl: *mut ::SSL) -> *mut stack_st_SRTP_PROTECTION_PROFILE;
+    pub fn SSL_get_selected_srtp_profile(ssl: *mut ::SSL) -> *mut SRTP_PROTECTION_PROFILE;
 }

--- a/openssl-sys/src/openssl/v10x.rs
+++ b/openssl-sys/src/openssl/v10x.rs
@@ -4,6 +4,7 @@ use std::process;
 use std::ptr;
 use std::sync::{Mutex, MutexGuard};
 use std::sync::{Once, ONCE_INIT};
+use SRTP_PROTECTION_PROFILE;
 
 #[cfg(ossl102)]
 use libc::time_t;
@@ -51,6 +52,12 @@ pub struct stack_st_SSL_CIPHER {
 
 #[repr(C)]
 pub struct stack_st_OPENSSL_STRING {
+    pub stack: _STACK,
+}
+
+
+#[repr(C)]
+pub struct stack_st_SRTP_PROTECTION_PROFILE {
     pub stack: _STACK,
 }
 
@@ -1002,4 +1009,9 @@ extern "C" {
 
     #[cfg(ossl102)]
     pub fn SSL_extension_supported(ext_type: c_uint) -> c_int;
+
+    pub fn SSL_set_tlsext_use_srtp(ssl: *mut ::SSL, profiles: *const c_char) -> c_int;
+    pub fn SSL_CTX_set_tlsext_use_srtp(ctx: *mut ::SSL_CTX, profiles: *const c_char) -> c_int;
+    pub fn SSL_get_srtp_profiles(ssl: *mut ::SSL) -> *mut stack_st_SRTP_PROTECTION_PROFILE;
+    pub fn SSL_get_selected_srtp_profile(ssl: *mut ::SSL) -> *mut SRTP_PROTECTION_PROFILE;
 }

--- a/openssl-sys/src/openssl/v110.rs
+++ b/openssl-sys/src/openssl/v110.rs
@@ -1,6 +1,7 @@
 use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void, size_t};
 use std::ptr;
 use std::sync::{Once, ONCE_INIT};
+use SRTP_PROTECTION_PROFILE;
 
 pub enum BIGNUM {}
 pub enum BIO {}
@@ -27,6 +28,7 @@ pub enum stack_st_X509 {}
 pub enum stack_st_X509_NAME {}
 pub enum stack_st_X509_ATTRIBUTE {}
 pub enum stack_st_X509_EXTENSION {}
+pub enum stack_st_SRTP_PROTECTION_PROFILE {}
 pub enum stack_st_SSL_CIPHER {}
 pub enum OPENSSL_INIT_SETTINGS {}
 pub enum X509 {}
@@ -139,6 +141,7 @@ pub unsafe fn SSL_get_min_proto_version(s: *mut ::SSL) -> c_int {
 pub unsafe fn SSL_get_max_proto_version(s: *mut ::SSL) -> c_int {
     ::SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, ptr::null_mut()) as c_int
 }
+
 
 extern "C" {
     pub fn BIO_new(type_: *const BIO_METHOD) -> *mut BIO;
@@ -392,4 +395,9 @@ extern "C" {
 
     pub fn SSL_CIPHER_get_cipher_nid(c: *const ::SSL_CIPHER) -> c_int;
     pub fn SSL_CIPHER_get_digest_nid(c: *const ::SSL_CIPHER) -> c_int;
+
+    pub fn SSL_set_tlsext_use_srtp(ssl: *mut ::SSL, profiles: *const c_char) -> c_int;
+    pub fn SSL_CTX_set_tlsext_use_srtp(ctx: *mut ::SSL_CTX, profiles: *const c_char) -> c_int;
+    pub fn SSL_get_srtp_profiles(ssl: *mut ::SSL) -> *mut stack_st_SRTP_PROTECTION_PROFILE;
+    pub fn SSL_get_selected_srtp_profile(ssl: *mut ::SSL) -> *mut SRTP_PROTECTION_PROFILE;
 }

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -57,6 +57,7 @@ pub mod rand;
 pub mod rsa;
 pub mod sha;
 pub mod sign;
+pub mod srtp;
 pub mod ssl;
 pub mod stack;
 pub mod string;

--- a/openssl/src/srtp.rs
+++ b/openssl/src/srtp.rs
@@ -1,0 +1,54 @@
+use ffi;
+use foreign_types::ForeignTypeRef;
+use libc::c_ulong;
+use stack::Stackable;
+use std::ffi::CStr;
+use std::str;
+
+#[allow(unused_unsafe)]
+foreign_type_and_impl_send_sync! {
+    type CType = ffi::SRTP_PROTECTION_PROFILE;
+    fn drop = ffi::SRTP_PROTECTION_PROFILE_free;
+
+    pub struct SrtpProtectionProfile;
+    /// Reference to `SrtpProtectionProfile`.
+    pub struct SrtpProtectionProfileRef;
+}
+
+impl Stackable for SrtpProtectionProfile {
+    type StackType = ffi::stack_st_SRTP_PROTECTION_PROFILE;
+}
+
+
+impl SrtpProtectionProfileRef {
+    pub fn id(&self) -> SrtpProfileId {
+        SrtpProfileId::from_raw(unsafe { (*self.as_ptr()).id })
+    }
+    pub fn name(&self) -> &'static str {
+        unsafe { CStr::from_ptr((*self.as_ptr()).name as *const _) }.to_str().expect("should be UTF-8")
+    }
+}
+
+
+/// type of SRTP profile to use.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SrtpProfileId(c_ulong);
+
+impl SrtpProfileId {
+    /// Creates a `SrtpProfileId` from an integer representation.
+    pub fn from_raw(value: c_ulong) -> SrtpProfileId {
+        SrtpProfileId(value)
+    }
+
+    /// Returns the integer representation of `SrtpProfileId`.
+    pub fn as_raw(&self) -> c_ulong {
+        self.0
+    }
+
+    pub const SRTP_AES128_CM_SHA1_80: SrtpProfileId = SrtpProfileId(ffi::SRTP_AES128_CM_SHA1_80);
+    pub const SRTP_AES128_CM_SHA1_32: SrtpProfileId = SrtpProfileId(ffi::SRTP_AES128_CM_SHA1_32);
+    pub const SRTP_AES128_F8_SHA1_80: SrtpProfileId = SrtpProfileId(ffi::SRTP_AES128_F8_SHA1_80);
+    pub const SRTP_AES128_F8_SHA1_32: SrtpProfileId = SrtpProfileId(ffi::SRTP_AES128_F8_SHA1_32);
+    pub const SRTP_NULL_SHA1_80: SrtpProfileId = SrtpProfileId(ffi::SRTP_NULL_SHA1_80);
+    pub const SRTP_NULL_SHA1_32: SrtpProfileId = SrtpProfileId(ffi::SRTP_NULL_SHA1_32);
+}


### PR DESCRIPTION
This change should allow for using DTLS/SRTP key handshake using the methods described in [SSL_CTX_set_tlsext_use_srtp](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_tlsext_use_srtp.html)

Open questions are all addressed.

- [X] On libressl 2.7.2 the test case just hangs for no apparent reason after exchanging a few bytes. (so test is disabled for now)

- [X] Is mapping of SRTP_PROTECTION_PROFILE ok? Specifically, the usage of a fake SRTP_PROTECTION_PROFILE_free method

- [X] Is it ok to copy data to a rust type (SrtpProfile) to obtain profile?

