### PR TITLE
Support the rest of LibreSSL 2.8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,9 @@ libressl_250: &LIBRESSL_250
   VERSION: 2.5.0
 libressl_270: &LIBRESSL_280
   LIBRARY: libressl
+  VERSION: 2.8.0
+libressl_281: &LIBRESSL_281
+  LIBRARY: libressl
   VERSION: 2.8.1
 
 x86_64: &X86_64
@@ -197,6 +200,10 @@ jobs:
     <<: *JOB
     environment:
       <<: [*LIBRESSL_280, *X86_64, *BASE]
+  x86_64-libressl-2.8.1:
+    <<: *JOB
+    environment:
+      <<: [*LIBRESSL_281, *X86_64, *BASE]
   macos:
     <<: *MACOS_JOB
     environment:
@@ -225,5 +232,6 @@ workflows:
     - armhf-openssl-1.0.2
     - x86_64-libressl-2.5.0
     - x86_64-libressl-2.8.0
+    - x86_64-libressl-2.8.1
     - macos
     - macos-vendored

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ libressl_250: &LIBRESSL_250
   VERSION: 2.5.0
 libressl_270: &LIBRESSL_280
   LIBRARY: libressl
-  VERSION: 2.8.0
+  VERSION: 2.8.1
 
 x86_64: &X86_64
   TARGET: x86_64-unknown-linux-gnu

--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -19,6 +19,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x2_08_00_00_0 {
             cfgs.push("libressl280");
         }
+        if libressl_version >= 0x2_08_01_00_0 {
+            cfgs.push("libressl281");
+        }
     } else {
         let openssl_version = openssl_version.unwrap();
 

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -497,7 +497,7 @@ See rust-openssl README for more information:
             (6, 2) => ('6', '2'),
             (6, _) => ('6', 'x'),
             (7, _) => ('7', 'x'),
-            (8, 0) => ('8', 'x'),
+            (8, _) => ('8', 'x'),
             _ => version_error(),
         };
 
@@ -538,7 +538,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 2.7, but a different version of OpenSSL was found. The build is now aborting
+through 2.8, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -497,7 +497,8 @@ See rust-openssl README for more information:
             (6, 2) => ('6', '2'),
             (6, _) => ('6', 'x'),
             (7, _) => ('7', 'x'),
-            (8, _) => ('8', 'x'),
+            (8, 0) => ('8', '0'),
+            (8, 1) => ('8', '1'),
             _ => version_error(),
         };
 
@@ -538,7 +539,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 2.8, but a different version of OpenSSL was found. The build is now aborting
+through 2.8.1, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl-sys/src/ocsp.rs
+++ b/openssl-sys/src/ocsp.rs
@@ -45,7 +45,7 @@ pub const V_OCSP_CERTSTATUS_UNKNOWN: c_int = 2;
 pub enum OCSP_BASICRESP {}
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl281))] {
         extern "C" {
             pub fn OCSP_cert_to_id(
                 dgst: *const EVP_MD,


### PR DESCRIPTION
LibreSSL 2.8.1 released, so update the check for all versions in the series, not just 2.8.0. Also fix the version mismatch error message that was missed in the initial 2.8.0 support addition.

Did not change any of the CI configs, but did run `cargo test` locally with all checks passing.