### PR TITLE
Fix documentation typo of "the"

### DIFF
--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1037,7 +1037,7 @@ impl SslContextBuilder {
 
     /// Sets the list of supported ciphers for the TLSv1.3 protocol.
     ///
-    /// The `set_cipher_list` method controls lthe cipher suites for protocols before TLSv1.3.
+    /// The `set_cipher_list` method controls the cipher suites for protocols before TLSv1.3.
     ///
     /// The format consists of TLSv1.3 ciphersuite names separated by `:` characters in order of
     /// preference.


### PR DESCRIPTION
 In the documentation of SslContextBuilder::set_certificate, 
we had written "lthe" rather than "the". In this commit,
we fix the typo.

