### PR TITLE
Add SHA3 & SHAKE128/256 EVP message digest functions in OpenSSL 1.1.1, fixes #1017.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ save_openssl: &SAVE_OPENSSL
     paths:
     - /openssl
 deps_key: &DEPS_KEY
-  key: deps-1.20.0-{{ checksum "Cargo.lock" }}-{{ checksum "~/lib_key" }}-2
+  key: deps-1.24.1-{{ checksum "Cargo.lock" }}-{{ checksum "~/lib_key" }}-2
 restore_deps: &RESTORE_DEPS
   restore_cache:
     <<: *DEPS_KEY
@@ -31,7 +31,7 @@ save_deps: &SAVE_DEPS
 job: &JOB
   working_directory: ~/build
   docker:
-  - image: rust:1.20.0
+  - image: rust:1.24.1
   steps:
   - checkout
   - run: apt-get update
@@ -74,7 +74,7 @@ macos_job: &MACOS_JOB
   - checkout
   - run: sudo mkdir /opt
   - run: sudo chown -R $USER /usr/local /opt
-  - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.20.0
+  - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.24.1
   - run: sudo ln -s $CARGO_HOME/bin/* /usr/local/bin
   - run: cargo generate-lockfile --verbose
   - run: echo "homebrew-x86_64-apple-darwin" > ~/lib_key
@@ -134,7 +134,7 @@ jobs:
   musl-vendored:
     <<: *JOB
     docker:
-    - image: rust:1.21.0
+    - image: rust:1.24.1
     environment:
       <<: [*VENDORED, *MUSL, *BASE]
   x86_64-vendored:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,20 +5,20 @@ environment:
     - TARGET: i686-pc-windows-gnu
       BITS: 32
       MSYS2: 1
-      OPENSSL_VERSION: 1_1_0i
+      OPENSSL_VERSION: 1_1_0j
     - TARGET: x86_64-pc-windows-msvc
       BITS: 64
-      OPENSSL_VERSION: 1_1_0i
+      OPENSSL_VERSION: 1_1_0j
       OPENSSL_DIR: C:\OpenSSL
 
     # 1.0.2, 64/32 bit
     - TARGET: x86_64-pc-windows-gnu
       BITS: 64
       MSYS2: 1
-      OPENSSL_VERSION: 1_0_2p
+      OPENSSL_VERSION: 1_0_2q
     - TARGET: i686-pc-windows-msvc
       BITS: 32
-      OPENSSL_VERSION: 1_0_2p
+      OPENSSL_VERSION: 1_0_2q
       OPENSSL_DIR: C:\OpenSSL
     - TARGET: x86_64-pc-windows-msvc
       VCPKG_DEFAULT_TRIPLET: x64-windows

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -53,6 +53,8 @@ extern "C" {
     pub fn EVP_DigestFinal_ex(ctx: *mut EVP_MD_CTX, res: *mut u8, n: *mut u32) -> c_int;
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, typ: *const EVP_MD) -> c_int;
     pub fn EVP_DigestFinal(ctx: *mut EVP_MD_CTX, res: *mut u8, n: *mut u32) -> c_int;
+    #[cfg(ossl111)]
+    pub fn EVP_DigestFinalXOF(ctx: *mut EVP_MD_CTX, res: *mut u8, len: usize) -> c_int;
 
     pub fn EVP_BytesToKey(
         typ: *const EVP_CIPHER,
@@ -148,6 +150,18 @@ extern "C" {
     pub fn EVP_sha256() -> *const EVP_MD;
     pub fn EVP_sha384() -> *const EVP_MD;
     pub fn EVP_sha512() -> *const EVP_MD;
+    #[cfg(ossl111)]
+    pub fn EVP_sha3_224() -> *const EVP_MD;
+    #[cfg(ossl111)]
+    pub fn EVP_sha3_256() -> *const EVP_MD;
+    #[cfg(ossl111)]
+    pub fn EVP_sha3_384() -> *const EVP_MD;
+    #[cfg(ossl111)]
+    pub fn EVP_sha3_512() -> *const EVP_MD;
+    #[cfg(ossl111)]
+    pub fn EVP_shake128() -> *const EVP_MD;
+    #[cfg(ossl111)]
+    pub fn EVP_shake256() -> *const EVP_MD;
     pub fn EVP_ripemd160() -> *const EVP_MD;
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -64,6 +64,26 @@ impl MessageDigest {
         unsafe { MessageDigest(ffi::EVP_sha512()) }
     }
 
+    #[cfg(ossl111)]
+    pub fn sha3_224() -> MessageDigest {
+        unsafe { MessageDigest(ffi::EVP_sha3_224()) }
+    }
+
+    #[cfg(ossl111)]
+    pub fn sha3_256() -> MessageDigest {
+        unsafe { MessageDigest(ffi::EVP_sha3_256()) }
+    }
+
+    #[cfg(ossl111)]
+    pub fn sha3_384() -> MessageDigest {
+        unsafe { MessageDigest(ffi::EVP_sha3_384()) }
+    }
+
+    #[cfg(ossl111)]
+    pub fn sha3_512() -> MessageDigest {
+        unsafe { MessageDigest(ffi::EVP_sha3_512()) }
+    }
+
     pub fn ripemd160() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_ripemd160()) }
     }
@@ -411,6 +431,56 @@ mod tests {
 
         for test in tests.iter() {
             hash_test(MessageDigest::sha256(), test);
+        }
+    }
+
+    #[cfg(ossl111)]
+    #[test]
+    fn test_sha3_224() {
+        let tests = [("416c6c20796f75722062617365206172652062656c6f6e6720746f207573",
+            "1de092dd9fbcbbf450f26264f4778abd48af851f2832924554c56913"
+        )];
+
+        for test in tests.iter() {
+            hash_test(MessageDigest::sha3_224(), test);
+        }
+    }
+
+    #[cfg(ossl111)]
+    #[test]
+    fn test_sha3_256() {
+        let tests = [("416c6c20796f75722062617365206172652062656c6f6e6720746f207573",
+            "b38e38f08bc1c0091ed4b5f060fe13e86aa4179578513ad11a6e3abba0062f61"
+        )];
+
+        for test in tests.iter() {
+            hash_test(MessageDigest::sha3_256(), test);
+        }
+    }
+
+    #[cfg(ossl111)]
+    #[test]
+    fn test_sha3_384() {
+        let tests = [("416c6c20796f75722062617365206172652062656c6f6e6720746f207573",
+            "966ee786ab3482dd811bf7c8fa8db79aa1f52f6c3c369942ef14240ebd857c6ff626ec35d9e131ff64d328\
+            ef2008ff16"
+        )];
+
+        for test in tests.iter() {
+            hash_test(MessageDigest::sha3_384(), test);
+        }
+    }
+
+    #[cfg(ossl111)]
+    #[test]
+    fn test_sha3_512() {
+        let tests = [("416c6c20796f75722062617365206172652062656c6f6e6720746f207573",
+            "c072288ef728cd53a029c47687960b9225893532f42b923156e37020bdc1eda753aafbf30af859d4f4c3a1\
+            807caee3a79f8eb02dcd61589fbbdf5f40c8787a72"
+        )];
+
+        for test in tests.iter() {
+            hash_test(MessageDigest::sha3_512(), test);
         }
     }
 


### PR DESCRIPTION
This PR adds SHA3 & SHAKE128/256 support to the crate with appropriate tests and an example of SHAKE128.

SHA3 can be used the same way as all pre-existing message digests.
SHAKE128/256 however, must use the XOF variants `Hasher::finish_xof` and `openssl::hash::hash_xof`.