### PR TITLE
add SslConnector builder without setting default verify paths

### DIFF
--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -63,8 +63,17 @@ impl SslConnector {
     ///
     /// The default configuration is subject to change, and is currently derived from Python.
     pub fn builder(method: SslMethod) -> Result<SslConnectorBuilder, ErrorStack> {
+        let mut builder = Self::builder_no_default_verify_paths(method)?;
+        builder.set_default_verify_paths()?;
+        Ok(builder)
+    }
+
+    /// Creates a new builder for TLS connections, without setting the default locations of
+    /// trusted certificates for verification.
+    ///
+    /// The default configuration is subject to change, and is currently derived from Python.
+    pub fn builder_no_default_verify_paths(method: SslMethod) -> Result<SslConnectorBuilder, ErrorStack> {
         let mut ctx = ctx(method)?;
-        ctx.set_default_verify_paths()?;
         ctx.set_cipher_list(
             "DEFAULT:!aNULL:!eNULL:!MD5:!3DES:!DES:!RC4:!IDEA:!SEED:!aDSS:!SRP:!PSK",
         )?;


### PR DESCRIPTION
SSL_CTX_set_default_verify_paths is irreversible, so let users construct a builder without it. i don't exactly intend this PR to land as-is, because i'm not sure what approach you'd want to take API-wise, but it seems removing `ctx.set_default_verify_paths()` from `SslConnector::builder` would be a breaking change, which is why i added a different constructor. Please let me know if there's a different direction you'd like to take.