### PR TITLE
Add session cache to SslConnector

### DIFF
--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -24,6 +24,7 @@ cfg-if = "0.1"
 foreign-types = "0.3.1"
 lazy_static = "1"
 libc = "0.2"
+linked_hash_set = "0.1"
 
 openssl-sys = { version = "0.9.40", path = "../openssl-sys" }
 

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -118,6 +118,7 @@ extern crate foreign_types;
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
+extern crate linked_hash_set;
 extern crate openssl_sys as ffi;
 
 #[cfg(test)]

--- a/openssl/src/ssl/cache.rs
+++ b/openssl/src/ssl/cache.rs
@@ -1,0 +1,82 @@
+use linked_hash_set::LinkedHashSet;
+use ssl::{SslSession, SslSessionRef};
+use std::borrow::Borrow;
+use std::collections::hash_map::{Entry, HashMap};
+use std::hash::{Hash, Hasher};
+
+#[derive(Hash, PartialEq, Eq, Clone)]
+pub struct SessionKey {
+    pub host: String,
+    pub port: u16,
+}
+
+#[derive(Clone)]
+struct HashSession(SslSession);
+
+impl PartialEq for HashSession {
+    fn eq(&self, other: &HashSession) -> bool {
+        self.0.id() == other.0.id()
+    }
+}
+
+impl Eq for HashSession {}
+
+impl Hash for HashSession {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.0.id().hash(state);
+    }
+}
+
+impl Borrow<[u8]> for HashSession {
+    fn borrow(&self) -> &[u8] {
+        self.0.id()
+    }
+}
+
+pub struct SessionCache {
+    sessions: HashMap<SessionKey, LinkedHashSet<HashSession>>,
+    reverse: HashMap<HashSession, SessionKey>,
+}
+
+impl SessionCache {
+    pub fn new() -> SessionCache {
+        SessionCache {
+            sessions: HashMap::new(),
+            reverse: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, key: SessionKey, session: SslSession) {
+        let session = HashSession(session);
+
+        self.sessions
+            .entry(key.clone())
+            .or_insert_with(LinkedHashSet::new)
+            .insert(session.clone());
+        self.reverse.insert(session.clone(), key);
+    }
+
+    pub fn get(&mut self, key: &SessionKey) -> Option<SslSession> {
+        let sessions = self.sessions.get_mut(key)?;
+        let session = sessions.front().cloned()?;
+        sessions.refresh(&session);
+        Some(session.0)
+    }
+
+    pub fn remove(&mut self, session: &SslSessionRef) {
+        let key = match self.reverse.remove(session.id()) {
+            Some(key) => key,
+            None => return,
+        };
+
+        if let Entry::Occupied(mut sessions) = self.sessions.entry(key) {
+            sessions.get_mut().remove(session.id());
+            if sessions.get().is_empty() {
+                sessions.remove();
+            }
+        }
+    }
+}

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -107,6 +107,7 @@ pub use ssl::connector::{
 pub use ssl::error::{Error, ErrorCode, HandshakeError};
 
 mod bio;
+mod cache;
 mod callbacks;
 mod connector;
 mod error;

--- a/openssl/src/ssl/test.rs
+++ b/openssl/src/ssl/test.rs
@@ -1435,6 +1435,66 @@ fn new_session_callback() {
 }
 
 #[test]
+fn connector_use_session_cache() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
+    ctx.set_certificate_file(&Path::new("test/cert.pem"), SslFiletype::PEM)
+        .unwrap();
+    ctx.set_private_key_file(&Path::new("test/key.pem"), SslFiletype::PEM)
+        .unwrap();
+    ctx.set_session_id_context(b"foo").unwrap();
+    let ctx = ctx.build();
+
+    let guard = thread::spawn(move || {
+        for i in 0..10 {
+            let stream = listener.accept().unwrap().0;
+            let ssl = Ssl::new(&ctx).unwrap();
+            let mut stream = ssl.accept(stream).unwrap();
+            stream.write_all(&[0]).unwrap();
+
+            if i > 0 {
+                assert!(stream.ssl().session_reused());
+            } else {
+                assert!(!stream.ssl().session_reused());
+            }
+        }
+    });
+
+    let mut connector_builder = SslConnector::builder(SslMethod::tls()).unwrap();
+    connector_builder.set_use_session_cache(true);
+    connector_builder.set_verify(SslVerifyMode::NONE);
+    let connector = connector_builder.build();
+
+    for i in 0..10 {
+        let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+
+        let mut config = connector.configure().unwrap();
+        config.set_session_cache_key("127.0.0.1".to_string(), port);
+        config.set_use_server_name_indication(false);
+        config.set_verify_hostname(false);
+
+        let mut stream = config.connect("127.0.0.1", stream).unwrap();
+
+        // Give server a chance to send the ticket in TLS 1.3, where the ticket
+        // can be sent after the handshake.
+        stream.read_exact(&mut [0]).unwrap();
+
+        // OpenSSL removes the session unless shut down.
+        stream.set_shutdown(ShutdownState::SENT);
+
+        if i > 0 {
+            assert!(stream.ssl().session_reused());
+        } else {
+            assert!(!stream.ssl().session_reused());
+        }
+    }
+
+    guard.join().unwrap();
+}
+
+#[test]
 fn keying_export() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
Currently to setting up session cache on the client side requires a bunch of callbacks and unsafe fn. This PR makes it easier by adding an opt-in cache storage to SslConnector, and exposes a simple and safe API (`set_use_session_cache` `set_session_cache_key`) for common use-cases. Existing applications will not change their behavior.

The relevant SessionCache code was copied from hyper-openssl.