### PR TITLE
Tell dependencies if vendored OpenSSL was used

### DIFF
--- a/openssl-sys/build/find_vendored.rs
+++ b/openssl-sys/build/find_vendored.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 pub fn get_openssl(_target: &str) -> (PathBuf, PathBuf) {
     let artifacts = openssl_src::Build::new().build();
+    println!("cargo:vendored=1");
     (
         artifacts.lib_dir().to_path_buf(),
         artifacts.include_dir().to_path_buf(),


### PR DESCRIPTION
The system OpenSSL knows where its certificates are. If
DEP_OPENSSL_VENDORED is not set:
- openssl-probe doesn't need to set any environment variables and can
get the paths from OpenSSL itself.
- Libraries that normally use `openssl_probe::probe()` and
`SSL_CTX_load_verify_locations` can instead use
`SSL_CTX_set_default_verify_paths`.

If it is set, programs can show a big scary warning that a potentially
ancient version of OpenSSL is used.