### PR TITLE
Fix lookup errors with SNI callback.

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -1564,6 +1564,10 @@ pub unsafe fn SSL_CTX_set_tlsext_servername_callback(
     SSL_CTX_callback_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cb)
 }
 
+pub unsafe fn SSL_CTX_set_tlsext_servername_arg(ctx: *mut SSL_CTX, arg: *mut c_void) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG, 0, arg)
+}
+
 pub unsafe fn SSL_set_tlsext_host_name(s: *mut SSL, name: *mut c_char) -> c_long {
     SSL_ctrl(
         s,


### PR DESCRIPTION
The job of an SNI callback is typically to swap out the context
associated with an SSL depending on the domain the client is trying to
talk to. Typically, only the callbacks associated with the current
context are used, but this is not the case for the SNI callback.

If SNI is run for a second time on a connection (i.e. in a
renegotiation) and the context was replaced with one that didn't itself
register an SNI callback, the old callback would run but wouldn't be
able to find its state in the context's ex data. To work around this, we
pass the pointer to the callback data directly to the callback to make
sure it's always available. It still lives in ex data to handle the
lifetime management.

Closes #979

@Geal could you give this a try?