### PR TITLE
Add Asn1TimeRef::duration_since and Asn1Time::now

### DIFF
--- a/openssl-sys/src/asn1.rs
+++ b/openssl-sys/src/asn1.rs
@@ -41,6 +41,12 @@ extern "C" {
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
     pub fn ASN1_TIME_free(tm: *mut ASN1_TIME);
     pub fn ASN1_TIME_print(b: *mut BIO, tm: *const ASN1_TIME) -> c_int;
+    pub fn ASN1_TIME_diff(
+        pday: *mut c_int,
+        psec: *mut c_int,
+        from: *const ASN1_TIME,
+        to: *const ASN1_TIME,
+    ) -> c_int;
 
     pub fn ASN1_INTEGER_free(x: *mut ASN1_INTEGER);
     pub fn ASN1_INTEGER_get(dest: *const ASN1_INTEGER) -> c_long;


### PR DESCRIPTION
This allows accessing the actual time without having to parse the `Display` output.