### PR TITLE
Add ssl::set_dtls_mtu_size(usize)

### DIFF
--- a/openssl-sys/src/bio.rs
+++ b/openssl-sys/src/bio.rs
@@ -7,6 +7,7 @@ pub const BIO_TYPE_NONE: c_int = 0;
 pub const BIO_CTRL_EOF: c_int = 2;
 pub const BIO_CTRL_INFO: c_int = 3;
 pub const BIO_CTRL_FLUSH: c_int = 11;
+pub const BIO_CTRL_DGRAM_QUERY_MTU: c_int = 40;
 pub const BIO_C_SET_BUF_MEM_EOF_RETURN: c_int = 130;
 
 extern "C" {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3804,6 +3804,20 @@ impl<S> SslStreamBuilder<S> {
     pub fn ssl(&self) -> &SslRef {
         &self.inner.ssl
     }
+
+    /// Set the DTLS MTU size.
+    ///
+    /// It will be ignored if the value is smaller than the minimum packet size
+    /// the DTLS protocol requires.
+    ///
+    /// # Panics
+    /// This function panics if the given mtu size can't be represented in a positive `c_long` range
+    pub fn set_dtls_mtu_size(&mut self, mtu_size: usize) {
+        unsafe {
+            let bio = self.inner.ssl.get_raw_rbio();
+            bio::set_dtls_mtu_size::<S>(bio, mtu_size);
+        }
+    }
 }
 
 /// The result of a shutdown request.

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -31,7 +31,7 @@ use ssl::{ClientHelloResponse, ExtensionContext};
 use ssl::{
     Error, HandshakeError, MidHandshakeSslStream, ShutdownResult, ShutdownState, Ssl, SslAcceptor,
     SslAcceptorBuilder, SslConnector, SslContext, SslContextBuilder, SslFiletype, SslMethod,
-    SslOptions, SslSessionCacheMode, SslStream, SslVerifyMode, StatusType,
+    SslOptions, SslSessionCacheMode, SslStream, SslStreamBuilder, SslVerifyMode, StatusType,
 };
 #[cfg(ossl102)]
 use x509::store::X509StoreBuilder;
@@ -322,7 +322,9 @@ fn test_connect_with_srtp_ctx() {
         ctx.set_private_key_file(&Path::new("test/key.pem"), SslFiletype::PEM)
             .unwrap();
         let ssl = Ssl::new(&ctx.build()).unwrap();
-        let mut stream = ssl.accept(stream).unwrap();
+        let mut builder = SslStreamBuilder::new(ssl, stream);
+        builder.set_dtls_mtu_size(1500);
+        let mut stream = builder.accept().unwrap();
 
         let mut buf = [0; 60];
         stream
@@ -340,7 +342,9 @@ fn test_connect_with_srtp_ctx() {
     ctx.set_tlsext_use_srtp("SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32")
         .unwrap();
     let ssl = Ssl::new(&ctx.build()).unwrap();
-    let mut stream = ssl.connect(stream).unwrap();
+    let mut builder = SslStreamBuilder::new(ssl, stream);
+    builder.set_dtls_mtu_size(1500);
+    let mut stream = builder.connect().unwrap();
 
     let mut buf = [1; 60];
     {
@@ -390,7 +394,9 @@ fn test_connect_with_srtp_ssl() {
             "SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32",
             profilenames
         );
-        let mut stream = ssl.accept(stream).unwrap();
+        let mut builder = SslStreamBuilder::new(ssl, stream);
+        builder.set_dtls_mtu_size(1500);
+        let mut stream = builder.accept().unwrap();
 
         let mut buf = [0; 60];
         stream
@@ -408,7 +414,9 @@ fn test_connect_with_srtp_ssl() {
     let mut ssl = Ssl::new(&ctx.build()).unwrap();
     ssl.set_tlsext_use_srtp("SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32")
         .unwrap();
-    let mut stream = ssl.connect(stream).unwrap();
+    let mut builder = SslStreamBuilder::new(ssl, stream);
+    builder.set_dtls_mtu_size(1500);
+    let mut stream = builder.connect().unwrap();
 
     let mut buf = [1; 60];
     {


### PR DESCRIPTION
This PR is a followup from [this issue](https://github.com/sfackler/rust-openssl/issues/1155)

`ssl::set_dtls_mtu_size(usize)` globally set the DTLS MTU size.

I first tried to make it a method on `Ssl` or `SslRef`, but I found that they can't be referenced easily from the current structure. Method on `SslStream` was not an option, as user can't access on it before the handshake completes.

But is it practical to use different MTU sized per connection? From my point of view, it's common to have globally configured DTLS MTU size for applications.

# Unresolved questions

- Maybe it's better to make it `Ssl`-local config?

- Should we remain 0 as a default value? I don't think it's sane default for DTLS, but increasing it should considered breaking change?