### PR TITLE
Add Debug trait for X509 and other types.

### DIFF
--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -67,15 +67,17 @@ foreign_type_and_impl_send_sync! {
 impl fmt::Display for Asn1GeneralizedTimeRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
-            match MemBio::new() {
+            let mem_bio = match MemBio::new() {
+                Err(_) => return f.write_str(""),
+                Ok(m) => m,
+            };
+            let print_result = cvt(ffi::ASN1_GENERALIZEDTIME_print(
+                mem_bio.as_ptr(),
+                self.as_ptr(),
+            ));
+            match print_result {
                 Err(_) => f.write_str(""),
-                Ok(mem_bio) => match cvt(ffi::ASN1_GENERALIZEDTIME_print(
-                    mem_bio.as_ptr(),
-                    self.as_ptr(),
-                )) {
-                    Err(_) => f.write_str(""),
-                    Ok(_) => f.write_str(str::from_utf8_unchecked(mem_bio.get_buf())),
-                },
+                Ok(_) => f.write_str(str::from_utf8_unchecked(mem_bio.get_buf())),
             }
         }
     }
@@ -211,12 +213,14 @@ impl<'a> PartialOrd<Asn1Time> for &'a Asn1TimeRef {
 impl fmt::Display for Asn1TimeRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
-            match MemBio::new() {
+            let mem_bio = match MemBio::new() {
+                Err(_) => return f.write_str("error"),
+                Ok(m) => m,
+            };
+            let print_result = cvt(ffi::ASN1_TIME_print(mem_bio.as_ptr(), self.as_ptr()));
+            match print_result {
                 Err(_) => f.write_str("error"),
-                Ok(mem_bio) => match cvt(ffi::ASN1_TIME_print(mem_bio.as_ptr(), self.as_ptr())) {
-                    Err(_) => f.write_str("error"),
-                    Ok(_) => f.write_str(str::from_utf8_unchecked(mem_bio.get_buf())),
-                },
+                Ok(_) => f.write_str(str::from_utf8_unchecked(mem_bio.get_buf())),
             }
         }
     }

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -68,7 +68,7 @@ impl fmt::Display for Asn1GeneralizedTimeRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
             let mem_bio = match MemBio::new() {
-                Err(_) => return f.write_str(""),
+                Err(_) => return f.write_str("error"),
                 Ok(m) => m,
             };
             let print_result = cvt(ffi::ASN1_GENERALIZEDTIME_print(
@@ -76,7 +76,7 @@ impl fmt::Display for Asn1GeneralizedTimeRef {
                 self.as_ptr(),
             ));
             match print_result {
-                Err(_) => f.write_str(""),
+                Err(_) => f.write_str("error"),
                 Ok(_) => f.write_str(str::from_utf8_unchecked(mem_bio.get_buf())),
             }
         }

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -67,12 +67,16 @@ foreign_type_and_impl_send_sync! {
 impl fmt::Display for Asn1GeneralizedTimeRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
-            let mem_bio = MemBio::new()?;
-            cvt(ffi::ASN1_GENERALIZEDTIME_print(
-                mem_bio.as_ptr(),
-                self.as_ptr(),
-            ))?;
-            write!(f, "{}", str::from_utf8_unchecked(mem_bio.get_buf()))
+            match MemBio::new() {
+                Err(_) => f.write_str(""),
+                Ok(mem_bio) => match cvt(ffi::ASN1_GENERALIZEDTIME_print(
+                    mem_bio.as_ptr(),
+                    self.as_ptr(),
+                )) {
+                    Err(_) => f.write_str(""),
+                    Ok(_) => f.write_str(str::from_utf8_unchecked(mem_bio.get_buf())),
+                },
+            }
         }
     }
 }
