### PR TITLE
Add EVP_EncryptInit_ex/EVP_EncryptFinish_ex, and the equivalently named

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -122,12 +122,24 @@ extern "C" {
         npubk: c_int,
     ) -> c_int;
     pub fn EVP_SealFinal(ctx: *mut EVP_CIPHER_CTX, out: *mut c_uchar, outl: *mut c_int) -> c_int;
+    pub fn EVP_EncryptInit_ex(
+        ctx: *mut EVP_CIPHER_CTX,
+        cipher: *const EVP_CIPHER,
+        impl_: *mut ENGINE,
+        key: *const c_uchar,
+        iv: *const c_uchar,
+    ) -> c_int;
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut c_uchar,
         outl: *mut c_int,
         in_: *const u8,
         inl: c_int,
+    ) -> c_int;
+    pub fn EVP_EncryptFinal_ex(
+        ctx: *mut EVP_CIPHER_CTX,
+        out: *mut c_uchar,
+        outl: *mut c_int,
     ) -> c_int;
     pub fn EVP_OpenInit(
         ctx: *mut EVP_CIPHER_CTX,
@@ -138,12 +150,24 @@ extern "C" {
         priv_: *mut EVP_PKEY,
     ) -> c_int;
     pub fn EVP_OpenFinal(ctx: *mut EVP_CIPHER_CTX, out: *mut c_uchar, outl: *mut c_int) -> c_int;
+    pub fn EVP_DecryptInit_ex(
+        ctx: *mut EVP_CIPHER_CTX,
+        cipher: *const EVP_CIPHER,
+        impl_: *mut ENGINE,
+        key: *const c_uchar,
+        iv: *const c_uchar,
+    ) -> c_int;
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut c_uchar,
         outl: *mut c_int,
         in_: *const u8,
         inl: c_int,
+    ) -> c_int;
+    pub fn EVP_DecryptFinal_ex(
+        ctx: *mut EVP_CIPHER_CTX,
+        outm: *mut c_uchar,
+        outl: *mut c_int
     ) -> c_int;
 }
 cfg_if! {


### PR DESCRIPTION
decrypt functions

Some functions including low level AES functions would be deprecated
in next OpenSSL version(3.0).
OpenSSL team says that application should use the high level EVP APIs,
so I added these functions.

See also:
https://github.com/openssl/openssl/pull/10580
https://github.com/openssl/openssl/pull/10740