### PR TITLE
Add a crate to define custom error libraries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,12 @@ jobs:
                   --manifest-path=systest/Cargo.toml \
                   <<# parameters.vendored >>--features vendored<</ parameters.vendored >> \
                   --target << parameters.target >>
+            - run: |
+                cargo test \
+                  --manifest-path=openssl-errors/Cargo.toml \
+                  <<# parameters.vendored >>--features openssl-sys/vendored<</ parameters.vendored >> \
+                  --target << parameters.target >> \
+                  <<# parameters.no_run >>--no-run<</ parameters.no_run >>
       - run: |
           ulimit -c unlimited
           export PATH=$OPENSSL_DIR/bin:$PATH
@@ -176,6 +182,10 @@ jobs:
           cargo run \
             --manifest-path=systest/Cargo.toml \
             <<# parameters.vendored >> --features vendored <</ parameters.vendored >>
+      - run: |
+          cargo run \
+            --manifest-path=openssl-errors/Cargo.toml \
+            <<# parameters.vendored >> --features openssl-sys/vendored <</ parameters.vendored >>
       - run: |
           PATH=/usr/local/opt/openssl/bin:$PATH
           cargo test \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
             --manifest-path=systest/Cargo.toml \
             <<# parameters.vendored >> --features vendored <</ parameters.vendored >>
       - run: |
-          cargo run \
+          cargo test \
             --manifest-path=openssl-errors/Cargo.toml \
             <<# parameters.vendored >> --features openssl-sys/vendored <</ parameters.vendored >>
       - run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,7 @@
 [workspace]
-members = ["openssl", "openssl-sys", "systest"]
+members = [
+    "openssl",
+    "openssl-errors",
+    "openssl-sys",
+    "systest",
+]

--- a/openssl-errors/Cargo.toml
+++ b/openssl-errors/Cargo.toml
@@ -3,6 +3,11 @@ name = "openssl-errors"
 version = "0.1.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
+license = "MIT/Apache-2.0"
+description = "Custom error library support for the openssl crate."
+repository = "https://github.com/sfackler/rust-openssl"
+readme = "README.md"
+categories = ["api-bindings"]
 
 [dependencies]
 libc = "0.2"