@@ -207,10 +211,20 @@ impl<'a> PartialOrd<Asn1Time> for &'a Asn1TimeRef {
 impl fmt::Display for Asn1TimeRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
-            let mem_bio = MemBio::new()?;
-            cvt(ffi::ASN1_TIME_print(mem_bio.as_ptr(), self.as_ptr()))?;
-            write!(f, "{}", str::from_utf8_unchecked(mem_bio.get_buf()))
+            match MemBio::new() {
+                Err(_) => f.write_str("error"),
+                Ok(mem_bio) => match cvt(ffi::ASN1_TIME_print(mem_bio.as_ptr(), self.as_ptr())) {
+                    Err(_) => f.write_str("error"),
+                    Ok(_) => f.write_str(str::from_utf8_unchecked(mem_bio.get_buf())),
+                },
+            }
         }
+    }
+}
+
+impl fmt::Debug for Asn1TimeRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.to_string())
     }
 }
 
@@ -389,6 +403,15 @@ impl Asn1StringRef {
     }
 }
 
+impl fmt::Debug for Asn1StringRef {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self.as_utf8() {
+            Ok(openssl_string) => openssl_string.fmt(fmt),
+            Err(_) => fmt.write_str("error"),
+        }
+    }
+}
+
 foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_INTEGER;
     fn drop = ffi::ASN1_INTEGER_free;
@@ -527,9 +550,17 @@ impl fmt::Display for Asn1ObjectRef {
                 self.as_ptr(),
                 0,
             );
-            let s = str::from_utf8(&buf[..len as usize]).map_err(|_| fmt::Error)?;
-            fmt.write_str(s)
+            match str::from_utf8(&buf[..len as usize]) {
+                Err(_) => fmt.write_str("error"),
+                Ok(s) => fmt.write_str(s),
+            }
         }
+    }
+}
+
+impl fmt::Debug for Asn1ObjectRef {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str(self.to_string().as_str())
     }
 }
 

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -301,9 +301,7 @@ impl<T> fmt::Debug for PKey<T> {
             Id::ED448 => "Ed448",
             _ => "unknown",
         };
-        fmt.debug_struct("public_key")
-            .field("algorithm", &alg)
-            .finish()
+        fmt.debug_struct("PKey").field("algorithm", &alg).finish()
         // TODO: Print details for each specific type of key
     }
 }

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -49,6 +49,7 @@ use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_long};
 use std::ffi::CString;
+use std::fmt;
 use std::mem;
 use std::ptr;
 
@@ -283,6 +284,27 @@ where
         /// [`i2d_PrivateKey`]: https://www.openssl.org/docs/man1.0.2/crypto/i2d_PrivateKey.html
         private_key_to_der,
         ffi::i2d_PrivateKey
+    }
+}
+
+impl<T> fmt::Debug for PKey<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let alg = match self.id() {
+            Id::RSA => "RSA",
+            Id::HMAC => "HMAC",
+            Id::DSA => "DSA",
+            Id::DH => "DH",
+            Id::EC => "EC",
+            #[cfg(ossl111)]
+            Id::ED25519 => "Ed25519",
+            #[cfg(ossl111)]
+            Id::ED448 => "Ed448",
+            _ => "unknown",
+        };
+        fmt.debug_struct("public_key")
+            .field("algorithm", &alg)
+            .finish()
+        // TODO: Print details for each specific type of key
     }
 }
 

--- a/openssl/src/stack.rs
+++ b/openssl/src/stack.rs
@@ -3,6 +3,7 @@ use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::c_int;
 use std::borrow::Borrow;
 use std::convert::AsRef;
+use std::fmt;
 use std::iter;
 use std::marker::PhantomData;
 use std::mem;
@@ -43,6 +44,15 @@ pub struct Stack<T: Stackable>(*mut T::StackType);
 unsafe impl<T: Stackable + Send> Send for Stack<T> {}
 unsafe impl<T: Stackable + Sync> Sync for Stack<T> {}
 
