### PR TITLE
Display for Error incorrectly showing func instead of reason.

### DIFF
--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -273,7 +273,7 @@ impl fmt::Display for Error {
         }
         match self.reason() {
             Some(r) => write!(fmt, ":{}", r)?,
-            None => write!(fmt, ":reason({})", ffi::ERR_GET_FUNC(self.code()))?,
+            None => write!(fmt, ":reason({})", ffi::ERR_GET_REASON(self.code()))?,
         }
         write!(
             fmt,


### PR DESCRIPTION
I found a small copy-paste error in the implementation of `Display` for `Error`.