### PR TITLE
adding PKE interface

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -433,6 +433,23 @@ extern "C" {
 
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> c_int;
     pub fn EVP_PKEY_keygen(ctx: *mut EVP_PKEY_CTX, key: *mut *mut EVP_PKEY) -> c_int;
+
+    pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> c_int;
+    pub fn EVP_PKEY_encrypt(
+        ctx: *mut EVP_PKEY_CTX,
+        pout: *mut c_uchar,
+        poutlen: *mut size_t,
+        pin: *const c_uchar,
+        pinlen: size_t,
+    ) -> c_int;
+    pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> c_int;
+    pub fn EVP_PKEY_decrypt(
+        ctx: *mut EVP_PKEY_CTX,
+        pout: *mut c_uchar,
+        poutlen: *mut size_t,
+        pin: *const c_uchar,
+        pinlen: size_t,
+    ) -> c_int;
 }
 
 cfg_if! {
@@ -443,6 +460,35 @@ cfg_if! {
     } else {
         extern "C" {
             pub fn EVP_PKCS82PKEY(p8: *mut PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
+        }
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl111))] {
+        extern "C" {
+            pub fn EVP_PKEY_get_raw_public_key(
+                pkey: *const EVP_PKEY,
+                ppub: *mut c_uchar,
+                len: *mut size_t,
+            ) -> c_int;
+            pub fn EVP_PKEY_new_raw_public_key(
+                ttype: c_int,
+                e: *mut ENGINE,
+                key: *const c_uchar,
+                keylen: size_t,
+            ) -> *mut EVP_PKEY;
+            pub fn EVP_PKEY_get_raw_private_key(
+                pkey: *const EVP_PKEY,
+                ppriv: *mut c_uchar,
+                len: *mut size_t,
+            ) -> c_int;
+            pub fn EVP_PKEY_new_raw_private_key(
+                ttype: c_int,
+                e: *mut ENGINE,
+                key: *const c_uchar,
+                keylen: size_t,
+            ) -> *mut EVP_PKEY;
         }
     }
 }

--- a/openssl-sys/src/object.rs
+++ b/openssl-sys/src/object.rs
@@ -15,4 +15,5 @@ extern "C" {
 
     pub fn OBJ_find_sigid_algs(signid: c_int, pdig_nid: *mut c_int, ppkey_nid: *mut c_int)
         -> c_int;
+    pub fn OBJ_sn2nid(sn: *const libc::c_char) -> libc::c_int;
 }


### PR DESCRIPTION
The patch adds PKE interface functions, namely:
     
       EVP_PKEY_encrypt_init
        EVP_PKEY_encrypt
        EVP_PKEY_decrypt_init
        EVP_PKEY_decrypt

Additionally it adds functions for getting and
setting public and private key to/from byte array.

	EVP_PKEY_get_raw_public_key
	EVP_PKEY_new_raw_public_key
	EVP_PKEY_get_raw_private_key
	EVP_PKEY_new_raw_private_key

Finally it also adds a function for getting NID
of a scheme by it's name (SN).