### PR TITLE
Expose pem serialize function for DSA private key

### DIFF
--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -80,6 +80,26 @@ impl<T> DsaRef<T>
 where
     T: HasPublic,
 {
+    private_key_to_pem! {
+        /// Serializes the private key to a PEM-encoded DSAPrivateKey structure.
+        ///
+        /// The output will have a header of `-----BEGIN DSA PRIVATE KEY-----`.
+        ///
+        /// This corresponds to [`PEM_write_bio_DSAPrivateKey`].
+        ///
+        /// [`PEM_write_bio_DSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_DSAPrivateKey.html
+        private_key_to_pem,
+        /// Serializes the private key to a PEM-encoded encrypted DSAPrivateKey structure.
+        ///
+        /// The output will have a header of `-----BEGIN DSA PRIVATE KEY-----`.
+        ///
+        /// This corresponds to [`PEM_write_bio_DSAPrivateKey`].
+        ///
+        /// [`PEM_write_bio_DSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_DSAPrivateKey.html
+        private_key_to_pem_passphrase,
+        ffi::PEM_write_bio_DSAPrivateKey
+    }
+
     to_pem! {
         /// Serialies the public key into a PEM-encoded SubjectPublicKeyInfo structure.
         ///


### PR DESCRIPTION
This pull request expose the PEM_write_bio_DSAPrivateKey(). 
There existed private key serialize function for Rsa and EcKey, but not for Dsa. That's weird... 
So, I made this. :grin: 