### PR TITLE
Fix cargo dependency documentation

### DIFF
--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -16,7 +16,7 @@
 //! 
 //! ```toml
 //! [dependencies]
-//! openssl = { version = "0.10", feature = ["vendored"] }
+//! openssl = { version = "0.10", features = ["vendored"] }
 //! ```
 //! 
 //! The vendored copy will not be configured to automatically find the system's root certificates, but the


### PR DESCRIPTION
`feature` -> `features`

As documented, you'd get the follow warning: `warning: unused manifest key: dependencies.openssl.feature`