### PR TITLE
Add improved pkg-config error message

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2"
 [build-dependencies]
 cc = "1.0"
 openssl-src = { version = "111.0.1", optional = true }
-pkg-config = "0.3.9"
+pkg-config = "0.3.18"
 autocfg = "1.0"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -1,5 +1,6 @@
-use pkg_config;
+use pkg_config::{self, Error as PkgConfigError};
 use std::ffi::OsString;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 
@@ -177,11 +178,15 @@ fn try_pkg_config() {
 
     let lib = match pkg_config::Config::new()
         .print_system_libs(false)
-        .find("openssl")
+        .probe("openssl")
     {
         Ok(lib) => lib,
-        Err(e) => {
-            println!("run pkg_config fail: {:?}", e);
+        Err(PkgConfigError::Command { cause, .. }) if cause.kind() == io::ErrorKind::NotFound => {
+            println!("failed to run pkg-config; is it installed?");
+            return;
+        }
+        Err(err) => {
+            print!("pkg-config error: {}", err);
             return;
         }
     };

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -181,7 +181,9 @@ fn try_pkg_config() {
         .probe("openssl")
     {
         Ok(lib) => lib,
-        Err(PkgConfigError::Command { cause, .. }) if cause.kind() == io::ErrorKind::NotFound => {
+        Err(PkgConfigError::Command { ref cause, .. })
+            if cause.kind() == io::ErrorKind::NotFound =>
+        {
             println!("failed to run pkg-config; is it installed?");
             return;
         }


### PR DESCRIPTION
When failing to run with "Command not found", the build now prints an error message prompting the user to check if pkg-config is installed

Fixes #1316 