### PR TITLE
Remove deprecated Error::description and Error::cause

### DIFF
--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -75,11 +75,7 @@ impl fmt::Display for ErrorStack {
     }
 }
 
-impl error::Error for ErrorStack {
-    fn description(&self) -> &str {
-        "An OpenSSL error stack"
-    }
-}
+impl error::Error for ErrorStack {}
 
 impl From<ErrorStack> for io::Error {
     fn from(e: ErrorStack) -> io::Error {
@@ -285,8 +281,4 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        "an OpenSSL error"
-    }
-}
+impl error::Error for Error {}

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1189,11 +1189,7 @@ impl fmt::Display for X509VerifyResult {
     }
 }
 
-impl Error for X509VerifyResult {
-    fn description(&self) -> &str {
-        "an X509 validation error"
-    }
-}
+impl Error for X509VerifyResult {}
 
 impl X509VerifyResult {
     /// Creates an `X509VerifyResult` from a raw error number.


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon. `Error::cause` has already been deprecated since 1.33.0.

This PR:
- Removes the implementations of `description`
- Replaces `cause` with `source`

Related PR: https://github.com/rust-lang/rust/pull/66919