### PR TITLE
Expose EC_POINT_dup as EcPoint::to_owned

### DIFF
--- a/openssl-sys/src/ec.rs
+++ b/openssl-sys/src/ec.rs
@@ -82,6 +82,11 @@ extern "C" {
 
     pub fn EC_POINT_free(point: *mut EC_POINT);
 
+    pub fn EC_POINT_dup(
+        p: *const EC_POINT,
+        group: *const EC_GROUP,
+    ) -> *mut EC_POINT;
+
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         p: *const EC_POINT,


### PR DESCRIPTION
Currently there's no easy way to convert `EcPointRef` back to the `EcPoint`.  For example, if `EcKey::public_key()` is called, the only way to get owned `EcPoint` is via serialization/deserialization.

This change leverages existing `EC_POINT_dup` function for straightforward conversion in a similar fashion to `BN_dup` and `BigNum::to_owned`.