### PR TITLE
Add SslRef::set_mtu

### DIFF
--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -450,6 +450,10 @@ cfg_if! {
     }
 }
 
+pub unsafe fn SSL_set_mtu(ssl: *mut SSL, mtu: c_long) -> c_long {
+    SSL_ctrl(ssl, SSL_CTRL_SET_MTU, mtu, ptr::null_mut())
+}
+
 pub type GEN_SESSION_CB =
     Option<unsafe extern "C" fn(*const SSL, *mut c_uchar, *mut c_uint) -> c_int>;
 
@@ -711,6 +715,7 @@ pub const SSL_CTRL_SET_TMP_ECDH: c_int = 4;
 #[cfg(any(libressl, all(ossl101, not(ossl110))))]
 pub const SSL_CTRL_GET_SESSION_REUSED: c_int = 8;
 pub const SSL_CTRL_EXTRA_CHAIN_CERT: c_int = 14;
+pub const SSL_CTRL_SET_MTU: c_int = 17;
 #[cfg(any(libressl, all(ossl101, not(ossl110))))]
 pub const SSL_CTRL_OPTIONS: c_int = 32;
 pub const SSL_CTRL_MODE: c_int = 33;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3368,6 +3368,13 @@ impl SslRef {
             }
         }
     }
+
+    /// Sets the MTU used for DTLS connections.
+    ///
+    /// This corresponds to `SSL_set_mtu`.
+    pub fn set_mtu(&mut self, mtu: u32) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::SSL_set_mtu(self.as_ptr(), mtu as c_long) as c_int).map(|_| ()) }
+    }
 }
 
 /// An SSL stream midway through the handshake process.
@@ -3892,6 +3899,7 @@ impl<S> SslStreamBuilder<S> {
     ///
     /// # Panics
     /// This function panics if the given mtu size can't be represented in a positive `c_long` range
+    #[deprecated(note = "Use SslRef::set_mtu instead", since = "0.10.30")]
     pub fn set_dtls_mtu_size(&mut self, mtu_size: usize) {
         unsafe {
             let bio = self.inner.ssl.get_raw_rbio();

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -321,10 +321,9 @@ fn test_connect_with_srtp_ctx() {
             .unwrap();
         ctx.set_private_key_file(&Path::new("test/key.pem"), SslFiletype::PEM)
             .unwrap();
-        let ssl = Ssl::new(&ctx.build()).unwrap();
-        let mut builder = SslStreamBuilder::new(ssl, stream);
-        builder.set_dtls_mtu_size(1500);
-        let mut stream = builder.accept().unwrap();
+        let mut ssl = Ssl::new(&ctx.build()).unwrap();
+        ssl.set_mtu(1500).unwrap();
+        let mut stream = ssl.accept(stream).unwrap();
 
         let mut buf = [0; 60];
         stream
@@ -341,10 +340,9 @@ fn test_connect_with_srtp_ctx() {
     let mut ctx = SslContext::builder(SslMethod::dtls()).unwrap();
     ctx.set_tlsext_use_srtp("SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32")
         .unwrap();
-    let ssl = Ssl::new(&ctx.build()).unwrap();
-    let mut builder = SslStreamBuilder::new(ssl, stream);
-    builder.set_dtls_mtu_size(1500);
-    let mut stream = builder.connect().unwrap();
+    let mut ssl = Ssl::new(&ctx.build()).unwrap();
+    ssl.set_mtu(1500).unwrap();
+    let mut stream = ssl.connect(stream).unwrap();
 
     let mut buf = [1; 60];
     {
@@ -394,9 +392,8 @@ fn test_connect_with_srtp_ssl() {
             "SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32",
             profilenames
         );
-        let mut builder = SslStreamBuilder::new(ssl, stream);
-        builder.set_dtls_mtu_size(1500);
-        let mut stream = builder.accept().unwrap();
+        ssl.set_mtu(1500).unwrap();
+        let mut stream = ssl.accept(stream).unwrap();
 
         let mut buf = [0; 60];
         stream
@@ -414,9 +411,8 @@ fn test_connect_with_srtp_ssl() {
     let mut ssl = Ssl::new(&ctx.build()).unwrap();
     ssl.set_tlsext_use_srtp("SRTP_AES128_CM_SHA1_80:SRTP_AES128_CM_SHA1_32")
         .unwrap();
-    let mut builder = SslStreamBuilder::new(ssl, stream);
-    builder.set_dtls_mtu_size(1500);
-    let mut stream = builder.connect().unwrap();
+    ssl.set_mtu(1500).unwrap();
+    let mut stream = ssl.connect(stream).unwrap();
 
     let mut buf = [1; 60];
     {


### PR DESCRIPTION
This is a significantly less weird than SslStreamBuilder::set_dtls_mtu_size, which is now deprecated.

Closes #1155 