### PR TITLE
Fix rustc warnings

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -259,7 +259,7 @@ fn parse_version(version: &str) -> u64 {
 
     // and the type specifier suffix
     let version = version.trim_right_matches(|c: char| match c {
-        '0'...'9' | 'a'...'f' | 'A'...'F' => false,
+        '0'..='9' | 'a'..='f' | 'A'..='F' => false,
         _ => true,
     });
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -88,10 +88,10 @@ pub type PasswordCallback = unsafe extern "C" fn(
 #[cfg(ossl110)]
 pub fn init() {
     use std::ptr;
-    use std::sync::{Once, ONCE_INIT};
+    use std::sync::Once;
 
     // explicitly initialize to work around https://github.com/openssl/openssl/issues/3505
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();
 
     INIT.call_once(|| unsafe {
         OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, ptr::null_mut());

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -17,7 +17,7 @@ use error::ErrorStack;
 pub struct StreamState<S> {
     pub stream: S,
     pub error: Option<io::Error>,
-    pub panic: Option<Box<Any + Send>>,
+    pub panic: Option<Box<dyn Any + Send>>,
 }
 
 /// Safe wrapper for BIO_METHOD
@@ -55,7 +55,7 @@ pub unsafe fn take_error<S>(bio: *mut BIO) -> Option<io::Error> {
     state.error.take()
 }
 
-pub unsafe fn take_panic<S>(bio: *mut BIO) -> Option<Box<Any + Send>> {
+pub unsafe fn take_panic<S>(bio: *mut BIO) -> Option<Box<dyn Any + Send>> {
     let state = state::<S>(bio);
     state.panic.take()
 }

--- a/openssl/src/ssl/error.rs
+++ b/openssl/src/ssl/error.rs
@@ -127,7 +127,7 @@ impl error::Error for Error {
         "an OpenSSL error"
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match self.cause {
             Some(InnerError::Io(ref e)) => Some(e),
             Some(InnerError::Ssl(ref e)) => Some(e),
@@ -159,7 +159,7 @@ impl<S: fmt::Debug> StdError for HandshakeError<S> {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             HandshakeError::SetupFailure(ref e) => Some(e),
             HandshakeError::Failure(ref s) | HandshakeError::WouldBlock(ref s) => Some(s.error()),

--- a/openssl/src/ssl/test/server.rs
+++ b/openssl/src/ssl/test/server.rs
@@ -46,8 +46,8 @@ impl Server {
 
 pub struct Builder {
     ctx: SslContextBuilder,
-    ssl_cb: Box<FnMut(&mut SslRef) + Send>,
-    io_cb: Box<FnMut(SslStream<TcpStream>) + Send>,
+    ssl_cb: Box<dyn FnMut(&mut SslRef) + Send>,
+    io_cb: Box<dyn FnMut(SslStream<TcpStream>) + Send>,
     should_error: bool,
 }
 

--- a/openssl/src/util.rs
+++ b/openssl/src/util.rs
@@ -14,7 +14,7 @@ pub struct CallbackState<F> {
     cb: Option<F>,
     /// If the callback panics, we place the panic object here, to be re-thrown once OpenSSL
     /// returns.
-    panic: Option<Box<Any + Send + 'static>>,
+    panic: Option<Box<dyn Any + Send + 'static>>,
 }
 
 impl<F> CallbackState<F> {


### PR DESCRIPTION
Quick PR to fix up some build warnings:

- Use `..=` for inclusive ranges
- Add the `dyn` keyword for trait objects
- Switch from `ONCE_INIT` to `std::sync::Once::new()`