### PR TITLE
Make openssl not cleanup at exit, which could lead to race conditions.

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -101,8 +101,13 @@ pub fn init() {
     // explicitly initialize to work around https://github.com/openssl/openssl/issues/3505
     static INIT: Once = Once::new();
 
+    #[cfg(not(ossl111b))]
+    let init_options = OPENSSL_INIT_LOAD_SSL_STRINGS;
+    #[cfg(ossl111b)]
+    let init_options = OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_NO_ATEXIT;
+
     INIT.call_once(|| unsafe {
-        OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, ptr::null_mut());
+        OPENSSL_init_ssl(init_options, ptr::null_mut());
     })
 }
 

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -1398,6 +1398,8 @@ cfg_if! {
 
 #[cfg(ossl110)]
 pub const OPENSSL_INIT_LOAD_SSL_STRINGS: u64 = 0x00200000;
+#[cfg(ossl111b)]
+pub const OPENSSL_INIT_NO_ATEXIT: u64 = 0x00080000;
 
 extern "C" {
     #[cfg(ossl110)]


### PR DESCRIPTION
Fixes #1293.