### PR TITLE
Support LibreSSL 3.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,10 +292,10 @@ workflows:
           library: libressl
           version: 2.5.5
       - linux:
-          name: x86_64-libressl-3.0
+          name: x86_64-libressl-3.0.1
           target: x86_64-unknown-linux-gnu
           library: libressl
-          version: 3.0.0
+          version: 3.0.1
       - macos:
           name: macos
       - macos:

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -202,6 +202,7 @@ See rust-openssl README for more information:
             (2, 9, 0) => ('2', '9', '0'),
             (2, 9, _) => ('2', '9', 'x'),
             (3, 0, 0) => ('3', '0', '0'),
+            (3, 0, 1) => ('3', '0', '1'),
             _ => version_error(),
         };
 
@@ -242,7 +243,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 2.9.x, but a different version of OpenSSL was found. The build is now aborting
+through 3.0.1, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "


### PR DESCRIPTION
[Development release](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.0.1-relnotes.txt).