### PR TITLE
Add NO RENEGOTIATION option

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -52,6 +52,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if openssl_version >= 0x1_01_00_07_0 {
             cfgs.push("ossl110g");
         }
+        if openssl_version >= 0x1_01_00_08_0 {
+            cfgs.push("ossl110h");
+        }
         if openssl_version >= 0x1_01_01_00_0 {
             cfgs.push("ossl111");
         }

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -318,6 +318,9 @@ pub const SSL_OP_NO_DTLSv1_2: c_ulong = 0x08000000;
 #[cfg(ossl111)]
 pub const SSL_OP_NO_TLSv1_3: c_ulong = 0x20000000;
 
+#[cfg(ossl110h)]
+pub const SSL_OP_NO_RENEGOTIATION: c_ulong = 0x40000000;
+
 cfg_if! {
     if #[cfg(ossl111)] {
         pub const SSL_OP_NO_SSL_MASK: c_ulong = SSL_OP_NO_SSLv2

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -238,6 +238,12 @@ bitflags! {
         #[cfg(any(ossl102, ossl110))]
         const NO_SSL_MASK = ffi::SSL_OP_NO_SSL_MASK;
 
+        /// Disallow all renegotiation in TLSv1.2 and earlier.
+        ///
+        /// Requires OpenSSL 1.1.0h or newer.
+        #[cfg(ossl110h)]
+        const NO_RENEGOTIATION = ffi::SSL_OP_NO_RENEGOTIATION;
+
         /// Enable TLSv1.3 Compatibility mode.
         ///
         /// Requires OpenSSL 1.1.1 or newer. This is on by default in 1.1.1, but a future version


### PR DESCRIPTION
SSL_OP_NO_RENEGOTIATION was added in OpenSSLv1.1.1 and backported to v1.1.0h.