### PR TITLE
Avoid false-failures if underlying network connection errors

### DIFF
--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -601,7 +601,10 @@ fn default_verify_paths() {
     ctx.set_default_verify_paths().unwrap();
     ctx.set_verify(SslVerifyMode::PEER);
     let ctx = ctx.build();
-    let s = TcpStream::connect("google.com:443").unwrap();
+    let s = match TcpStream::connect("google.com:443") {
+        Ok(s) => s,
+        Err(_) => return,
+    };
     let mut ssl = Ssl::new(&ctx).unwrap();
     ssl.set_hostname("google.com").unwrap();
     let mut socket = ssl.connect(s).unwrap();


### PR DESCRIPTION
In Air-Gapped or otherwise network-restricted environments,
   TcpStream::connect can spuriously fail due to name resolution
   failure, or just in establishing the socket itself.

In this situation, the test can't give a meaningful result, and this
failure doesn't indicate a problem in the OpenSSL stack.

Closes: https://github.com/sfackler/rust-openssl/issues/1215