### PR TITLE
Expose EC_GROUP_get0_generator as EcGroup::generator

### DIFF
--- a/openssl-sys/src/ec.rs
+++ b/openssl-sys/src/ec.rs
@@ -30,6 +30,8 @@ extern "C" {
         ctx: *mut BN_CTX,
     ) -> c_int;
 
+    pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
+
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> c_int;
 
     pub fn EC_GROUP_set_asn1_flag(key: *mut EC_GROUP, flag: c_int);


### PR DESCRIPTION
While `EcGroup::mul_generator` can be used to obtain the base point of the curve by multiplying by one, I feel like a more straightforward way would be better.
