### PR TITLE
Upgrade foreign-types to 0.5

### DIFF
--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -21,7 +21,7 @@ vendored = ['openssl-sys/vendored']
 [dependencies]
 bitflags = "1.0"
 cfg-if = "0.1"
-foreign-types = "0.3.1"
+foreign-types = "0.5.0"
 lazy_static = "1"
 libc = "0.2"
 

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -47,10 +47,7 @@ bitflags! {
     }
 }
 
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::CMS_ContentInfo;
-    fn drop = ffi::CMS_ContentInfo_free;
-
+foreign_type! {
     /// High level CMS wrapper
     ///
     /// CMS supports nesting various types of data, including signatures, certificates,
@@ -59,11 +56,10 @@ foreign_type_and_impl_send_sync! {
     /// CMS and OpenSSL follows this RFC's implmentation.
     ///
     /// [`RFC 5652`]: https://tools.ietf.org/html/rfc5652#page-6
-    pub struct CmsContentInfo;
-    /// Reference to [`CMSContentInfo`]
-    ///
-    /// [`CMSContentInfo`]:struct.CmsContentInfo.html
-    pub struct CmsContentInfoRef;
+    pub unsafe type CmsContentInfo : Send + Sync {
+       type CType = ffi::CMS_ContentInfo;
+       fn drop = ffi::CMS_ContentInfo_free;
+    }
 }
 
 impl CmsContentInfoRef {
@@ -129,7 +125,7 @@ impl CmsContentInfo {
 
             let cms = cvt_p(ffi::SMIME_read_CMS(bio.as_ptr(), ptr::null_mut()))?;
 
-            Ok(CmsContentInfo::from_ptr(cms))
+            Ok(CmsContentInfo(cms))
         }
     }
 
@@ -191,7 +187,7 @@ impl CmsContentInfo {
                 flags.bits(),
             ))?;
 
-            Ok(CmsContentInfo::from_ptr(cms))
+            Ok(CmsContentInfo(cms))
         }
     }
 
@@ -217,7 +213,7 @@ impl CmsContentInfo {
                 flags.bits(),
             ))?;
 
-            Ok(CmsContentInfo::from_ptr(cms))
+            Ok(CmsContentInfo(cms))
         }
     }
 }

