### PR TITLE
Expose HKDF functions

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -1,4 +1,6 @@
 use libc::*;
+use std::ptr;
+
 use *;
 
 pub const EVP_MAX_MD_SIZE: c_uint = 64;
@@ -20,6 +22,24 @@ pub const EVP_PKEY_X448: c_int = NID_X448;
 pub const EVP_PKEY_ED448: c_int = NID_ED448;
 pub const EVP_PKEY_HMAC: c_int = NID_hmac;
 pub const EVP_PKEY_CMAC: c_int = NID_cmac;
+#[cfg(ossl111)]
+pub const EVP_PKEY_HKDF: c_int = NID_hkdf;
+#[cfg(ossl111)]
+pub const EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND: c_int = 0;
+#[cfg(ossl111)]
+pub const EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY: c_int = 1;
+#[cfg(ossl111)]
+pub const EVP_PKEY_HKDEF_MODE_EXPAND_ONLY: c_int = 2;
+#[cfg(ossl111)]
+pub const EVP_PKEY_CTRL_HKDF_MD: c_int = EVP_PKEY_ALG_CTRL + 3;
+#[cfg(ossl111)]
+pub const EVP_PKEY_CTRL_HKDF_SALT: c_int = EVP_PKEY_ALG_CTRL + 4;
+#[cfg(ossl111)]
+pub const EVP_PKEY_CTRL_HKDF_KEY: c_int = EVP_PKEY_ALG_CTRL + 5;
+#[cfg(ossl111)]
+pub const EVP_PKEY_CTRL_HKDF_INFO: c_int = EVP_PKEY_ALG_CTRL + 6;
+#[cfg(ossl111)]
+pub const EVP_PKEY_CTRL_HKDF_MODE: c_int = EVP_PKEY_ALG_CTRL + 7;
 
 pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
 pub const EVP_CTRL_GCM_GET_TAG: c_int = 0x10;
@@ -373,6 +393,8 @@ pub const EVP_PKEY_OP_SIGNCTX: c_int = 1 << 6;
 pub const EVP_PKEY_OP_VERIFYCTX: c_int = 1 << 7;
 pub const EVP_PKEY_OP_ENCRYPT: c_int = 1 << 8;
 pub const EVP_PKEY_OP_DECRYPT: c_int = 1 << 9;
+#[cfg(ossl111)]
+pub const EVP_PKEY_OP_DERIVE: c_int = 1 << 10;
 
 pub const EVP_PKEY_OP_TYPE_SIG: c_int = EVP_PKEY_OP_SIGN
     | EVP_PKEY_OP_VERIFY
