### PR TITLE
Remove size check panic on Crypter::{update,finalize}()

### DIFF
--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -492,12 +492,9 @@ impl Crypter {
     ///
     /// # Panics
     ///
-    /// Panics if `output.len() < input.len() + block_size` where
-    /// `block_size` is the block size of the cipher (see `Cipher::block_size`),
-    /// or if `output.len() > c_int::max_value()`.
+    /// Panics if `output.len() > c_int::max_value()`.
     pub fn update(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize, ErrorStack> {
         unsafe {
-            assert!(output.len() >= input.len() + self.block_size);
             assert!(output.len() <= c_int::max_value() as usize);
             let mut outl = output.len() as c_int;
             let inl = input.len() as c_int;
@@ -520,13 +517,8 @@ impl Crypter {
     /// The number of bytes written to `output` is returned.
     ///
     /// `update` should not be called after this method.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `output` is less than the cipher's block size.
     pub fn finalize(&mut self, output: &mut [u8]) -> Result<usize, ErrorStack> {
         unsafe {
-            assert!(output.len() >= self.block_size);
             let mut outl = cmp::min(output.len(), c_int::max_value() as usize) as c_int;
 
             cvt(ffi::EVP_CipherFinal(


### PR DESCRIPTION
The size of the output is deterministic for the size of the input. This means
that the caller can know when a buffer that is less than the existing check is
sufficient. This is particularly common in key wrapping scenarios.
    
For example, if I want to wrap two 16-byte keys using AES-CBC, the resulting
ciphertext will always be 32 bytes. Thus, I create a 32-byte buffer and call
`Crypter::update()` twice; once for each key. The first call succeeds, but the
second call panics. This is true even though the buffer is exactly the size
needed. Likewise, if both `Crypter::update()` calls succeed, the
`Crypter::finalize()` function will also panic.
    
We should, therefore, let `EVP_CipherUpdate()` and `EVP_CipherFinal()` generate any
errors when the output buffer has insufficient size and not try and be smarter
than the functions we are wrapping.