### PR TITLE
Added support for Ed25519 and Ed448 signatures

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -10,6 +10,10 @@ pub const EVP_PKEY_RSA: c_int = NID_rsaEncryption;
 pub const EVP_PKEY_DSA: c_int = NID_dsa;
 pub const EVP_PKEY_DH: c_int = NID_dhKeyAgreement;
 pub const EVP_PKEY_EC: c_int = NID_X9_62_id_ecPublicKey;
+#[cfg(ossl111)]
+pub const EVP_PKEY_ED25519: c_int = NID_ED25519;
+#[cfg(ossl111)]
+pub const EVP_PKEY_ED448: c_int = NID_ED448;
 pub const EVP_PKEY_HMAC: c_int = NID_hmac;
 pub const EVP_PKEY_CMAC: c_int = NID_cmac;
 
@@ -150,6 +154,27 @@ cfg_if! {
     } else {
         extern "C" {
             pub fn EVP_PKEY_size(pkey: *mut EVP_PKEY) -> c_int;
+        }
+    }
+}
+cfg_if! {
+    if #[cfg(ossl111)] {
+        extern "C" {
+            pub fn EVP_DigestSign(
+                ctx: *mut EVP_MD_CTX,
+                sigret: *mut c_uchar,
+                siglen: *mut size_t,
+                tbs: *const c_uchar,
+                tbslen: size_t
+            ) -> c_int;
+
+            pub fn EVP_DigestVerify(
+                ctx: *mut EVP_MD_CTX,
+                sigret: *const c_uchar,
+                siglen: size_t,
+                tbs: *const c_uchar,
+                tbslen: size_t
+            ) -> c_int;
         }
     }
 }

--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -912,3 +912,7 @@ pub const NID_rc4_hmac_md5: c_int = 915;
 pub const NID_aes_128_cbc_hmac_sha1: c_int = 916;
 pub const NID_aes_192_cbc_hmac_sha1: c_int = 917;
 pub const NID_aes_256_cbc_hmac_sha1: c_int = 918;
+#[cfg(ossl111)]
+pub const NID_ED25519: c_int = 1087;
+#[cfg(ossl111)]
+pub const NID_ED448: c_int = 1088;

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -90,6 +90,11 @@ impl Id {
     pub const DSA: Id = Id(ffi::EVP_PKEY_DSA);
     pub const DH: Id = Id(ffi::EVP_PKEY_DH);
     pub const EC: Id = Id(ffi::EVP_PKEY_EC);
+
+    #[cfg(ossl111)]
+    pub const ED25519: Id = Id(ffi::EVP_PKEY_ED25519);
+    #[cfg(ossl111)]
+    pub const ED448: Id = Id(ffi::EVP_PKEY_ED448);
 }
 
 /// A trait indicating that a key has parameters.
@@ -424,6 +429,40 @@ impl PKey<Private> {
 
             Ok(PKey::from_ptr(key))
         }
+    }
+
+    #[cfg(ossl110)]
+    fn generate_eddsa(nid: c_int) -> Result<PKey<Private>, ErrorStack> {
+        unsafe {
+            let kctx = cvt_p(ffi::EVP_PKEY_CTX_new_id(nid, ptr::null_mut()))?;
+            let ret = cvt(ffi::EVP_PKEY_keygen_init(kctx));
+            if let Err(e) = ret {
+                ffi::EVP_PKEY_CTX_free(kctx);
+                return Err(e);
+            }
+            let mut key = ptr::null_mut();
+            let ret = cvt(ffi::EVP_PKEY_keygen(kctx, &mut key));
+
+            ffi::EVP_PKEY_CTX_free(kctx);
+
+            if let Err(e) = ret {
+                return Err(e);
+            }
+
+            Ok(PKey::from_ptr(key))
+        }
+    }
+
+    /// Generates a new private Ed25519 key
+    #[cfg(ossl111)]
+    pub fn generate_ed25519() -> Result<PKey<Private>, ErrorStack> {
+        PKey::generate_eddsa(ffi::EVP_PKEY_ED25519)
+    }
+
+    /// Generates a new private Ed448 key
+    #[cfg(ossl111)]
+    pub fn generate_ed448() -> Result<PKey<Private>, ErrorStack> {
+        PKey::generate_eddsa(ffi::EVP_PKEY_ED448)
     }
 
     private_key_from_pem! {

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -279,8 +279,12 @@ impl<'a> Signer<'a> {
     /// OpenSSL documentation at [`EVP_DigestSignFinal`].
     ///
     /// [`EVP_DigestSignFinal`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_DigestSignFinal.html
-    #[cfg(not(ossl111))]
     pub fn len(&self) -> Result<usize, ErrorStack> {
+        self.len_intern()
+    }
+
+    #[cfg(not(ossl111))]
+    fn len_intern(&self) -> Result<usize, ErrorStack> {
         unsafe {
             let mut len = 0;
             cvt(ffi::EVP_DigestSignFinal(
@@ -293,7 +297,7 @@ impl<'a> Signer<'a> {
     }
 
     #[cfg(ossl111)]
-    pub fn len(&self) -> Result<usize, ErrorStack> {
+    fn len_intern(&self) -> Result<usize, ErrorStack> {
         unsafe {
             let mut len = 0;
             cvt(ffi::EVP_DigestSign(


### PR DESCRIPTION
Added constants for Ed25519 and Ed448 as well as oneshot sign and verify function to `Signer` and `Verfier` to support PureEdDSA signatures.