--- a/openssl/src/conf.rs
+++ b/openssl/src/conf.rs
@@ -28,12 +28,11 @@ impl ConfMethod {
     }
 }
 
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::CONF;
-    fn drop = ffi::NCONF_free;
-
-    pub struct Conf;
-    pub struct ConfRef;
+foreign_type! {
+    pub unsafe type Conf : Send + Sync {
+      type CType = ffi::CONF;
+      fn drop = ffi::NCONF_free;
+    }
 }
 
 impl Conf {

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -8,13 +8,12 @@ use bn::BigNum;
 use pkey::{HasParams, Params};
 use {cvt, cvt_p};
 
-generic_foreign_type_and_impl_send_sync! {
-    type CType = ffi::DH;
-    fn drop = ffi::DH_free;
-
-    pub struct Dh<T>;
-
-    pub struct DhRef<T>;
+foreign_type! {
+    pub unsafe type Dh<T> : Send + Sync {
+      type CType = ffi::DH;
+      type PhantomData = T;
+      fn drop = ffi::DH_free;
+    }
 }
 
 impl<T> DhRef<T>
@@ -47,8 +46,8 @@ where
 impl Dh<Params> {
     pub fn from_params(p: BigNum, g: BigNum, q: BigNum) -> Result<Dh<Params>, ErrorStack> {
         unsafe {
-            let dh = Dh::from_ptr(cvt_p(ffi::DH_new())?);
-            cvt(DH_set0_pqg(dh.0, p.as_ptr(), q.as_ptr(), g.as_ptr()))?;
+            let dh = Dh::from_ptr(cvt_p(ffi::DH_new())?.as_ptr());
+            cvt(DH_set0_pqg(dh.0.as_ptr(), p.as_ptr(), q.as_ptr(), g.as_ptr()))?;
             mem::forget((p, g, q));
             Ok(dh)
         }
@@ -83,7 +82,7 @@ impl Dh<Params> {
     pub fn get_1024_160() -> Result<Dh<Params>, ErrorStack> {
         unsafe {
             ffi::init();
-            cvt_p(ffi::DH_get_1024_160()).map(|p| Dh::from_ptr(p))
+            cvt_p(ffi::DH_get_1024_160()).map(|p| Dh::from_ptr(p.as_ptr()))
         }
     }
 
@@ -92,7 +91,7 @@ impl Dh<Params> {
     pub fn get_2048_224() -> Result<Dh<Params>, ErrorStack> {
         unsafe {
             ffi::init();
-            cvt_p(ffi::DH_get_2048_224()).map(|p| Dh::from_ptr(p))
+            cvt_p(ffi::DH_get_2048_224()).map(|p| Dh::from_ptr(p.as_ptr()))
         }
     }
 
@@ -101,7 +100,7 @@ impl Dh<Params> {
     pub fn get_2048_256() -> Result<Dh<Params>, ErrorStack> {
         unsafe {
             ffi::init();
-            cvt_p(ffi::DH_get_2048_256()).map(|p| Dh::from_ptr(p))
+            cvt_p(ffi::DH_get_2048_256()).map(|p| Dh::from_ptr(p.as_ptr()))
         }
     }
 }

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -132,6 +132,7 @@ pub use ffi::init;
 use libc::c_int;
 
 use error::ErrorStack;
+use std::ptr::NonNull;
 
 #[macro_use]
 mod macros;
@@ -176,11 +177,11 @@ pub mod symm;
 pub mod version;
 pub mod x509;
 
-fn cvt_p<T>(r: *mut T) -> Result<*mut T, ErrorStack> {
-    if r.is_null() {
-        Err(ErrorStack::get())
+fn cvt_p<T>(r: *mut T) -> Result<NonNull<T>, ErrorStack> {
+    if let Some(ptr) = NonNull::new(r) {
+        Ok(ptr)
     } else {
-        Ok(r)
+        Err(ErrorStack::get())
     }
 }
 

--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! private_key_from_pem {
                          ptr::null_mut(),
                          None,
                          passphrase.as_ptr() as *const _ as *mut _))
-                    .map(|p| ::foreign_types::ForeignType::from_ptr(p))
+                    .map(|p| ::foreign_types::ForeignType::from_ptr(p.as_ptr()))
             }
         }
 
@@ -28,7 +28,7 @@ macro_rules! private_key_from_pem {
                          ptr::null_mut(),
                          Some(::util::invoke_passwd_cb::<F>),
                          &mut cb as *mut _ as *mut _))
-                    .map(|p| ::foreign_types::ForeignType::from_ptr(p))
+                    .map(|p| ::foreign_types::ForeignType::from_ptr(p.as_ptr()))
             }
         }
     }
@@ -110,7 +110,7 @@ macro_rules! from_der {
                 ::ffi::init();
                 let len = ::std::cmp::min(der.len(), ::libc::c_long::max_value() as usize) as ::libc::c_long;
                 ::cvt_p($f(::std::ptr::null_mut(), &mut der.as_ptr(), len))
-                    .map(|p| ::foreign_types::ForeignType::from_ptr(p))
+                    .map(|p| ::foreign_types::ForeignType::from_ptr(p.as_ptr()))
             }
         }
     }
@@ -124,146 +124,9 @@ macro_rules! from_pem {
                 ::init();
                 let bio = ::bio::MemBioSlice::new(pem)?;
                 cvt_p($f(bio.as_ptr(), ::std::ptr::null_mut(), None, ::std::ptr::null_mut()))
-                    .map(|p| ::foreign_types::ForeignType::from_ptr(p))
+                    .map(|p| ::foreign_types::ForeignType::from_ptr(p.as_ptr()))
             }
         }
     }
 }
 
