### PR TITLE
Switch from `rustc_version` to `autocfg`

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2"
 cc = "1.0"
 openssl-src = { version = "111.0.1", optional = true }
 pkg-config = "0.3.9"
-rustc_version = "0.2"
+autocfg = "0.1.2"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -2,7 +2,7 @@ extern crate cc;
 #[cfg(feature = "vendored")]
 extern crate openssl_src;
 extern crate pkg_config;
-extern crate rustc_version;
+extern crate autocfg;
 #[cfg(target_env = "msvc")]
 extern crate vcpkg;
 
@@ -94,9 +94,9 @@ fn main() {
 }
 
 fn check_rustc_versions() {
-    let version = rustc_version::version().unwrap();
+    let cfg = autocfg::new();
 
-    if version >= rustc_version::Version::new(1, 31, 0) {
+    if cfg.probe_rustc_version(1, 31) {
         println!("cargo:rustc-cfg=const_fn");
     }
 }


### PR DESCRIPTION
This switches the `openssl-sys` crate from using `rustc_version` as a
crate to check the version of rustc to using `autocfg`. While
functionally the same this has a few advantages:

* The `autocfg` crate has fewer dependencies and compiles faster
* If the `semver` crate has the `serde` feature activated, turns out
  `openssl-sys` gets compiled quite late in the dependency graph which
  can push back further C compilations. This is due to the slower
  compilation time of `serde` itself.
* The `autocfg` crate I believe is a bit more robust in terms of being
  flexible with the output of rustc itself.