### PR TITLE
Add constructor for creating Asn1Object from a textual OID representation

### DIFF
--- a/openssl-sys/src/object.rs
+++ b/openssl-sys/src/object.rs
@@ -16,4 +16,5 @@ extern "C" {
     pub fn OBJ_find_sigid_algs(signid: c_int, pdig_nid: *mut c_int, ppkey_nid: *mut c_int)
         -> c_int;
     pub fn OBJ_sn2nid(sn: *const libc::c_char) -> libc::c_int;
+    pub fn OBJ_txt2obj(s: *const libc::c_char, no_name: libc::c_int) -> *mut ASN1_OBJECT;
 }


### PR DESCRIPTION
This is effectively a wrapper for OBJ_txt2obj.