### PR TITLE
Add SSL_CTX_add_client_CA on OpenSSL

### DIFF
--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -1093,6 +1093,9 @@ extern "C" {
 
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, list: *mut stack_st_X509_NAME);
 
+    #[cfg(not(libressl))]
+    pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, cacert: *mut X509) -> c_int;
+
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> c_int;
     pub fn SSL_CTX_load_verify_locations(
         ctx: *mut SSL_CTX,

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -870,6 +870,23 @@ impl SslContextBuilder {
         }
     }
 
+    /// Add the provided CA certificate to the list sent by the server to the client when
+    /// requesting client-side TLS authentication.
+    ///
+    /// This corresponds to [`SSL_CTX_add_client_CA`].
+    ///
+    /// [`SSL_CTX_add_client_CA`]: https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_client_CA_list.html
+    #[cfg(not(libressl))]
+    pub fn add_client_ca(&mut self, cacert: &mut X509) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::SSL_CTX_add_client_CA(
+                self.as_ptr(),
+                cacert.as_ptr()
+            ))
+            .map(|_| ())
+        }
+    }
+
     /// Set the context identifier for sessions.
     ///
     /// This value identifies the server's session cache to clients, telling them when they're

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -877,7 +877,7 @@ impl SslContextBuilder {
     ///
     /// [`SSL_CTX_add_client_CA`]: https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_client_CA_list.html
     #[cfg(not(libressl))]
-    pub fn add_client_ca(&mut self, cacert: &mut X509) -> Result<(), ErrorStack> {
+    pub fn add_client_ca(&mut self, cacert: &mut X509Ref) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::SSL_CTX_add_client_CA(
                 self.as_ptr(),

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -877,7 +877,7 @@ impl SslContextBuilder {
     ///
     /// [`SSL_CTX_add_client_CA`]: https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_client_CA_list.html
     #[cfg(not(libressl))]
-    pub fn add_client_ca(&mut self, cacert: &mut X509Ref) -> Result<(), ErrorStack> {
+    pub fn add_client_ca(&mut self, cacert: &X509Ref) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::SSL_CTX_add_client_CA(
                 self.as_ptr(),


### PR DESCRIPTION
Currently this crate only exposes the `SSL_CTX_set_client_CA_list` function, which requires an owned stack of x509 names.  As far as I can tell, the only way to get such a stack is to call the `SSL_load_client_CA_file` function which reads files from the disk.

With this PR one can load a x509 from memory and add it the client list without needing to touch the disk (and there's already functions to add CAs, keys, certificate chains etc. from memory).