### PR TITLE
use library names supplied by vcpkg

### DIFF
--- a/openssl-sys/CHANGELOG.md
+++ b/openssl-sys/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed windows-msvc library names when using OpenSSL from vcpkg.
+
 ## [v0.9.54] - 2020-01-29
 
 ### Added

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -24,7 +24,7 @@ pkg-config = "0.3.9"
 autocfg = "1.0"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
-vcpkg = "0.2"
+vcpkg = "0.2.8"
 
 # We don't actually use metadeps for annoying reasons but this is still here for tooling
 [package.metadata.pkg-config]

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -194,31 +194,16 @@ fn try_pkg_config() {
 /// should emit all of the cargo metadata that we need.
 #[cfg(target_env = "msvc")]
 fn try_vcpkg() {
-    use vcpkg;
-
     // vcpkg will not emit any metadata if it can not find libraries
     // appropriate for the target triple with the desired linkage.
 
-    let mut lib = vcpkg::Config::new()
+    let lib = vcpkg::Config::new()
         .emit_includes(true)
-        .lib_name("libcrypto")
-        .lib_name("libssl")
-        .probe("openssl");
+        .find_package("openssl");
 
     if let Err(e) = lib {
         println!(
-            "note: vcpkg did not find openssl as libcrypto and libssl: {}",
-            e
-        );
-        lib = vcpkg::Config::new()
-            .emit_includes(true)
-            .lib_name("libeay32")
-            .lib_name("ssleay32")
-            .probe("openssl");
-    }
-    if let Err(e) = lib {
-        println!(
-            "note: vcpkg did not find openssl as ssleay32 and libeay32: {}",
+            "note: vcpkg did not find openssl: {}",
             e
         );
         return;


### PR DESCRIPTION
The current version of openssl-sys fails to build against OpenSSL 1.1.1d from a vcpkg installation because the DLLs now have more elaborate names, `libcrypto-1_1-x64.dll` for example. This PR switches to querying vcpkg for the library names rather than them being hardcoded in `build.rs`.
