### PR TITLE
Added clonability for sha hash state.  Useful for incremental hashing

### DIFF
--- a/openssl-sys/src/sha.rs
+++ b/openssl-sys/src/sha.rs
@@ -5,6 +5,7 @@ pub type SHA_LONG = c_uint;
 pub const SHA_LBLOCK: c_int = 16;
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct SHA_CTX {
     pub h0: SHA_LONG,
     pub h1: SHA_LONG,

--- a/openssl-sys/src/sha.rs
+++ b/openssl-sys/src/sha.rs
@@ -26,6 +26,7 @@ extern "C" {
 }
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct SHA256_CTX {
     pub h: [SHA_LONG; 8],
     pub Nl: SHA_LONG,
@@ -49,6 +50,7 @@ extern "C" {
 pub type SHA_LONG64 = u64;
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct SHA512_CTX {
     pub h: [SHA_LONG64; 8],
     pub Nl: SHA_LONG64,

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -146,6 +146,7 @@ impl Sha1 {
 }
 
 /// An object which calculates a SHA224 hash of some data.
+#[derive(Clone)]
 pub struct Sha224(ffi::SHA256_CTX);
 
 impl Sha224 {
@@ -181,6 +182,7 @@ impl Sha224 {
 }
 
 /// An object which calculates a SHA256 hash of some data.
+#[derive(Clone)]
 pub struct Sha256(ffi::SHA256_CTX);
 
 impl Sha256 {
@@ -216,6 +218,7 @@ impl Sha256 {
 }
 
 /// An object which calculates a SHA384 hash of some data.
+#[derive(Clone)]
 pub struct Sha384(ffi::SHA512_CTX);
 
 impl Sha384 {
@@ -251,6 +254,7 @@ impl Sha384 {
 }
 
 /// An object which calculates a SHA512 hash of some data.
+#[derive(Clone)]
 pub struct Sha512(ffi::SHA512_CTX);
 
 impl Sha512 {

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -110,6 +110,7 @@ pub fn sha512(data: &[u8]) -> [u8; 64] {
 ///
 /// SHA1 is known to be insecure - it should not be used unless required for
 /// compatibility with existing systems.
+#[derive(Clone)]
 pub struct Sha1(ffi::SHA_CTX);
 
 impl Sha1 {

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -314,6 +314,20 @@ mod test {
     }
 
     #[test]
+    fn cloning_allows_incremental_hashing() {
+        let expected = "a9993e364706816aba3e25717850c26c9cd0d89d";
+
+        let mut hasher = Sha1::new();
+        hasher.update(b"a");
+
+        let mut incr_hasher = hasher.clone();
+        incr_hasher.update(b"bc");
+
+        assert_eq!(hex::encode(incr_hasher.finish()), expected);
+        assert_ne!(hex::encode(hasher.finish()), expected);
+    }
+
+    #[test]
     fn standalone_224() {
         let data = b"abc";
         let expected = "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7";


### PR DESCRIPTION
This PR adds the ability to clone the hash state.  This is useful for incremental hashing where the base of the hash is constant but some suffix blocks are changing.  As a simple example let's say I have the following base blocks:

```
let base = [0; 512];
let mut hasher = Sha1::new();
hasher.update(&base)
```

I then have a suffix partial block that I want to finish the hash up with that is changing:

```
let suffix = [1; 32];
hasher.update(&suffix);
let hash = hasher.finish();
```

If I then want to see what a different suffix might be like, I have to start all over, even if the base blocks are identical.  Instead with clonability I can do this:

```
let suffix = [1; 32];
let mut hasher2 = hasher.clone();
hasher2.update(&suffix);
let hash = hasher2.finish();

let suffix2 = [2; 32];
let mut hasher3 = hasher.clone();
hasher3.update(&suffix);
let hash = hasher3.finish();
```

The sum total work is far less than having to start over and re-process the base blocks.