### PR TITLE
Add impl From<u32> for BigNum.

### DIFF
--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -1130,6 +1130,12 @@ impl fmt::Display for BigNum {
     }
 }
 
+impl From<u32> for BigNum {
+    fn from(num: u32) -> Self {
+        Self::from_u32(num).unwrap()
+    }
+}
+
 impl PartialEq<BigNumRef> for BigNumRef {
     fn eq(&self, oth: &BigNumRef) -> bool {
         self.cmp(oth) == Ordering::Equal


### PR DESCRIPTION
This allows for a function which takes generic parameters to still operate on constant numbers like 1 and 0. As a sort of trivial example:
```
    fn plus_one<T>(a: &T) -> T 
        where T:
            cmp::PartialEq + 
            From<u32>,
            for<'a> &'a T: ops::Add<Output = T>,
    {
        a + &T::from(1)
    }
```

I hope that using `unwrap()` in that way is ok. It seems that's how you're implementing the `ops::` traits, so I figured it would?
