### PR TITLE
Add ecx (X25519, X448) support

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -11,7 +11,11 @@ pub const EVP_PKEY_DSA: c_int = NID_dsa;
 pub const EVP_PKEY_DH: c_int = NID_dhKeyAgreement;
 pub const EVP_PKEY_EC: c_int = NID_X9_62_id_ecPublicKey;
 #[cfg(ossl111)]
+pub const EVP_PKEY_X25519: c_int = NID_X25519;
+#[cfg(ossl111)]
 pub const EVP_PKEY_ED25519: c_int = NID_ED25519;
+#[cfg(ossl111)]
+pub const EVP_PKEY_X448: c_int = NID_X448;
 #[cfg(ossl111)]
 pub const EVP_PKEY_ED448: c_int = NID_ED448;
 pub const EVP_PKEY_HMAC: c_int = NID_hmac;

--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -913,6 +913,10 @@ pub const NID_aes_128_cbc_hmac_sha1: c_int = 916;
 pub const NID_aes_192_cbc_hmac_sha1: c_int = 917;
 pub const NID_aes_256_cbc_hmac_sha1: c_int = 918;
 #[cfg(ossl111)]
+pub const NID_X25519: c_int = 1034;
+#[cfg(ossl111)]
+pub const NID_X448: c_int = 1035;
+#[cfg(ossl111)]
 pub const NID_ED25519: c_int = 1087;
 #[cfg(ossl111)]
 pub const NID_ED448: c_int = 1088;

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -88,6 +88,10 @@ impl Id {
     pub const ED25519: Id = Id(ffi::EVP_PKEY_ED25519);
     #[cfg(ossl111)]
     pub const ED448: Id = Id(ffi::EVP_PKEY_ED448);
+    #[cfg(ossl111)]
+    pub const X25519: Id = Id(ffi::EVP_PKEY_X25519);
+    #[cfg(ossl111)]
+    pub const X448: Id = Id(ffi::EVP_PKEY_X448);
 
     /// Creates a `Id` from an integer representation.
     pub fn from_raw(value: c_int) -> Id {
@@ -492,6 +496,18 @@ impl PKey<Private> {
 
             Ok(PKey::from_ptr(key))
         }
+    }
+
+    /// Generates a new private Ed25519 key
+    #[cfg(ossl111)]
+    pub fn generate_x25519() -> Result<PKey<Private>, ErrorStack> {
+        PKey::generate_eddsa(ffi::EVP_PKEY_X25519)
+    }
+
+    /// Generates a new private Ed448 key
+    #[cfg(ossl111)]
+    pub fn generate_x448() -> Result<PKey<Private>, ErrorStack> {
+        PKey::generate_eddsa(ffi::EVP_PKEY_X448)
     }
 
     /// Generates a new private Ed25519 key


### PR DESCRIPTION
I'm developing [josekit](https://crates.io/crates/josekit) to support JWE in Rust.

The ECDH-ES algorithm in JWE spec needs a ecx (X25519, X448) feature. This feature is supported by openssl. But not by rust-openssl, So I added some constants based on openssl-1.1.1g.

If you can, I'd be happy to merge it.