### PR TITLE
Support LibreSSL 3.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,10 +292,10 @@ workflows:
           library: libressl
           version: 2.5.5
       - linux:
-          name: x86_64-libressl-3.1.1
+          name: x86_64-libressl-3.2.0
           target: x86_64-unknown-linux-gnu
           library: libressl
-          version: 3.1.1
+          version: 3.2.0
       - macos:
           name: macos
       - macos:

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -220,6 +220,7 @@ See rust-openssl README for more information:
             (3, 0, _) => ('3', '0', 'x'),
             (3, 1, 0) => ('3', '1', '0'),
             (3, 1, _) => ('3', '1', 'x'),
+            (3, 2, 0) => ('3', '2', '0'),
             _ => version_error(),
         };
 
@@ -260,7 +261,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 3.1.x, but a different version of OpenSSL was found. The build is now aborting
+through 3.2.0, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "


### PR DESCRIPTION
[New development release](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.2.0-relnotes.txt).