### PR TITLE
Add Debug impl for EcKey

### DIFF
--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -34,6 +34,7 @@
 use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
+use std::fmt;
 use std::ptr;
 
 use bn::{BigNumContextRef, BigNumRef};
@@ -822,6 +823,12 @@ impl EcKey<Private> {
 impl<T> Clone for EcKey<T> {
     fn clone(&self) -> EcKey<T> {
         (**self).to_owned()
+    }
+}
+
+impl<T> fmt::Debug for EcKey<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "EcKey")
     }
 }
 


### PR DESCRIPTION
This is a small PR to implement Debug trait for EcKey. 
There exists Debug impl. for Rsa and Dsa, but not EcKey. It is inconvenient to derive Debug for structs containing EcKey. So I impl Debug trait for EcKey like Rsa and Dsa does. 