+impl<T> fmt::Debug for Stack<T>
+where
+    T: Stackable,
+    T::Ref: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_list().entries(self).finish()
+    }
+}
 impl<T: Stackable> Drop for Stack<T> {
     fn drop(&mut self) {
         unsafe {

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -671,6 +671,35 @@ impl Clone for X509 {
     }
 }
 
+impl fmt::Debug for X509 {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let serial = match &self.serial_number().to_bn() {
+            Ok(bn) => match bn.to_hex_str() {
+                Ok(hex) => hex.to_string(),
+                Err(_) => "".to_string(),
+            },
+            Err(_) => "".to_string(),
+        };
+        let mut debug_struct = formatter.debug_struct("X509");
+        debug_struct.field("serial_number", &serial);
+        debug_struct.field("signature_algorithm", &self.signature_algorithm().object());
+        debug_struct.field("issuer", &self.issuer_name());
+        debug_struct.field("subject", &self.subject_name());
+        if let Some(subject_alt_names) = &self.subject_alt_names() {
+            debug_struct.field("subject_alt_names", subject_alt_names);
+        }
+        debug_struct.field("not_before", &self.not_before());
+        debug_struct.field("not_after", &self.not_after());
+
+        if let Ok(public_key) = &self.public_key() {
+            debug_struct.field("public_key", public_key);
+        };
+        // TODO: Print extensions once they are supported on the X509 struct.
+
+        debug_struct.finish()
+    }
+}
+
 impl AsRef<X509Ref> for X509Ref {
     fn as_ref(&self) -> &X509Ref {
         self
@@ -867,6 +896,12 @@ impl X509NameRef {
     }
 }
 
+impl fmt::Debug for X509NameRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.debug_list().entries(self.entries()).finish()
+    }
+}
+
 /// A type to destructure and examine an `X509Name`.
 pub struct X509NameEntries<'a> {
     name: &'a X509NameRef,
@@ -939,6 +974,12 @@ impl X509NameEntryRef {
             let object = ffi::X509_NAME_ENTRY_get_object(self.as_ptr());
             Asn1ObjectRef::from_ptr(object)
         }
+    }
+}
+
+impl fmt::Debug for X509NameEntryRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_fmt(format_args!("{:?} = {:?}", self.object(), self.data()))
     }
 }
 
@@ -1295,6 +1336,25 @@ impl GeneralNameRef {
 
             Some(slice::from_raw_parts(ptr as *const u8, len as usize))
         }
