### PR TITLE
Fix build on DragonFly

### DIFF
--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -60,6 +60,11 @@ fn find_openssl_dir(target: &str) -> OsString {
         return OsString::from("/usr");
     }
 
+    // DragonFly has libressl (or openssl) in ports, but this doesn't include a pkg-config file
+    if host == target && target.contains("dragonfly") {
+        return OsString::from("/usr/local");
+    }
+
     let mut msg = format!(
         "
 


### PR DESCRIPTION
DragonFly has libressl/openssl in ports (/usr/local). With this commit,
rust-openssl builds out of the box given that either libressl or openssl is
installed (which is usually the case).

Tested on DragonFly 5.9-DEVELOPMENT with libressl-3.0.2.