### PR TITLE
Fix static build on windows-gnu targets

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -86,7 +86,7 @@ fn main() {
         Some(ref v) => v.split(":").collect(),
         None => match version {
             Version::Openssl10x if target.contains("windows") => vec!["ssleay32", "libeay32"],
-            Version::Openssl11x if target.contains("windows") => vec!["libssl", "libcrypto"],
+            Version::Openssl11x if target.contains("windows-msvc") => vec!["libssl", "libcrypto"],
             _ => vec!["ssl", "crypto"],
         },
     };


### PR DESCRIPTION
Static builds for *-pc-windows-gnu targets broke, because the linker
would look for the incorrect libraries. OpenSSL builds produce
libssl.dll rather than ssl.dll which makes the linker unhappy with the
normal -lssl -lcrypto [1].

A workaround could be used:

    export OPENSSL_LIBS="ssl:crypto"

but it's arguably better to have the openssl-sys crate do the right
thing.

[1] http://www.mingw.org/wiki/specify_the_libraries_for_the_linker_to_use