### PR TITLE
Add support for AES-OCB mode

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -21,6 +21,12 @@ pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
 pub const EVP_CTRL_GCM_GET_TAG: c_int = 0x10;
 pub const EVP_CTRL_GCM_SET_TAG: c_int = 0x11;
 
+// Keeping above for backwards compatability
+pub const EVP_CTRL_AEAD_SET_IVLEN: c_int = EVP_CTRL_GCM_SET_IVLEN;
+pub const EVP_CTRL_AEAD_GET_TAG: c_int = EVP_CTRL_GCM_GET_TAG;
+pub const EVP_CTRL_AEAD_SET_TAG: c_int = EVP_CTRL_GCM_SET_TAG;
+
+
 pub unsafe fn EVP_get_digestbynid(type_: c_int) -> *const EVP_MD {
     EVP_get_digestbyname(OBJ_nid2sn(type_))
 }
@@ -275,6 +281,7 @@ extern "C" {
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
     pub fn EVP_aes_128_xts() -> *const EVP_CIPHER;
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
+    pub fn EVP_aes_128_ocb() -> *const EVP_CIPHER;
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
@@ -284,6 +291,7 @@ extern "C" {
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
+    pub fn EVP_aes_192_ocb() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
@@ -294,6 +302,7 @@ extern "C" {
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
+    pub fn EVP_aes_256_ocb() -> *const EVP_CIPHER;
     #[cfg(ossl110)]
     pub fn EVP_chacha20() -> *const ::EVP_CIPHER;
     #[cfg(ossl110)]

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -21,12 +21,6 @@ pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
 pub const EVP_CTRL_GCM_GET_TAG: c_int = 0x10;
 pub const EVP_CTRL_GCM_SET_TAG: c_int = 0x11;
 
-// Keeping above for backwards compatability
-pub const EVP_CTRL_AEAD_SET_IVLEN: c_int = EVP_CTRL_GCM_SET_IVLEN;
-pub const EVP_CTRL_AEAD_GET_TAG: c_int = EVP_CTRL_GCM_GET_TAG;
-pub const EVP_CTRL_AEAD_SET_TAG: c_int = EVP_CTRL_GCM_SET_TAG;
-
-
 pub unsafe fn EVP_get_digestbynid(type_: c_int) -> *const EVP_MD {
     EVP_get_digestbyname(OBJ_nid2sn(type_))
 }
@@ -281,6 +275,7 @@ extern "C" {
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
     pub fn EVP_aes_128_xts() -> *const EVP_CIPHER;
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
+    #[cfg(ossl110)]
     pub fn EVP_aes_128_ocb() -> *const EVP_CIPHER;
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
@@ -291,6 +286,7 @@ extern "C" {
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
+    #[cfg(ossl110)]
     pub fn EVP_aes_192_ocb() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
@@ -302,6 +298,7 @@ extern "C" {
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
+    #[cfg(ossl110)]
     pub fn EVP_aes_256_ocb() -> *const EVP_CIPHER;
     #[cfg(ossl110)]
     pub fn EVP_chacha20() -> *const ::EVP_CIPHER;

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -131,7 +131,7 @@ impl Cipher {
     }
 
     /// Requires OpenSSL 1.1.0 or newer.
-    #[cfg(any(ossl110))]
+    #[cfg(ossl110)]
     pub fn aes_128_ocb() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_ocb()) }
     }
@@ -173,7 +173,7 @@ impl Cipher {
     }
 
     /// Requires OpenSSL 1.1.0 or newer.
-    #[cfg(any(ossl110))]
+    #[cfg(ossl110)]
     pub fn aes_192_ocb() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_ocb()) }
     }
@@ -219,7 +219,7 @@ impl Cipher {
     }
 
     /// Requires OpenSSL 1.1.0 or newer.
-    #[cfg(any(ossl110))]
+    #[cfg(ossl110)]
     pub fn aes_256_ocb() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_ocb()) }
     }
@@ -318,14 +318,14 @@ impl Cipher {
     }
 
     /// Determines whether the cipher is using OCB mode
-    #[cfg(any(ossl110))]
+    #[cfg(ossl110)]
     fn is_ocb(&self) -> bool {
         *self == Cipher::aes_128_ocb() ||
         *self == Cipher::aes_192_ocb() ||
         *self == Cipher::aes_256_ocb()
     }
 