-macro_rules! foreign_type_and_impl_send_sync {
-    (
-        $(#[$impl_attr:meta])*
-        type CType = $ctype:ty;
-        fn drop = $drop:expr;
-        $(fn clone = $clone:expr;)*
-
-        $(#[$owned_attr:meta])*
-        pub struct $owned:ident;
-        $(#[$borrowed_attr:meta])*
-        pub struct $borrowed:ident;
-    )
-        => {
-            foreign_type! {
-                $(#[$impl_attr])*
-                type CType = $ctype;
-                fn drop = $drop;
-                $(fn clone = $clone;)*
-                $(#[$owned_attr])*
-                pub struct $owned;
-                $(#[$borrowed_attr])*
-                pub struct $borrowed;
-            }
-
-            unsafe impl Send for $owned{}
-            unsafe impl Send for $borrowed{}
-            unsafe impl Sync for $owned{}
-            unsafe impl Sync for $borrowed{}
-        };
-}
-
-macro_rules! generic_foreign_type_and_impl_send_sync {
-    (
-        $(#[$impl_attr:meta])*
-        type CType = $ctype:ty;
-        fn drop = $drop:expr;
-        $(fn clone = $clone:expr;)*
-
-        $(#[$owned_attr:meta])*
-        pub struct $owned:ident<T>;
-        $(#[$borrowed_attr:meta])*
-        pub struct $borrowed:ident<T>;
-    ) => {
-        $(#[$owned_attr])*
-        pub struct $owned<T>(*mut $ctype, ::std::marker::PhantomData<T>);
-
-        $(#[$impl_attr])*
-        impl<T> ::foreign_types::ForeignType for $owned<T> {
-            type CType = $ctype;
-            type Ref = $borrowed<T>;
-
-            #[inline]
-            unsafe fn from_ptr(ptr: *mut $ctype) -> $owned<T> {
-                $owned(ptr, ::std::marker::PhantomData)
-            }
-
-            #[inline]
-            fn as_ptr(&self) -> *mut $ctype {
-                self.0
-            }
-        }
-
-        impl<T> Drop for $owned<T> {
-            #[inline]
-            fn drop(&mut self) {
-                unsafe { $drop(self.0) }
-            }
-        }
-
-        $(
-            impl<T> Clone for $owned<T> {
-                #[inline]
-                fn clone(&self) -> $owned<T> {
-                    unsafe {
-                        let handle: *mut $ctype = $clone(self.0);
-                        ::foreign_types::ForeignType::from_ptr(handle)
-                    }
-                }
-            }
-
-            impl<T> ::std::borrow::ToOwned for $borrowed<T> {
-                type Owned = $owned<T>;
-                #[inline]
-                fn to_owned(&self) -> $owned<T> {
-                    unsafe {
-                        let handle: *mut $ctype =
-                            $clone(::foreign_types::ForeignTypeRef::as_ptr(self));
-                        $crate::ForeignType::from_ptr(handle)
-                    }
-                }
-            }
-        )*
-
-        impl<T> ::std::ops::Deref for $owned<T> {
-            type Target = $borrowed<T>;
-
-            #[inline]
-            fn deref(&self) -> &$borrowed<T> {
-                unsafe { ::foreign_types::ForeignTypeRef::from_ptr(self.0) }
-            }
-        }
-
-        impl<T> ::std::ops::DerefMut for $owned<T> {
-            #[inline]
-            fn deref_mut(&mut self) -> &mut $borrowed<T> {
-                unsafe { ::foreign_types::ForeignTypeRef::from_ptr_mut(self.0) }
-            }
-        }
-
-        impl<T> ::std::borrow::Borrow<$borrowed<T>> for $owned<T> {
-            #[inline]
-            fn borrow(&self) -> &$borrowed<T> {
-                &**self
-            }
-        }
-
-        impl<T> ::std::convert::AsRef<$borrowed<T>> for $owned<T> {
-            #[inline]
-            fn as_ref(&self) -> &$borrowed<T> {
-                &**self
-            }
-        }
-
-        $(#[$borrowed_attr])*
-        pub struct $borrowed<T>(::foreign_types::Opaque, ::std::marker::PhantomData<T>);
-
-        $(#[$impl_attr])*
-        impl<T> ::foreign_types::ForeignTypeRef for $borrowed<T> {
-            type CType = $ctype;
-        }
-
-        unsafe impl<T> Send for $owned<T>{}
-        unsafe impl<T> Send for $borrowed<T>{}
-        unsafe impl<T> Sync for $owned<T>{}
-        unsafe impl<T> Sync for $borrowed<T>{}
-    };
-}

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -84,7 +84,7 @@ impl Nid {
     pub fn long_name(&self) -> Result<&'static str, ErrorStack> {
         unsafe {
             cvt_p(ffi::OBJ_nid2ln(self.0) as *mut c_char)
-                .map(|nameptr| str::from_utf8(CStr::from_ptr(nameptr).to_bytes()).unwrap())
+                .map(|nameptr| str::from_utf8(CStr::from_ptr(nameptr.as_ptr()).to_bytes()).unwrap())
         }
     }
 
@@ -95,7 +95,7 @@ impl Nid {
     pub fn short_name(&self) -> Result<&'static str, ErrorStack> {
         unsafe {
             cvt_p(ffi::OBJ_nid2sn(self.0) as *mut c_char)
-                .map(|nameptr| str::from_utf8(CStr::from_ptr(nameptr).to_bytes()).unwrap())
+                .map(|nameptr| str::from_utf8(CStr::from_ptr(nameptr.as_ptr()).to_bytes()).unwrap())
         }
     }
 

--- a/openssl/src/ocsp.rs
+++ b/openssl/src/ocsp.rs
@@ -136,12 +136,11 @@ impl<'a> OcspStatus<'a> {
     }
 }
 
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::OCSP_BASICRESP;
-    fn drop = ffi::OCSP_BASICRESP_free;
-
-    pub struct OcspBasicResponse;
-    pub struct OcspBasicResponseRef;
+foreign_type! {
+    pub unsafe type OcspBasicResponse : Send + Sync {
+      type CType = ffi::OCSP_BASICRESP;
+      fn drop = ffi::OCSP_BASICRESP_free;
+    }
 }
 
 impl OcspBasicResponseRef {
@@ -204,12 +203,11 @@ impl OcspBasicResponseRef {
     }
 }
 
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::OCSP_CERTID;
-    fn drop = ffi::OCSP_CERTID_free;
-
-    pub struct OcspCertId;
-    pub struct OcspCertIdRef;
+foreign_type! {
+    pub unsafe type OcspCertId : Send + Sync {
+      type CType = ffi::OCSP_CERTID;
+      fn drop = ffi::OCSP_CERTID_free;
+    }
 }
 
 impl OcspCertId {
@@ -230,12 +228,11 @@ impl OcspCertId {
     }
 }
 
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::OCSP_RESPONSE;
-    fn drop = ffi::OCSP_RESPONSE_free;
-
-    pub struct OcspResponse;
-    pub struct OcspResponseRef;
+foreign_type! {
+    pub unsafe type OcspResponse : Send + Sync {
+      type CType = ffi::OCSP_RESPONSE;
+      fn drop = ffi::OCSP_RESPONSE_free;
+    }
 }
 
 impl OcspResponse {
@@ -293,12 +290,11 @@ impl OcspResponseRef {
     }
 }
 
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::OCSP_REQUEST;
-    fn drop = ffi::OCSP_REQUEST_free;
-
-    pub struct OcspRequest;
-    pub struct OcspRequestRef;
+foreign_type! {
+    pub unsafe type OcspRequest : Send + Sync {
+      type CType = ffi::OCSP_REQUEST;
+      fn drop = ffi::OCSP_REQUEST_free;
+    }
 }
 
 impl OcspRequest {
@@ -337,15 +333,14 @@ impl OcspRequestRef {
         unsafe {
             let ptr = cvt_p(ffi::OCSP_request_add0_id(self.as_ptr(), id.as_ptr()))?;
             mem::forget(id);
-            Ok(OcspOneReqRef::from_ptr_mut(ptr))
+            Ok(OcspOneReqRef::from_ptr_mut(ptr.as_ptr()))
         }
     }
 }
 
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::OCSP_ONEREQ;
-    fn drop = ffi::OCSP_ONEREQ_free;
-
-    pub struct OcspOneReq;
-    pub struct OcspOneReqRef;
+foreign_type! {
+    pub unsafe type OcspOneReq : Send + Sync {
+      type CType = ffi::OCSP_ONEREQ;
+      fn drop = ffi::OCSP_ONEREQ_free;
+    }
 }

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -13,12 +13,11 @@ use stack::Stack;
 use x509::{X509Ref, X509};
 use {cvt, cvt_p};
 
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::PKCS12;
-    fn drop = ffi::PKCS12_free;
-
-    pub struct Pkcs12;
-    pub struct Pkcs12Ref;
+foreign_type! {
+    pub unsafe type Pkcs12 : Send + Sync {
+      type CType = ffi::PKCS12;
+      fn drop = ffi::PKCS12_free;
+    }
 }
 
 impl Pkcs12Ref {

--- a/openssl/src/pkcs7.rs
+++ b/openssl/src/pkcs7.rs
@@ -11,17 +11,14 @@ use x509::store::X509StoreRef;
 use x509::{X509Ref, X509};
 use {cvt, cvt_p};
 
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::PKCS7;
-    fn drop = ffi::PKCS7_free;
-
+foreign_type! {
     /// A PKCS#7 structure.
     ///
     /// Contains signed and/or encrypted data.
-    pub struct Pkcs7;
-
-    /// Reference to `Pkcs7`
-    pub struct Pkcs7Ref;
+    pub unsafe type Pkcs7 : Send + Sync {
+     type CType = ffi::PKCS7;
+     fn drop = ffi::PKCS7_free;
+    }
 }
 
 bitflags! {

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -167,21 +167,21 @@ impl<'a> Signer<'a> {
             let ctx = cvt_p(EVP_MD_CTX_new())?;
             let mut pctx: *mut ffi::EVP_PKEY_CTX = ptr::null_mut();
             let r = ffi::EVP_DigestSignInit(
-                ctx,
+                ctx.as_ptr(),
                 &mut pctx,
                 type_.map(|t| t.as_ptr()).unwrap_or(ptr::null()),
                 ptr::null_mut(),
                 pkey.as_ptr(),
             );
             if r != 1 {
-                EVP_MD_CTX_free(ctx);
+                EVP_MD_CTX_free(ctx.as_ptr());
                 return Err(ErrorStack::get());
             }
 
             assert!(!pctx.is_null());
 
             Ok(Signer {
-                md_ctx: ctx,
+                md_ctx: ctx.as_ptr(),
                 pctx,
                 _p: PhantomData,
             })
@@ -454,21 +454,21 @@ impl<'a> Verifier<'a> {
             let ctx = cvt_p(EVP_MD_CTX_new())?;
             let mut pctx: *mut ffi::EVP_PKEY_CTX = ptr::null_mut();
             let r = ffi::EVP_DigestVerifyInit(
-                ctx,
+                ctx.as_ptr(),
                 &mut pctx,
                 type_.map(|t| t.as_ptr()).unwrap_or(ptr::null()),
                 ptr::null_mut(),
                 pkey.as_ptr(),
             );
             if r != 1 {
-                EVP_MD_CTX_free(ctx);
+                EVP_MD_CTX_free(ctx.as_ptr());
                 return Err(ErrorStack::get());
             }
 
             assert!(!pctx.is_null());
 
             Ok(Verifier {
-                md_ctx: ctx,
+                md_ctx: ctx.as_ptr(),
                 pctx,
                 pkey_pd: PhantomData,
             })

--- a/openssl/src/srtp.rs
+++ b/openssl/src/srtp.rs
@@ -9,13 +9,11 @@ use std::str;
 unsafe fn free(_profile: *mut ffi::SRTP_PROTECTION_PROFILE) {}
 
 #[allow(unused_unsafe)]
-foreign_type_and_impl_send_sync! {
-    type CType = ffi::SRTP_PROTECTION_PROFILE;
-    fn drop = free;
-
-    pub struct SrtpProtectionProfile;
-    /// Reference to `SrtpProtectionProfile`.
-    pub struct SrtpProtectionProfileRef;
+foreign_type! {
+    pub unsafe type SrtpProtectionProfile : Send + Sync {
+       type CType = ffi::SRTP_PROTECTION_PROFILE;
+       fn drop = free;
+    }
 }
 
 impl Stackable for SrtpProtectionProfile {

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -44,7 +44,7 @@ pub fn new<S: Read + Write>(stream: S) -> Result<(*mut BIO, BioMethod), ErrorSta
     });
 
     unsafe {
-        let bio = cvt_p(BIO_new(method.0.get()))?;
+        let bio = cvt_p(BIO_new(method.0.get()))?.as_ptr();
         BIO_set_data(bio, Box::into_raw(state) as *mut _);
         BIO_set_init(bio, 1);
 

--- a/openssl/src/string.rs
+++ b/openssl/src/string.rs
@@ -9,12 +9,11 @@ use std::str;
 
 use stack::Stackable;
 
-foreign_type_and_impl_send_sync! {
+foreign_type! {
+    pub unsafe type OpensslString : Send + Sync {
     type CType = c_char;
     fn drop = free;
-
-    pub struct OpensslString;
-    pub struct OpensslStringRef;
+    }
 }
 
 impl fmt::Display for OpensslString {

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -49,14 +49,12 @@ use stack::StackRef;
 use x509::{X509Object, X509};
 use {cvt, cvt_p};
 
-foreign_type_and_impl_send_sync! {
+foreign_type! {
+    /// A builder type used to construct an `X509Store`.
+    pub unsafe type X509StoreBuilder : Send + Sync {
     type CType = ffi::X509_STORE;
     fn drop = ffi::X509_STORE_free;
-
-    /// A builder type used to construct an `X509Store`.
-    pub struct X509StoreBuilder;
-    /// Reference to an `X509StoreBuilder`.
-    pub struct X509StoreBuilderRef;
+    }
 }
 
 impl X509StoreBuilder {
@@ -96,14 +94,12 @@ impl X509StoreBuilderRef {
     }
 }
 
-foreign_type_and_impl_send_sync! {
+foreign_type! {
+    /// A certificate store to hold trusted `X509` certificates.
+    pub unsafe type X509Store : Send + Sync {
     type CType = ffi::X509_STORE;
     fn drop = ffi::X509_STORE_free;
-
-    /// A certificate store to hold trusted `X509` certificates.
-    pub struct X509Store;
-    /// Reference to an `X509Store`.
-    pub struct X509StoreRef;
+    }
 }
 
 impl X509StoreRef {

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -23,14 +23,12 @@ bitflags! {
     }
 }
 
-foreign_type_and_impl_send_sync! {
+foreign_type! {
+    /// Adjust parameters associated with certificate verification.
+    pub unsafe type X509VerifyParam : Send + Sync {
     type CType = ffi::X509_VERIFY_PARAM;
     fn drop = ffi::X509_VERIFY_PARAM_free;
-
-    /// Adjust parameters associated with certificate verification.
-    pub struct X509VerifyParam;
-    /// Reference to `X509VerifyParam`.
-    pub struct X509VerifyParamRef;
+    }
 }
 
 impl X509VerifyParamRef {


### PR DESCRIPTION
Version 0.5 adds the into_ptr() function on foreign-types i.e. it releases the ownership of the raw pointer. Also changed cvt_p to return NonNull, since foreign-types makes heavy use of it