--- a/openssl-errors/Cargo.toml
+++ b/openssl-errors/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "openssl-errors"
+version = "0.1.0"
+authors = ["Steven Fackler <sfackler@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+libc = "0.2"
+
+openssl-sys = { version = "0.9.42", path = "../openssl-sys" }
+
+[dev-dependencies]
+openssl = { version = "0.10.19", path = "../openssl" }

--- a/openssl-errors/LICENSE-APACHE
+++ b/openssl-errors/LICENSE-APACHE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/openssl-errors/LICENSE-MIT
+++ b/openssl-errors/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Steven Fackler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openssl-errors/README.md
+++ b/openssl-errors/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/openssl-errors/src/lib.rs
+++ b/openssl-errors/src/lib.rs
@@ -1,0 +1,213 @@
+use libc::{c_char, c_int};
+use std::ptr;
+use std::borrow::Cow;
+use std::marker::PhantomData;
+
+#[doc(hidden)]
+pub mod export {
+    pub use libc::{c_char, c_int};
+    pub use openssl_sys::{
+        init, ERR_get_next_error_library, ERR_load_strings, ERR_PACK, ERR_STRING_DATA,
+    };
+    pub use std::borrow::Cow;
+    pub use std::option::Option;
+    pub use std::ptr::null;
+    pub use std::sync::Once;
+}
+
+pub trait Library {
+    fn id() -> c_int;
+}
+
+pub struct Function<T>(c_int, PhantomData<T>);
+
+impl<T> Function<T> {
+    #[inline]
+    pub const fn from_raw(raw: c_int) -> Function<T> {
+        Function(raw, PhantomData)
+    }
+
+    #[inline]
+    pub const fn as_raw(&self) -> c_int {
+        self.0
+    }
+}
+
+pub struct Reason<T>(c_int, PhantomData<T>);
+
+impl<T> Reason<T> {
+    #[inline]
+    pub const fn from_raw(raw: c_int) -> Reason<T> {
+        Reason(raw, PhantomData)
+    }
+
+    #[inline]
+    pub const fn as_raw(&self) -> c_int {
+        self.0
+    }
+}
+
+/// This is not considered part of this crate's public API. It is subject to change at any time.
+///
+/// # Safety
+///
+/// `file` and `message` must be null-terminated.
+#[doc(hidden)]
+pub unsafe fn __put_error<T>(
+    func: Function<T>,
+    reason: Reason<T>,
+    file: &'static str,
+    line: u32,
+    message: Option<Cow<'static, str>>,
+) where
+    T: Library,
+{
+    openssl_sys::ERR_put_error(
+        T::id(),
+        func.as_raw(),
+        reason.as_raw(),
+        file.as_ptr() as *const c_char,
+        line as c_int,
+    );
+    let data = match message {
+        Some(Cow::Borrowed(s)) => Some((s.as_ptr() as *const c_char as *mut c_char, 0)),
+        Some(Cow::Owned(s)) => {
+            let ptr = openssl_sys::CRYPTO_malloc(
+                s.len() as _,
+                concat!(file!(), "\0").as_ptr() as *const c_char,
+                line!() as c_int,
+            ) as *mut c_char;
+            if ptr.is_null() {
+                None
+            } else {
+                ptr::copy_nonoverlapping(s.as_ptr(), ptr as *mut u8, s.len());
+                Some((ptr, openssl_sys::ERR_TXT_MALLOCED))
+            }
+        }
+        None => None
+    };
+    if let Some((ptr, flags)) = data {
+        openssl_sys::ERR_set_error_data(ptr, flags | openssl_sys::ERR_TXT_STRING);
+    }
+}
+
+#[macro_export]
+macro_rules! put_error {
+    ($function:expr, $reason:expr) => {
+        unsafe {
+            $crate::__put_error(
+                $function,
+                $reason,
+                concat!(file!(), "\0"),
+                line!(),
+                $crate::export::Option::None,
+            );
+        }
+    };
+    ($function:expr, $reason:expr, $message:expr) => {
+        unsafe {
+            $crate::__put_error(
+                $function,
+                $reason,
+                concat!(file!(), "\0"),
+                line!(),
+                $crate::export::Option::Some($crate::export::Cow::Borrowed(
+                    concat!($message, "\0"),
+                )),
+            );
+        }
+    };
+    ($function:expr, $reason:expr, $message:expr, $($args:tt)*) => {
+        unsafe {
+            $crate::__put_error(
+                $function,
+                $reason,
+                concat!(file!(), "\0"),
+                line!(),
+                $crate::export::Option::Some($crate::export::Cow::Owned(
+                    format!(concat!($message, "\0"), $($args)*)),
+                ),
+            );
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! openssl_errors {
+    ($(
+        $lib_vis:vis library $lib_name:ident($lib_str:expr) {
+            functions {
+                $(
+                    $func_name:ident($func_str:expr);
+                )*
+            }
+
+            reasons {
+                $(
+                    $reason_name:ident($reason_str:expr);
+                )*
+            }
+        }
+    )*) => {$(
+        $lib_vis enum $lib_name {}
+
+        impl $crate::Library for $lib_name {
+            fn id() -> $crate::export::c_int {
+                static INIT: $crate::export::Once = $crate::export::Once::new();
+                static mut LIB_NUM: $crate::export::c_int = 0;
+                static mut STRINGS: [$crate::export::ERR_STRING_DATA; 2 + $crate::openssl_errors!(@count $($func_name;)* $($reason_name;)*)] = [
+                    $crate::export::ERR_STRING_DATA {
+                        error: 0,
+                        string: concat!($lib_str, "\0").as_ptr() as *const $crate::export::c_char,
+                    },
+                    $(
+                        $crate::export::ERR_STRING_DATA {
+                            error: $crate::export::ERR_PACK(0, $lib_name::$func_name.as_raw(), 0),
+                            string: concat!($func_str, "\0").as_ptr() as *const $crate::export::c_char,
+                        },
+                    )*
+                    $(
+                        $crate::export::ERR_STRING_DATA {
+                            error: $crate::export::ERR_PACK(0, 0, $lib_name::$reason_name.as_raw()),
+                            string: concat!($reason_str, "\0").as_ptr() as *const $crate::export::c_char,
+                        },
+                    )*
+                    $crate::export::ERR_STRING_DATA {
+                        error: 0,
+                        string: $crate::export::null(),
+                    }
+                ];
+
+                unsafe {
+                    INIT.call_once(|| {
+                        $crate::export::init();
+                        LIB_NUM = $crate::export::ERR_get_next_error_library();
+                        STRINGS[0].error = $crate::export::ERR_PACK(LIB_NUM, 0, 0);
+                        $crate::export::ERR_load_strings(LIB_NUM, STRINGS.as_mut_ptr());
+                    });
+
+                    LIB_NUM
+                }
+            }
+        }
+
+        impl $lib_name {
+            $crate::openssl_errors!(@func_consts $lib_name; 1; $($func_name;)*);
+            $crate::openssl_errors!(@reason_consts $lib_name; 1; $($reason_name;)*);
+        }
+    )*};
+    (@func_consts $lib_name:ident; $n:expr; $name:ident; $($tt:tt)*) => {
+        pub const $name: $crate::Function<$lib_name> = $crate::Function::from_raw($n);
+        $crate::openssl_errors!(@func_consts $lib_name; $n + 1; $($tt)*);
+    };
+    (@func_consts $lib_name:ident; $n:expr;) => {};
+    (@reason_consts $lib_name:ident; $n:expr; $name:ident; $($tt:tt)*) => {
+        pub const $name: $crate::Reason<$lib_name> = $crate::Reason::from_raw($n);
+        $crate::openssl_errors!(@reason_consts $lib_name; $n + 1; $($tt)*);
+    };
+    (@reason_consts $lib_name:ident; $n:expr;) => {};
+    (@count $i:ident; $($tt:tt)*) => {
+        1 + $crate::openssl_errors!(@count $($tt)*)
+    };
+    (@count) => { 0 };
+}

--- a/openssl-errors/src/lib.rs
+++ b/openssl-errors/src/lib.rs
@@ -45,6 +45,7 @@
 //! println!("{}", Error::get().unwrap());
 //! ```
 #![warn(missing_docs)]
+#![doc(html_root_url = "https://docs.rs/openssl-errors/0.1")]
 
 use libc::{c_char, c_int};
 use std::borrow::Cow;

--- a/openssl-errors/tests/test.rs
+++ b/openssl-errors/tests/test.rs
@@ -1,0 +1,54 @@
+use openssl::error::Error;
+
+openssl_errors::openssl_errors! {
+    library Test("test library") {
+        functions {
+            FOO("function foo");
+            BAR("function bar");
+        }
+
+        reasons {
+            NO_MILK("out of milk");
+            NO_BACON("out of bacon");
+        }
+    }
+}
+
+#[test]
+fn basic() {
+    openssl_errors::put_error!(Test::FOO, Test::NO_MILK);
+
+    let error = Error::get().unwrap();
+    assert_eq!(error.library().unwrap(), "test library");
+    assert_eq!(error.function().unwrap(), "function foo");
+    assert_eq!(error.reason().unwrap(), "out of milk");
+    assert_eq!(error.file(), "openssl-errors/tests/test.rs");
+    assert_eq!(error.line(), 19);
+    assert_eq!(error.data(), None);
+}
+
+#[test]
+fn static_data() {
+    openssl_errors::put_error!(Test::BAR, Test::NO_BACON, "foobar");
+
+    let error = Error::get().unwrap();
+    assert_eq!(error.library().unwrap(), "test library");
+    assert_eq!(error.function().unwrap(), "function bar");
+    assert_eq!(error.reason().unwrap(), "out of bacon");
+    assert_eq!(error.file(), "openssl-errors/tests/test.rs");
+    assert_eq!(error.line(), 32);
+    assert_eq!(error.data(), Some("foobar"));
+}
+
+#[test]
+fn dynamic_data() {
+    openssl_errors::put_error!(Test::BAR, Test::NO_MILK, "hello {}", "world");
+
+    let error = Error::get().unwrap();
+    assert_eq!(error.library().unwrap(), "test library");
+    assert_eq!(error.function().unwrap(), "function bar");
+    assert_eq!(error.reason().unwrap(), "out of milk");
+    assert_eq!(error.file(), "openssl-errors/tests/test.rs");
+    assert_eq!(error.line(), 45);
+    assert_eq!(error.data(), Some("hello world"));
+}


### PR DESCRIPTION
This isn't going to live in openssl itself until I'm more confident that this is the right API.