### PR TITLE
Fix private key serializtion in HasPublic impl for DsaRef

### DIFF
--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -80,26 +80,6 @@ impl<T> DsaRef<T>
 where
     T: HasPublic,
 {
-    private_key_to_pem! {
-        /// Serializes the private key to a PEM-encoded DSAPrivateKey structure.
-        ///
-        /// The output will have a header of `-----BEGIN DSA PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_DSAPrivateKey`].
-        ///
-        /// [`PEM_write_bio_DSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_DSAPrivateKey.html
-        private_key_to_pem,
-        /// Serializes the private key to a PEM-encoded encrypted DSAPrivateKey structure.
-        ///
-        /// The output will have a header of `-----BEGIN DSA PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_DSAPrivateKey`].
-        ///
-        /// [`PEM_write_bio_DSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_DSAPrivateKey.html
-        private_key_to_pem_passphrase,
-        ffi::PEM_write_bio_DSAPrivateKey
-    }
-
     to_pem! {
         /// Serialies the public key into a PEM-encoded SubjectPublicKeyInfo structure.
         ///
@@ -136,6 +116,26 @@ impl<T> DsaRef<T>
 where
     T: HasPrivate,
 {
+    private_key_to_pem! {
+        /// Serializes the private key to a PEM-encoded DSAPrivateKey structure.
+        ///
+        /// The output will have a header of `-----BEGIN DSA PRIVATE KEY-----`.
+        ///
+        /// This corresponds to [`PEM_write_bio_DSAPrivateKey`].
+        ///
+        /// [`PEM_write_bio_DSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_DSAPrivateKey.html
+        private_key_to_pem,
+        /// Serializes the private key to a PEM-encoded encrypted DSAPrivateKey structure.
+        ///
+        /// The output will have a header of `-----BEGIN DSA PRIVATE KEY-----`.
+        ///
+        /// This corresponds to [`PEM_write_bio_DSAPrivateKey`].
+        ///
+        /// [`PEM_write_bio_DSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_DSAPrivateKey.html
+        private_key_to_pem_passphrase,
+        ffi::PEM_write_bio_DSAPrivateKey
+    }
+
     /// Returns a reference to the private key component of `self`.
     pub fn priv_key(&self) -> &BigNumRef {
         unsafe {


### PR DESCRIPTION
The `private_key_to_pem!` macro for `Dsa` is wrongly placed in `HasPublic` impl block. I moved it to the correct `HasPrivate` block. People can no longer call `private_key_to_pem()` on `Dsa<Public>`.

P.s. By `git blame`, it seems that this was my fault...  :sweat_smile: