### PR TITLE
Bump dependency on openssl-src-rs

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2"
 [build-dependencies]
 pkg-config = "0.3.9"
 cc = "1.0"
-openssl-src = { version = "110.0.4", optional = true }
+openssl-src = { version = "111.0.1", optional = true }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -29,6 +29,7 @@ const DEFINES: &'static [&'static str] = &[
     "OPENSSL_NO_SRP",
     "OPENSSL_NO_SSL3_METHOD",
     "OPENSSL_NO_TLSEXT",
+    "OPENSSL_NO_STDIO",
 ];
 
 enum Version {

--- a/openssl-sys/src/bio.rs
+++ b/openssl-sys/src/bio.rs
@@ -73,6 +73,7 @@ cfg_if! {
     }
 }
 extern "C" {
+    #[cfg(not(osslconf = "OPENSSL_NO_STDIO"))]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: c_int) -> *mut BIO;
     #[cfg(any(ossl110, libressl273))]
     pub fn BIO_set_data(a: *mut ::BIO, data: *mut c_void);


### PR DESCRIPTION
Brings in the first release with OpenSSL 1.1.1