### PR TITLE
Expose EC_GROUP_get_cofactor as EcGroup::cofactor

### DIFF
--- a/openssl-sys/src/ec.rs
+++ b/openssl-sys/src/ec.rs
@@ -30,6 +30,12 @@ extern "C" {
         ctx: *mut BN_CTX,
     ) -> c_int;
 
+    pub fn EC_GROUP_get_cofactor(
+        group: *const EC_GROUP,
+        cofactor: *mut BIGNUM,
+        ctx: *mut BN_CTX,
+    ) -> c_int;
+
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> c_int;


### PR DESCRIPTION
It would be nice to expose the proper way to obtain the group cofactor to avoid hardcoding the values, even despite the fact that the cofactor is 1 for most popular curves used with ECDSA.