+    }
+}
+
+impl fmt::Debug for GeneralNameRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(email) = self.email() {
+            return formatter.write_str(email);
+        }
+        if let Some(dnsname) = self.dnsname() {
+            return formatter.write_str(dnsname);
+        }
+        if let Some(uri) = self.uri() {
+            return formatter.write_str(uri);
+        }
+        if let Some(ipaddress) = self.ipaddress() {
+            let result = String::from_utf8_lossy(ipaddress);
+            return formatter.write_str(&result);
+        }
+        Ok(())
     }
 }
 

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1342,19 +1342,17 @@ impl GeneralNameRef {
 impl fmt::Debug for GeneralNameRef {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         if let Some(email) = self.email() {
-            return formatter.write_str(email);
-        }
-        if let Some(dnsname) = self.dnsname() {
-            return formatter.write_str(dnsname);
-        }
-        if let Some(uri) = self.uri() {
-            return formatter.write_str(uri);
-        }
-        if let Some(ipaddress) = self.ipaddress() {
+            formatter.write_str(email)
+        } else if let Some(dnsname) = self.dnsname() {
+            formatter.write_str(dnsname)
+        } else if let Some(uri) = self.uri() {
+            formatter.write_str(uri)
+        } else if let Some(ipaddress) = self.ipaddress() {
             let result = String::from_utf8_lossy(ipaddress);
-            return formatter.write_str(&result);
+            formatter.write_str(&result)
+        } else {
+            formatter.write_str("(empty)")
         }
-        Ok(())
     }
 }
 

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -36,27 +36,12 @@ fn test_debug() {
     let cert = include_bytes!("../../test/cert.pem");
     let cert = X509::from_pem(cert).unwrap();
     let debugged = format!("{:#?}", cert);
-    let expected = r#"X509 {
-    serial_number: "8771F7BDEE982FA5",
-    signature_algorithm: sha256WithRSAEncryption,
-    issuer: [
-        countryName = "AU",
-        stateOrProvinceName = "Some-State",
-        organizationName = "Internet Widgits Pty Ltd",
-    ],
-    subject: [
-        countryName = "AU",
-        stateOrProvinceName = "Some-State",
-        organizationName = "Internet Widgits Pty Ltd",
-        commonName = "foobar.com",
-    ],
-    not_before: Aug 14 17:00:03 2016 GMT,
-    not_after: Aug 12 17:00:03 2026 GMT,
-    public_key: PKey {
-        algorithm: "RSA",
-    },
-}"#;
-    assert_eq!(expected, debugged);
+    assert!(debugged.contains(r#"serial_number: "8771F7BDEE982FA5""#));
+    assert!(debugged.contains(r#"signature_algorithm: sha256WithRSAEncryption"#));
+    assert!(debugged.contains(r#"countryName = "AU""#));
+    assert!(debugged.contains(r#"stateOrProvinceName = Some-State"#));
+    assert!(debugged.contains(r#"not_before: Aug 14 17:00:03 2016 GMT"#));
+    assert!(debugged.contains(r#"not_after: Aug 12 17:00:03 2026 GMT"#));
 }
 
 #[test]

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -39,7 +39,7 @@ fn test_debug() {
     assert!(debugged.contains(r#"serial_number: "8771F7BDEE982FA5""#));
     assert!(debugged.contains(r#"signature_algorithm: sha256WithRSAEncryption"#));
     assert!(debugged.contains(r#"countryName = "AU""#));
-    assert!(debugged.contains(r#"stateOrProvinceName = Some-State"#));
+    assert!(debugged.contains(r#"stateOrProvinceName = "Some-State""#));
     assert!(debugged.contains(r#"not_before: Aug 14 17:00:03 2016 GMT"#));
     assert!(debugged.contains(r#"not_after: Aug 12 17:00:03 2026 GMT"#));
 }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -32,6 +32,34 @@ fn test_cert_loading() {
 }
 
 #[test]
+fn test_debug() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let debugged = format!("{:#?}", cert);
+    let expected = r#"X509 {
+    serial_number: "8771F7BDEE982FA5",
+    signature_algorithm: sha256WithRSAEncryption,
+    issuer: [
+        countryName = "AU",
+        stateOrProvinceName = "Some-State",
+        organizationName = "Internet Widgits Pty Ltd",
+    ],
+    subject: [
+        countryName = "AU",
+        stateOrProvinceName = "Some-State",
+        organizationName = "Internet Widgits Pty Ltd",
+        commonName = "foobar.com",
+    ],
+    not_before: Aug 14 17:00:03 2016 GMT,
+    not_after: Aug 12 17:00:03 2026 GMT,
+    public_key: public_key {
+        algorithm: "RSA",
+    },
+}"#;
+    assert_eq!(expected, debugged);
+}
+
+#[test]
 fn test_cert_issue_validity() {
     let cert = include_bytes!("../../test/cert.pem");
     let cert = X509::from_pem(cert).unwrap();

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -52,7 +52,7 @@ fn test_debug() {
     ],
     not_before: Aug 14 17:00:03 2016 GMT,
     not_after: Aug 12 17:00:03 2026 GMT,
-    public_key: public_key {
+    public_key: PKey {
         algorithm: "RSA",
     },
 }"#;


### PR DESCRIPTION
This currently leaves out at least two useful things:
 - The detailed SubjectPublicKeyInfo, e.g. the modulus of RSA keys.
 - Extensions.

This also tweaks a couple of existing Display traits. The existing traits could
return errors if, for instance, an Asn1TimeRef were uninitialized, causing a
panic. Per the `fmt` docs (https://doc.rust-lang.org/std/fmt/index.html#formatting-traits):

> Formatting implementations should ensure that they propagate errors from the Formatter (e.g., when calling write!). However, they should never return errors spuriously. That is, a formatting implementation must and may only return an error if the passed-in Formatter returns an error.