### PR TITLE
Update to mem::MaybeUninit and Once::new()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
         default: false
       image:
         type: string
-        default: 1.33.0
+        default: 1.41.0
       minimal_build:
         type: boolean
         default: false
@@ -172,7 +172,7 @@ jobs:
         default: false
       image:
         type: string
-        default: 1.33.0
+        default: 1.41.0
     macos:
       xcode: "9.0"
     environment:
@@ -224,7 +224,7 @@ workflows:
           name: mimimal-version
           target: x86_64-unknown-linux-musl
           vendored: true
-          image: 1.31.0
+          image: 1.36.0
           minimal_build: true
       - linux:
           name: musl-vendored

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -103,7 +103,7 @@ pub fn init() {
     use std::io::{self, Write};
     use std::mem;
     use std::process;
-    use std::sync::{Mutex, MutexGuard, Once, ONCE_INIT};
+    use std::sync::{Mutex, MutexGuard, Once};
 
     static mut MUTEXES: *mut Vec<Mutex<()>> = 0 as *mut Vec<Mutex<()>>;
     static mut GUARDS: *mut Vec<Option<MutexGuard<'static, ()>>> =
@@ -147,7 +147,7 @@ pub fn init() {
         }
     }
 
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();;
 
     INIT.call_once(|| unsafe {
         SSL_library_init();

--- a/openssl/src/aes.rs
+++ b/openssl/src/aes.rs
@@ -78,14 +78,14 @@ impl AesKey {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize / 8);
 
-            let mut aes_key = mem::uninitialized();
+            let mut aes_key = mem::MaybeUninit::uninit();
             let r = ffi::AES_set_encrypt_key(
                 key.as_ptr() as *const _,
                 key.len() as c_int * 8,
-                &mut aes_key,
+                aes_key.as_mut_ptr(),
             );
             if r == 0 {
-                Ok(AesKey(aes_key))
+                Ok(AesKey(aes_key.assume_init()))
             } else {
                 Err(KeyError(()))
             }
@@ -101,15 +101,15 @@ impl AesKey {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize / 8);
 
-            let mut aes_key = mem::uninitialized();
+            let mut aes_key = mem::MaybeUninit::uninit();
             let r = ffi::AES_set_decrypt_key(
                 key.as_ptr() as *const _,
                 key.len() as c_int * 8,
-                &mut aes_key,
+                aes_key.as_mut_ptr(),
             );
 
             if r == 0 {
-                Ok(AesKey(aes_key))
+                Ok(AesKey(aes_key.assume_init()))
             } else {
                 Err(KeyError(()))
             }

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -58,9 +58,9 @@ use std::mem;
 #[inline]
 pub fn sha1(data: &[u8]) -> [u8; 20] {
     unsafe {
-        let mut hash: [u8; 20] = mem::uninitialized();
-        ffi::SHA1(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: mem::MaybeUninit<[u8; 20]> = mem::MaybeUninit::uninit();
+        ffi::SHA1(data.as_ptr(), data.len(), hash.as_mut_ptr() as *mut u8);
+        hash.assume_init()
     }
 }
 
@@ -68,9 +68,9 @@ pub fn sha1(data: &[u8]) -> [u8; 20] {
 #[inline]
 pub fn sha224(data: &[u8]) -> [u8; 28] {
     unsafe {
-        let mut hash: [u8; 28] = mem::uninitialized();
-        ffi::SHA224(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: mem::MaybeUninit<[u8; 28]> = mem::MaybeUninit::uninit();
+        ffi::SHA224(data.as_ptr(), data.len(), hash.as_mut_ptr() as *mut u8);
+        hash.assume_init()
     }
 }
 
@@ -78,9 +78,9 @@ pub fn sha224(data: &[u8]) -> [u8; 28] {
 #[inline]
 pub fn sha256(data: &[u8]) -> [u8; 32] {
     unsafe {
-        let mut hash: [u8; 32] = mem::uninitialized();
-        ffi::SHA256(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: mem::MaybeUninit<[u8; 32]> = mem::MaybeUninit::uninit();
+        ffi::SHA256(data.as_ptr(), data.len(), hash.as_mut_ptr() as *mut u8);
+        hash.assume_init()
     }
 }
 
@@ -88,9 +88,9 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
 #[inline]
 pub fn sha384(data: &[u8]) -> [u8; 48] {
     unsafe {
-        let mut hash: [u8; 48] = mem::uninitialized();
-        ffi::SHA384(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: mem::MaybeUninit<[u8; 48]> = mem::MaybeUninit::uninit();
+        ffi::SHA384(data.as_ptr(), data.len(), hash.as_mut_ptr() as *mut u8);
+        hash.assume_init()
     }
 }
 
@@ -98,9 +98,9 @@ pub fn sha384(data: &[u8]) -> [u8; 48] {
 #[inline]
 pub fn sha512(data: &[u8]) -> [u8; 64] {
     unsafe {
-        let mut hash: [u8; 64] = mem::uninitialized();
-        ffi::SHA512(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: mem::MaybeUninit<[u8; 64]> = mem::MaybeUninit::uninit();
+        ffi::SHA512(data.as_ptr(), data.len(), hash.as_mut_ptr() as *mut u8);
+        hash.assume_init()
     }
 }
 
@@ -118,9 +118,9 @@ impl Sha1 {
     #[inline]
     pub fn new() -> Sha1 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA1_Init(&mut ctx);
-            Sha1(ctx)
+            let mut ctx: mem::MaybeUninit<ffi::SHA_CTX> = mem::MaybeUninit::uninit();
+            ffi::SHA1_Init(ctx.as_mut_ptr());
+            Sha1(ctx.assume_init())
         }
     }
 
@@ -138,9 +138,9 @@ impl Sha1 {
     #[inline]
     pub fn finish(mut self) -> [u8; 20] {
         unsafe {
-            let mut hash: [u8; 20] = mem::uninitialized();
-            ffi::SHA1_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: mem::MaybeUninit<[u8; 20]> = mem::MaybeUninit::uninit();
+            ffi::SHA1_Final(hash.as_mut_ptr() as *mut u8, &mut self.0);
+            hash.assume_init()
         }
     }
 }
@@ -154,9 +154,9 @@ impl Sha224 {
     #[inline]
     pub fn new() -> Sha224 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA224_Init(&mut ctx);
-            Sha224(ctx)
+            let mut ctx: mem::MaybeUninit<ffi::SHA256_CTX> = mem::MaybeUninit::uninit();
+            ffi::SHA224_Init(ctx.as_mut_ptr());
+            Sha224(ctx.assume_init())
         }
     }
 
@@ -174,9 +174,9 @@ impl Sha224 {
     #[inline]
     pub fn finish(mut self) -> [u8; 28] {
         unsafe {
-            let mut hash: [u8; 28] = mem::uninitialized();
-            ffi::SHA224_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: mem::MaybeUninit<[u8; 28]> = mem::MaybeUninit::uninit();
+            ffi::SHA224_Final(hash.as_mut_ptr() as *mut u8, &mut self.0);
+            hash.assume_init()
         }
     }
 }
@@ -190,9 +190,9 @@ impl Sha256 {
     #[inline]
     pub fn new() -> Sha256 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA256_Init(&mut ctx);
-            Sha256(ctx)
+            let mut ctx: mem::MaybeUninit<ffi::SHA256_CTX> = mem::MaybeUninit::uninit();
+            ffi::SHA256_Init(ctx.as_mut_ptr());
+            Sha256(ctx.assume_init())
         }
     }
 
@@ -210,9 +210,9 @@ impl Sha256 {
     #[inline]
     pub fn finish(mut self) -> [u8; 32] {
         unsafe {
-            let mut hash: [u8; 32] = mem::uninitialized();
-            ffi::SHA256_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: mem::MaybeUninit<[u8; 32]> = mem::MaybeUninit::uninit();
+            ffi::SHA256_Final(hash.as_mut_ptr() as *mut u8, &mut self.0);
+            hash.assume_init()
         }
     }
 }
@@ -226,9 +226,9 @@ impl Sha384 {
     #[inline]
     pub fn new() -> Sha384 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA384_Init(&mut ctx);
-            Sha384(ctx)
+            let mut ctx: mem::MaybeUninit<ffi::SHA512_CTX> = mem::MaybeUninit::uninit();
+            ffi::SHA384_Init(ctx.as_mut_ptr());
+            Sha384(ctx.assume_init())
         }
     }
 
@@ -246,9 +246,9 @@ impl Sha384 {
     #[inline]
     pub fn finish(mut self) -> [u8; 48] {
         unsafe {
-            let mut hash: [u8; 48] = mem::uninitialized();
-            ffi::SHA384_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: mem::MaybeUninit<[u8; 48]> = mem::MaybeUninit::uninit();
+            ffi::SHA384_Final(hash.as_mut_ptr() as *mut u8, &mut self.0);
+            hash.assume_init()
         }
     }
 }
@@ -262,9 +262,9 @@ impl Sha512 {
     #[inline]
     pub fn new() -> Sha512 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA512_Init(&mut ctx);
-            Sha512(ctx)
+            let mut ctx: mem::MaybeUninit<ffi::SHA512_CTX> = mem::MaybeUninit::uninit();
+            ffi::SHA512_Init(ctx.as_mut_ptr());
+            Sha512(ctx.assume_init())
         }
     }
 
@@ -282,9 +282,9 @@ impl Sha512 {
     #[inline]
     pub fn finish(mut self) -> [u8; 64] {
         unsafe {
-            let mut hash: [u8; 64] = mem::uninitialized();
-            ffi::SHA512_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: mem::MaybeUninit<[u8; 64]> = mem::MaybeUninit::uninit();
+            ffi::SHA512_Final(hash.as_mut_ptr() as *mut u8, &mut self.0);
+            hash.assume_init()
         }
     }
 }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3928,11 +3928,11 @@ cfg_if! {
             )
         }
     } else {
-        use std::sync::{Once, ONCE_INIT};
+        use std::sync::Once;
 
         unsafe fn get_new_idx(f: ffi::CRYPTO_EX_free) -> c_int {
             // hack around https://rt.openssl.org/Ticket/Display.html?id=3710&user=guest&pass=guest
-            static ONCE: Once = ONCE_INIT;
+            static ONCE: Once = Once::new();
             ONCE.call_once(|| {
                 ffi::SSL_CTX_get_ex_new_index(0, ptr::null_mut(), None, None, None);
             });
@@ -3942,7 +3942,7 @@ cfg_if! {
 
         unsafe fn get_new_ssl_idx(f: ffi::CRYPTO_EX_free) -> c_int {
             // hack around https://rt.openssl.org/Ticket/Display.html?id=3710&user=guest&pass=guest
-            static ONCE: Once = ONCE_INIT;
+            static ONCE: Once = Once::new();
             ONCE.call_once(|| {
                 ffi::SSL_get_ex_new_index(0, ptr::null_mut(), None, None, None);
             });


### PR DESCRIPTION
Newest version of rust compiler warns about deprecation for `mem::uninitialized` and `ONCE_INIT` - prefers these versions. I confirmed this compiles on the latest stable as well as the latest nightly.