@@ -438,6 +460,78 @@ const_ptr_api! {
     extern "C" {
         pub fn EVP_PKCS82PKEY(p8: #[const_ptr_if(any(ossl110, libressl280))] PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
     }
+}
+
+#[cfg(ossl111)]
+pub unsafe fn EVP_PKEY_CTX_hkdf_mode(ctx: *mut EVP_PKEY_CTX, mode: c_int) -> c_int {
+    EVP_PKEY_CTX_ctrl(
+        ctx,
+        -1,
+        EVP_PKEY_OP_DERIVE,
+        EVP_PKEY_CTRL_HKDF_MODE,
+        mode,
+        ptr::null_mut(),
+    )
+}
+
+#[cfg(ossl111)]
+pub unsafe fn EVP_PKEY_CTX_set_hkdf_md(ctx: *mut EVP_PKEY_CTX, md: *const EVP_MD) -> c_int {
+    EVP_PKEY_CTX_ctrl(
+        ctx,
+        -1,
+        EVP_PKEY_OP_DERIVE,
+        EVP_PKEY_CTRL_HKDF_MD,
+        0,
+        md as *mut c_void,
+    )
+}
+
+#[cfg(ossl111)]
+pub unsafe fn EVP_PKEY_CTX_set1_hkdf_salt(
+    ctx: *mut EVP_PKEY_CTX,
+    salt: *const u8,
+    saltlen: c_int,
+) -> c_int {
+    EVP_PKEY_CTX_ctrl(
+        ctx,
+        -1,
+        EVP_PKEY_OP_DERIVE,
+        EVP_PKEY_CTRL_HKDF_SALT,
+        saltlen,
+        salt as *mut c_void,
+    )
+}
+
+#[cfg(ossl111)]
+pub unsafe fn EVP_PKEY_CTX_set1_hkdf_key(
+    ctx: *mut EVP_PKEY_CTX,
+    key: *const u8,
+    keylen: c_int,
+) -> c_int {
+    EVP_PKEY_CTX_ctrl(
+        ctx,
+        -1,
+        EVP_PKEY_OP_DERIVE,
+        EVP_PKEY_CTRL_HKDF_KEY,
+        keylen,
+        key as *mut c_void,
+    )
+}
+
+#[cfg(ossl111)]
+pub unsafe fn EVP_PKEY_CTX_add1_hkdf_info(
+    ctx: *mut EVP_PKEY_CTX,
+    info: *const u8,
+    infolen: c_int,
+) -> c_int {
+    EVP_PKEY_CTX_ctrl(
+        ctx,
+        -1,
+        EVP_PKEY_OP_DERIVE,
+        EVP_PKEY_CTRL_HKDF_INFO,
+        infolen,
+        info as *mut c_void,
+    )
 }
 
 cfg_if! {

--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -920,3 +920,5 @@ pub const NID_X448: c_int = 1035;
 pub const NID_ED25519: c_int = 1087;
 #[cfg(ossl111)]
 pub const NID_ED448: c_int = 1088;
+#[cfg(ossl111)]
+pub const NID_hkdf: c_int = 1036;

--- a/openssl/src/pkcs5.rs
+++ b/openssl/src/pkcs5.rs
@@ -1,10 +1,10 @@
 use libc::c_int;
 use std::ptr;
 
-use crate::cvt;
 use crate::error::ErrorStack;
-use crate::hash::MessageDigest;
+use crate::hash::{DigestBytes, MessageDigest};
 use crate::symm::Cipher;
+use crate::{cvt, cvt_p};
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct KeyIvPair {
@@ -135,6 +135,216 @@ pub fn scrypt(
             key.len(),
         ))
         .map(|_| ())
+    }
+}
+
+/// Derive a key using the HKDF algorithm, by applying `hkdf_extract`
+/// followed by `hkdf_expand`.
+///
+/// Requires OpenSSL 1.1.1 or newer.
+#[cfg(any(ossl111))]
+pub fn hkdf(
+    input: &[u8],
+    salt: &[u8],
+    info: &[u8],
+    hash: MessageDigest,
+    key: &mut [u8],
+) -> Result<(), ErrorStack> {
+    unsafe {
+        assert!(input.len() <= c_int::max_value() as usize);
+        assert!(salt.len() <= c_int::max_value() as usize);
+        assert!(info.len() <= c_int::max_value() as usize);
+        assert!(key.len() <= c_int::max_value() as usize);
+
+        ffi::init();
+        let kctx = cvt_p(ffi::EVP_PKEY_CTX_new_id(
+            ffi::EVP_PKEY_HKDF,
+            ptr::null_mut(),
+        ))?;
+
+        let ret = (|| {
+            cvt(ffi::EVP_PKEY_derive_init(kctx))?;
+
+            cvt(ffi::EVP_PKEY_CTX_hkdf_mode(
+                kctx,
+                ffi::EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND,
+            ))?;
+
+            cvt(ffi::EVP_PKEY_CTX_set_hkdf_md(kctx, hash.as_ptr()))?;
+
+            cvt(ffi::EVP_PKEY_CTX_set1_hkdf_key(
+                kctx,
+                input.as_ptr() as *const _,
+                input.len() as c_int,
+            ))?;
+
+            cvt(ffi::EVP_PKEY_CTX_set1_hkdf_salt(
+                kctx,
+                salt.as_ptr() as *const _,
+                salt.len() as c_int,
+            ))?;
+
+            cvt(ffi::EVP_PKEY_CTX_add1_hkdf_info(
+                kctx,
+                info.as_ptr() as *const _,
+                info.len() as c_int,
+            ))?;
+            Ok(())
+        })();
+
+        if let Err(e) = ret {
+            // Free memory
+            ffi::EVP_PKEY_CTX_free(kctx);
+            return Err(e);
+        }
+
+        let mut len = key.len();
+
+        let ret = cvt(ffi::EVP_PKEY_derive(kctx, key.as_mut_ptr(), &mut len));
+
+        // Free memory
+        ffi::EVP_PKEY_CTX_free(kctx);
+
+        if let Err(e) = ret {
+            return Err(e);
+        }
+
+        Ok(())
+    }
+}
+
+/// Extract a pseudorandom key from an input keying material using the
+/// HKDF algorithm.
+///
+/// Requires OpenSSL 1.1.1 or newer.
+#[cfg(any(ossl111))]
+pub fn hkdf_extract(
+    input: &[u8],
+    salt: &[u8],
+    hash: MessageDigest,
+) -> Result<DigestBytes, ErrorStack> {
+    unsafe {
+        assert!(input.len() <= c_int::max_value() as usize);
+        assert!(salt.len() <= c_int::max_value() as usize);
+
+        ffi::init();
+        let kctx = cvt_p(ffi::EVP_PKEY_CTX_new_id(
+            ffi::EVP_PKEY_HKDF,
+            ptr::null_mut(),
+        ))?;
+
+        let ret = (|| {
+            cvt(ffi::EVP_PKEY_derive_init(kctx))?;
+
+            cvt(ffi::EVP_PKEY_CTX_hkdf_mode(
+                kctx,
+                ffi::EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY,
+            ))?;
+
+            cvt(ffi::EVP_PKEY_CTX_set_hkdf_md(kctx, hash.as_ptr()))?;
+
+            cvt(ffi::EVP_PKEY_CTX_set1_hkdf_key(
+                kctx,
+                input.as_ptr() as *const _,
+                input.len() as c_int,
+            ))?;
+
+            cvt(ffi::EVP_PKEY_CTX_set1_hkdf_salt(
+                kctx,
+                salt.as_ptr() as *const _,
+                salt.len() as c_int,
+            ))?;
+            Ok(())
+        })();
+
+        if let Err(e) = ret {
+            // Free memory
+            ffi::EVP_PKEY_CTX_free(kctx);
+            return Err(e);
+        }
+
+        let mut len = ffi::EVP_MAX_MD_SIZE as usize;
+        let mut buf = [0; ffi::EVP_MAX_MD_SIZE as usize];
+        let ret = cvt(ffi::EVP_PKEY_derive(kctx, buf.as_mut_ptr(), &mut len));
+
+        // Free memory
+        ffi::EVP_PKEY_CTX_free(kctx);
+
+        if let Err(e) = ret {
+            return Err(e);
+        }
+
+        Ok(DigestBytes {
+            buf,
+            len: len as usize,
+        })
+    }
+}
+
+/// Expand a pseudorandom key to an output keying material using the
+/// HKDF algorithm.
+///
+/// Requires OpenSSL 1.1.1 or newer.
+#[cfg(any(ossl111))]
+pub fn hkdf_expand(
+    prk: &[u8],
+    info: &[u8],
+    hash: MessageDigest,
+    key: &mut [u8],
+) -> Result<(), ErrorStack> {
+    unsafe {
+        assert!(prk.len() <= c_int::max_value() as usize);
+        assert!(info.len() <= c_int::max_value() as usize);
+        assert!(key.len() <= c_int::max_value() as usize);
+
+        ffi::init();
+        let kctx = cvt_p(ffi::EVP_PKEY_CTX_new_id(
+            ffi::EVP_PKEY_HKDF,
+            ptr::null_mut(),
+        ))?;
+
+        let ret = (|| {
+            cvt(ffi::EVP_PKEY_derive_init(kctx))?;
+
+            cvt(ffi::EVP_PKEY_CTX_hkdf_mode(
+                kctx,
+                ffi::EVP_PKEY_HKDEF_MODE_EXPAND_ONLY,
+            ))?;
+
+            cvt(ffi::EVP_PKEY_CTX_set_hkdf_md(kctx, hash.as_ptr()))?;
+
+            cvt(ffi::EVP_PKEY_CTX_set1_hkdf_key(
+                kctx,
+                prk.as_ptr() as *const _,
+                prk.len() as c_int,
+            ))?;
+
+            cvt(ffi::EVP_PKEY_CTX_add1_hkdf_info(
+                kctx,
+                info.as_ptr() as *const _,
+                info.len() as c_int,
+            ))?;
+            Ok(())
+        })();
+
+        if let Err(e) = ret {
+            // Free memory
+            ffi::EVP_PKEY_CTX_free(kctx);
+            return Err(e);
+        }
+
+        let mut len = key.len();
+
+        let ret = cvt(ffi::EVP_PKEY_derive(kctx, key.as_mut_ptr(), &mut len));
+
+        // Free memory
+        ffi::EVP_PKEY_CTX_free(kctx);
+
+        if let Err(e) = ret {
+            return Err(e);
+        }
+
+        Ok(())
     }
 }
 
