### PR TITLE
Explicitly support LibreSSL 2.9.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,6 @@ openssl_101: &OPENSSL_101
 libressl_250: &LIBRESSL_250
   LIBRARY: libressl
   VERSION: 2.5.0
-libressl_28x: &LIBRESSL_28x
-  LIBRARY: libressl
-  VERSION: 2.8.2
 libressl_290: &LIBRESSL_290
   LIBRARY: libressl
   VERSION: 2.9.0
@@ -196,10 +193,6 @@ jobs:
     <<: *JOB
     environment:
       <<: [*LIBRESSL_250, *X86_64, *BASE]
-  x86_64-libressl-2.8.x:
-    <<: *JOB
-    environment:
-      <<: [*LIBRESSL_28x, *X86_64, *BASE]
   x86_64-libressl-2.9.0:
     <<: *JOB
     environment:
@@ -231,6 +224,6 @@ workflows:
     - armhf-openssl-1.1.0
     - armhf-openssl-1.0.2
     - x86_64-libressl-2.5.0
-    - x86_64-libressl-2.8.x
+    - x86_64-libressl-2.9.0
     - macos
     - macos-vendored

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,9 @@ libressl_250: &LIBRESSL_250
 libressl_28x: &LIBRESSL_28x
   LIBRARY: libressl
   VERSION: 2.8.2
+libressl_290: &LIBRESSL_290
+  LIBRARY: libressl
+  VERSION: 2.9.0
 
 x86_64: &X86_64
   TARGET: x86_64-unknown-linux-gnu
@@ -197,6 +200,10 @@ jobs:
     <<: *JOB
     environment:
       <<: [*LIBRESSL_28x, *X86_64, *BASE]
+  x86_64-libressl-2.9.0:
+    <<: *JOB
+    environment:
+      <<: [*LIBRESSL_290, *X86_64, *BASE]
   macos:
     <<: *MACOS_JOB
     environment:

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -504,6 +504,7 @@ See rust-openssl README for more information:
             (8, 0) => ('8', '0'),
             (8, 1) => ('8', '1'),
             (8, _) => ('8', 'x'),
+            (9, 0) => ('9', '0'),
             _ => version_error(),
         };
 
@@ -544,7 +545,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 2.8.1, but a different version of OpenSSL was found. The build is now aborting
+through 2.9.0, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "


### PR DESCRIPTION
My OpenBSD-current machine reports LibreSSL 2.9.0 (https://github.com/libressl-portable/openbsd/commit/091c2f11e0cdcdbe529170fc394fe359922c0e34). This hasn't yet had a formal release AFAICS, but it does mean that openssl-sys can't build. Nothing has changed in a bad way since 2.8.2 that I can see from the logs, and `cargo test` passes. However, since it's not clear to me if further 2.9.* releases would maintain any such guarantees, I've conservatively restricted things to only match against 2.9.0.