### PR TITLE
Add support for LibreSSL 2.8.2

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -503,6 +503,7 @@ See rust-openssl README for more information:
             (7, _) => ('7', 'x'),
             (8, 0) => ('8', '0'),
             (8, 1) => ('8', '1'),
+            (8, 2) => ('8', '2'),
             (8, _) => ('8', 'x'),
             _ => version_error(),
         };
@@ -544,7 +545,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 2.8.1, but a different version of OpenSSL was found. The build is now aborting
+through 2.8.2, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -8,7 +8,7 @@ libc = "0.2"
 openssl-sys = { path = "../openssl-sys" }
 
 [build-dependencies]
-ctest = "0.1"
+ctest = "0.2"
 
 [features]
 vendored = ['openssl-sys/vendored']

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -67,7 +67,8 @@ fn main() {
         cfg.header("openssl/cms.h");
     }
 
-    cfg.type_name(|s, is_struct| {
+    // TODO: decide whether we need is_union
+    cfg.type_name(|s, is_struct, _| {
         // Add some `*` on some callback parameters to get function pointer to
         // typecheck in C, especially on MSVC.
         if s == "PasswordCallback" {


### PR DESCRIPTION
Hi, since the new LibreSSL version is now released (and shipped in several distros), supporting it would make sense. I also updated the dependency on `ctest`, as the build otherwise fails for me (presumably because the old version's parsing is somewhat incomplete).