### PR TITLE
In the documentation of SslContextBuilder::set_session_id_context, we…

### DIFF
--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -885,7 +885,7 @@ impl SslContextBuilder {
     /// Set the context identifier for sessions.
     ///
     /// This value identifies the server's session cache to clients, telling them when they're
-    /// able to reuse sessions. It should be be set to a unique value per server, unless multiple
+    /// able to reuse sessions. It should be set to a unique value per server, unless multiple
     /// servers share a session cache.
     ///
     /// This value should be set when using client certificates, or each request will fail its


### PR DESCRIPTION
 In the documentation of SslContextBuilder::set_session_id_context, 
we had written "be be" rather than "be". In this commit,
we fix the typo.
