### PR TITLE
Add PEM/DER serialization for EC public key

### DIFF
--- a/openssl-sys/src/pem.rs
+++ b/openssl-sys/src/pem.rs
@@ -92,6 +92,13 @@ extern "C" {
         callback: pem_password_cb,
         user_data: *mut c_void,
     ) -> c_int;
+    pub fn PEM_read_bio_EC_PUBKEY(
+        bp: *mut BIO,
+        ec: *mut *mut EC_KEY,
+        callback: pem_password_cb,
+        user_data: *mut c_void,
+    ) -> *mut EC_KEY;
+    pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, ec: *mut EC_KEY) -> c_int;
     pub fn PEM_read_bio_DHparams(
         bio: *mut BIO,
         out: *mut *mut DH,

--- a/openssl-sys/src/x509.rs
+++ b/openssl-sys/src/x509.rs
@@ -132,6 +132,12 @@ extern "C" {
     pub fn i2d_RSA_PUBKEY(k: *mut RSA, buf: *mut *mut u8) -> c_int;
     pub fn d2i_DSA_PUBKEY(k: *mut *mut DSA, pp: *mut *const c_uchar, length: c_long) -> *mut DSA;
     pub fn i2d_DSA_PUBKEY(a: *mut DSA, pp: *mut *mut c_uchar) -> c_int;
+    pub fn d2i_EC_PUBKEY(
+        a: *mut *mut EC_KEY,
+        pp: *mut *const c_uchar,
+        length: c_long,
+    ) -> *mut EC_KEY;
+    pub fn i2d_EC_PUBKEY(a: *mut EC_KEY, pp: *mut *mut c_uchar) -> c_int;
     pub fn i2d_PrivateKey(k: *mut EVP_PKEY, buf: *mut *mut u8) -> c_int;
 
     pub fn d2i_ECPrivateKey(

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -642,6 +642,28 @@ where
             EcPointRef::from_ptr(ptr as *mut _)
         }
     }
+
+    to_pem! {
+        /// Serialies the public key into a PEM-encoded SubjectPublicKeyInfo structure.
+        ///
+        /// The output will have a header of `-----BEGIN PUBLIC KEY-----`.
+        ///
+        /// This corresponds to [`PEM_write_bio_EC_PUBKEY`].
+        ///
+        /// [`PEM_write_bio_EC_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_EC_PUBKEY.html
+        public_key_to_pem,
+        ffi::PEM_write_bio_EC_PUBKEY
+    }
+
+    to_der! {
+        /// Serializes the public key into a DER-encoded SubjectPublicKeyInfo structure.
+        ///
+        /// This corresponds to [`i2d_EC_PUBKEY`].
+        ///
+        /// [`i2d_EC_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/i2d_EC_PUBKEY.html
+        public_key_to_der,
+        ffi::i2d_EC_PUBKEY
+    }
 }
 
 impl<T> EcKeyRef<T>
@@ -777,6 +799,30 @@ impl EcKey<Public> {
                     .map(|_| key)
                 })
         }
+    }
+
+    from_pem! {
+        /// Decodes a PEM-encoded SubjectPublicKeyInfo structure containing a EC key.
+        ///
+        /// The input should have a header of `-----BEGIN PUBLIC KEY-----`.
+        ///
+        /// This corresponds to [`PEM_read_bio_EC_PUBKEY`].
+        ///
+        /// [`PEM_read_bio_EC_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_read_bio_EC_PUBKEY.html
+        public_key_from_pem,
+        EcKey<Public>,
+        ffi::PEM_read_bio_EC_PUBKEY
+    }
+
+    from_der! {
+        /// Decodes a DER-encoded SubjectPublicKeyInfo structure containing a EC key.
+        ///
+        /// This corresponds to [`d2i_EC_PUBKEY`].
+        ///
+        /// [`d2i_EC_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/d2i_EC_PUBKEY.html
+        public_key_from_der,
+        EcKey<Public>,
+        ffi::d2i_EC_PUBKEY
     }
 }
 


### PR DESCRIPTION
The EC key lacked of public key serialization/deserialization functions. So I just added them. :slightly_smiling_face:  
