### PR TITLE
Add some additional CMS methods

### DIFF
--- a/openssl-sys/src/asn1.rs
+++ b/openssl-sys/src/asn1.rs
@@ -25,6 +25,7 @@ extern "C" {
 stack!(stack_st_ASN1_OBJECT);
 
 extern "C" {
+    pub fn OBJ_txt2obj(oid: *const c_char, no_name: c_int) -> *mut ASN1_OBJECT;
     pub fn ASN1_STRING_type_new(ty: c_int) -> *mut ASN1_STRING;
     #[cfg(any(ossl110, libressl273))]
     pub fn ASN1_STRING_get0_data(x: *const ASN1_STRING) -> *const c_uchar;

--- a/openssl-sys/src/cms.rs
+++ b/openssl-sys/src/cms.rs
@@ -1,6 +1,7 @@
 use libc::*;
 
 pub enum CMS_ContentInfo {}
+pub enum CMS_SignerInfo {}
 
 extern "C" {
     #[cfg(ossl101)]
@@ -56,6 +57,15 @@ pub const CMS_ASCIICRLF: c_uint = 0x80000;
 
 extern "C" {
     #[cfg(ossl101)]
+    pub fn CMS_decrypt(
+        cms: *mut ::CMS_ContentInfo,
+        pkey: *mut ::EVP_PKEY,
+        cert: *mut ::X509,
+        dcont: *mut ::BIO,
+        out: *mut ::BIO,
+        flags: c_uint,
+    ) -> c_int;
+    #[cfg(ossl101)]
     pub fn SMIME_read_CMS(bio: *mut ::BIO, bcont: *mut *mut ::BIO) -> *mut ::CMS_ContentInfo;
 
     #[cfg(ossl101)]
@@ -66,14 +76,43 @@ extern "C" {
         data: *mut ::BIO,
         flags: c_uint,
     ) -> *mut ::CMS_ContentInfo;
-
     #[cfg(ossl101)]
-    pub fn CMS_decrypt(
+    pub fn CMS_add1_signer(
         cms: *mut ::CMS_ContentInfo,
+        signcert: *mut ::X509,
         pkey: *mut ::EVP_PKEY,
-        cert: *mut ::X509,
+        md: *const ::EVP_MD,
+        flags: c_uint,
+    ) -> *mut ::CMS_SignerInfo;
+    #[cfg(ossl101)]
+    pub fn CMS_final(
+        cms: *mut ::CMS_ContentInfo,
+        data: *mut ::BIO,
         dcont: *mut ::BIO,
+        flags: c_uint,
+    ) -> c_int;
+    #[cfg(ossl101)]
+    pub fn CMS_verify(
+        cms: *mut ::CMS_ContentInfo,
+        certs: *mut ::stack_st_X509,
+        store: *mut ::X509_STORE,
+        indata: *mut ::BIO,
         out: *mut ::BIO,
         flags: c_uint,
     ) -> c_int;
+    #[cfg(ossl101)]
+    pub fn d2i_CMS_ContentInfo(
+        a: *mut *mut ::CMS_ContentInfo,
+        ppin: *mut *const c_uchar,
+        length: c_long,
+    ) -> *mut ::CMS_ContentInfo;
+    pub fn CMS_signed_add1_attr_by_OBJ(
+        si: *mut ::CMS_SignerInfo,
+        obj: *const ::ASN1_OBJECT,
+        bytes_type: c_int,
+        bytes: *const c_void,
+        len: c_int,
+    ) -> c_int;
+    #[cfg(ossl101)]
+    pub fn CMS_SignerInfo_sign(si: *mut ::CMS_SignerInfo) -> c_int;
 }

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -27,6 +27,7 @@
 use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_char, c_int, c_long};
+use std::ffi::CString;
 use std::fmt;
 use std::ptr;
 use std::slice;
@@ -271,6 +272,18 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [`Asn1Object`]: struct.Asn1Object.html
     pub struct Asn1ObjectRef;
+}
+
+impl Asn1Object {
+    /// Returns an ASN1_object from a given OID in text form.
+    pub fn from_txt(oid: &str, no_name: bool) -> Asn1Object {
+        unsafe {
+            Asn1Object::from_ptr(ffi::OBJ_txt2obj(
+                CString::new(oid).unwrap().as_ptr(),
+                no_name as c_int,
+            ))
+        }
+    }
 }
 
 impl Asn1ObjectRef {


### PR DESCRIPTION
This adds the following methods:
- Asn1Object::from_txt
- CmsContentInfo::add_signer
- CmsContentInfo::verify
- CmsContentInfo::partial

Documentation is still pending and should be addressed in the next commit, but I'd be grateful for a code review.