-    #[cfg(not(any(ossl110)))]
+    #[cfg(not(ossl110))]
     const fn is_ocb(&self) -> bool {
         false
     }
@@ -1425,7 +1425,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(ossl110))]
+    #[cfg(ossl110)]
     fn test_aes_128_ocb() {
         let key = "000102030405060708090a0b0c0d0e0f";
         let aad = "0001020304050607";
@@ -1461,7 +1461,7 @@ mod tests {
      }
 
     #[test]
-    #[cfg(any(ossl110))]
+    #[cfg(ossl110)]
     fn test_aes_128_ocb_fail() {
         let key = "000102030405060708090a0b0c0d0e0f";
         let aad = "0001020304050607";

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -130,6 +130,8 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_ofb()) }
     }
 
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[cfg(any(ossl110))]
     pub fn aes_128_ocb() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_ocb()) }
     }
@@ -170,6 +172,8 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_ofb()) }
     }
 
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[cfg(any(ossl110))]
     pub fn aes_192_ocb() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_ocb()) }
     }
@@ -214,6 +218,8 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_ofb()) }
     }
 
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[cfg(any(ossl110))]
     pub fn aes_256_ocb() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_ocb()) }
     }
@@ -312,10 +318,16 @@ impl Cipher {
     }
 
     /// Determines whether the cipher is using OCB mode
+    #[cfg(any(ossl110))]
     fn is_ocb(&self) -> bool {
         *self == Cipher::aes_128_ocb() ||
         *self == Cipher::aes_192_ocb() ||
         *self == Cipher::aes_256_ocb()
+    }
+
+    #[cfg(not(any(ossl110)))]
+    const fn is_ocb(&self) -> bool {
+        false
     }
 }
 
@@ -440,7 +452,7 @@ impl Crypter {
                         assert!(iv.len() <= c_int::max_value() as usize);
                         cvt(ffi::EVP_CIPHER_CTX_ctrl(
                             crypter.ctx,
-                            ffi::EVP_CTRL_AEAD_SET_IVLEN,
+                            ffi::EVP_CTRL_GCM_SET_IVLEN,
                             iv.len() as c_int,
                             ptr::null_mut(),
                         ))?;
@@ -482,7 +494,7 @@ impl Crypter {
             // NB: this constant is actually more general than just GCM.
             cvt(ffi::EVP_CIPHER_CTX_ctrl(
                 self.ctx,
-                ffi::EVP_CTRL_AEAD_SET_TAG,
+                ffi::EVP_CTRL_GCM_SET_TAG,
                 tag.len() as c_int,
                 tag.as_ptr() as *mut _,
             ))
@@ -500,7 +512,7 @@ impl Crypter {
             // NB: this constant is actually more general than just GCM.
             cvt(ffi::EVP_CIPHER_CTX_ctrl(
                 self.ctx,
-                ffi::EVP_CTRL_AEAD_SET_TAG,
+                ffi::EVP_CTRL_GCM_SET_TAG,
                 tag_len as c_int,
                 ptr::null_mut(),
             ))
@@ -626,7 +638,7 @@ impl Crypter {
             assert!(tag.len() <= c_int::max_value() as usize);
             cvt(ffi::EVP_CIPHER_CTX_ctrl(
                 self.ctx,
-                ffi::EVP_CTRL_AEAD_GET_TAG,
+                ffi::EVP_CTRL_GCM_GET_TAG,
                 tag.len() as c_int,
                 tag.as_mut_ptr() as *mut _,
             ))
@@ -1413,6 +1425,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(ossl110))]
     fn test_aes_128_ocb() {
         let key = "000102030405060708090a0b0c0d0e0f";
         let aad = "0001020304050607";
@@ -1448,6 +1461,7 @@ mod tests {
      }
 
     #[test]
+    #[cfg(any(ossl110))]
     fn test_aes_128_ocb_fail() {
         let key = "000102030405060708090a0b0c0d0e0f";
         let aad = "0001020304050607";


### PR DESCRIPTION
See https://github.com/sfackler/rust-openssl/issues/1268#issuecomment-625976521 as to why there are only 128 bit tests.

closes: #1268 