### PR TITLE
Attach cfg[allow_deprecated] to methods w/ uninitialized functionality

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -103,7 +103,7 @@ pub fn init() {
     use std::io::{self, Write};
     use std::mem;
     use std::process;
-    use std::sync::{Mutex, MutexGuard, Once, ONCE_INIT};
+    use std::sync::{Mutex, MutexGuard, Once};
 
     static mut MUTEXES: *mut Vec<Mutex<()>> = 0 as *mut Vec<Mutex<()>>;
     static mut GUARDS: *mut Vec<Option<MutexGuard<'static, ()>>> =
@@ -147,7 +147,7 @@ pub fn init() {
         }
     }
 
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();
 
     INIT.call_once(|| unsafe {
         SSL_library_init();

--- a/openssl/src/aes.rs
+++ b/openssl/src/aes.rs
@@ -74,6 +74,7 @@ impl AesKey {
     /// # Failure
     ///
     /// Returns an error if the key is not 128, 192, or 256 bits.
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new_encrypt(key: &[u8]) -> Result<AesKey, KeyError> {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize / 8);
@@ -97,6 +98,7 @@ impl AesKey {
     /// # Failure
     ///
     /// Returns an error if the key is not 128, 192, or 256 bits.
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new_decrypt(key: &[u8]) -> Result<AesKey, KeyError> {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize / 8);

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -56,6 +56,7 @@ use std::mem;
 /// SHA1 is known to be insecure - it should not be used unless required for
 /// compatibility with existing systems.
 #[inline]
+#[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha1(data: &[u8]) -> [u8; 20] {
     unsafe {
         let mut hash: [u8; 20] = mem::uninitialized();
@@ -66,6 +67,7 @@ pub fn sha1(data: &[u8]) -> [u8; 20] {
 
 /// Computes the SHA224 hash of some data.
 #[inline]
+#[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha224(data: &[u8]) -> [u8; 28] {
     unsafe {
         let mut hash: [u8; 28] = mem::uninitialized();
@@ -76,6 +78,7 @@ pub fn sha224(data: &[u8]) -> [u8; 28] {
 
 /// Computes the SHA256 hash of some data.
 #[inline]
+#[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha256(data: &[u8]) -> [u8; 32] {
     unsafe {
         let mut hash: [u8; 32] = mem::uninitialized();
@@ -86,6 +89,7 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
 
 /// Computes the SHA384 hash of some data.
 #[inline]
+#[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha384(data: &[u8]) -> [u8; 48] {
     unsafe {
         let mut hash: [u8; 48] = mem::uninitialized();
@@ -96,6 +100,7 @@ pub fn sha384(data: &[u8]) -> [u8; 48] {
 
 /// Computes the SHA512 hash of some data.
 #[inline]
+#[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha512(data: &[u8]) -> [u8; 64] {
     unsafe {
         let mut hash: [u8; 64] = mem::uninitialized();
@@ -116,6 +121,7 @@ pub struct Sha1(ffi::SHA_CTX);
 impl Sha1 {
     /// Creates a new hasher.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha1 {
         unsafe {
             let mut ctx = mem::uninitialized();
@@ -136,6 +142,7 @@ impl Sha1 {
 
     /// Returns the hash of the data.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 20] {
         unsafe {
             let mut hash: [u8; 20] = mem::uninitialized();
@@ -152,6 +159,7 @@ pub struct Sha224(ffi::SHA256_CTX);
 impl Sha224 {
     /// Creates a new hasher.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha224 {
         unsafe {
             let mut ctx = mem::uninitialized();
@@ -172,6 +180,7 @@ impl Sha224 {
 
     /// Returns the hash of the data.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 28] {
         unsafe {
             let mut hash: [u8; 28] = mem::uninitialized();
@@ -188,6 +197,7 @@ pub struct Sha256(ffi::SHA256_CTX);
 impl Sha256 {
     /// Creates a new hasher.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha256 {
         unsafe {
             let mut ctx = mem::uninitialized();
@@ -208,6 +218,7 @@ impl Sha256 {
 
     /// Returns the hash of the data.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 32] {
         unsafe {
             let mut hash: [u8; 32] = mem::uninitialized();
@@ -224,6 +235,7 @@ pub struct Sha384(ffi::SHA512_CTX);
 impl Sha384 {
     /// Creates a new hasher.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha384 {
         unsafe {
             let mut ctx = mem::uninitialized();
@@ -244,6 +256,7 @@ impl Sha384 {
 
     /// Returns the hash of the data.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 48] {
         unsafe {
             let mut hash: [u8; 48] = mem::uninitialized();
@@ -260,6 +273,7 @@ pub struct Sha512(ffi::SHA512_CTX);
 impl Sha512 {
     /// Creates a new hasher.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha512 {
         unsafe {
             let mut ctx = mem::uninitialized();
@@ -280,6 +294,7 @@ impl Sha512 {
 
     /// Returns the hash of the data.
     #[inline]
+    #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 64] {
         unsafe {
             let mut hash: [u8; 64] = mem::uninitialized();

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3928,11 +3928,11 @@ cfg_if! {
             )
         }
     } else {
-        use std::sync::{Once, ONCE_INIT};
+        use std::sync::Once;
 
         unsafe fn get_new_idx(f: ffi::CRYPTO_EX_free) -> c_int {
             // hack around https://rt.openssl.org/Ticket/Display.html?id=3710&user=guest&pass=guest
-            static ONCE: Once = ONCE_INIT;
+            static ONCE: Once = Once::new();
             ONCE.call_once(|| {
                 ffi::SSL_CTX_get_ex_new_index(0, ptr::null_mut(), None, None, None);
             });
@@ -3942,7 +3942,7 @@ cfg_if! {
 
         unsafe fn get_new_ssl_idx(f: ffi::CRYPTO_EX_free) -> c_int {
             // hack around https://rt.openssl.org/Ticket/Display.html?id=3710&user=guest&pass=guest
-            static ONCE: Once = ONCE_INIT;
+            static ONCE: Once = Once::new();
             ONCE.call_once(|| {
                 ffi::SSL_get_ex_new_index(0, ptr::null_mut(), None, None, None);
             });


### PR DESCRIPTION
Additionally - update usage of ONCE_INIT