@@ -298,5 +508,64 @@ mod tests {
         )
         .unwrap();
         assert_eq!(hex::encode(&actual[..]), expected);
+    }
+
+    #[test]
+    #[cfg(ossl111)]
+    fn hkdf() {
+        // Test vectors from RFC 5689
+        let input = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b";
+        let salt = "000102030405060708090a0b0c";
+        let info = "f0f1f2f3f4f5f6f7f8f9";
+        let mut key = vec![0; 42];
+        let expected =
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865";
+
+        super::hkdf(
+            &hex::decode(input).unwrap(),
+            &hex::decode(salt).unwrap(),
+            &hex::decode(info).unwrap(),
+            MessageDigest::sha256(),
+            &mut key,
+        )
+        .unwrap();
+        assert_eq!(hex::encode(&key[..]), expected);
+    }
+
+    #[test]
+    #[cfg(ossl111)]
+    fn hkdf_extract() {
+        // Test vectors from RFC 5689
+        let input = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b";
+        let salt = "000102030405060708090a0b0c";
+        let expected = "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5";
+
+        let prk = super::hkdf_extract(
+            &hex::decode(input).unwrap(),
+            &hex::decode(salt).unwrap(),
+            MessageDigest::sha256(),
+        )
+        .unwrap();
+        assert_eq!(hex::encode(&prk[..]), expected);
+    }
+
+    #[test]
+    #[cfg(ossl111)]
+    fn hkdf_expand() {
+        // Test vectors from RFC 5689
+        let prk = "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5";
+        let info = "f0f1f2f3f4f5f6f7f8f9";
+        let mut key = vec![0; 42];
+        let expected =
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865";
+
+        super::hkdf_expand(
+            &hex::decode(prk).unwrap(),
+            &hex::decode(info).unwrap(),
+            MessageDigest::sha256(),
+            &mut key,
+        )
+        .unwrap();
+        assert_eq!(hex::encode(&key[..]), expected);
     }
 }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -63,8 +63,12 @@ fn main() {
         .header("openssl/evp.h")
         .header("openssl/x509_vfy.h");
 
-    if openssl_version.is_some() {
+    if let Some(v) = openssl_version {
         cfg.header("openssl/cms.h");
+        #[allow(clippy::unusual_byte_groupings)]
+        if v >= 0x1_01_01_00_0 {
+            cfg.header("openssl/kdf.h");
+        }
     }
 
     #[allow(clippy::if_same_then_else)]


### PR DESCRIPTION
This adds functions for HKDF (HMAC-based Extract-and-Expand Key Derivation Function), provided by OpenSSL 1.1.1.

Fixes #1233.