### PR TITLE
Remove non-cargo directive output of environment variables

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -29,11 +29,6 @@ fn env_inner(name: &str) -> Option<OsString> {
     let var = env::var_os(name);
     println!("cargo:rerun-if-env-changed={}", name);
 
-    match var {
-        Some(ref v) => println!("{} = {}", name, v.to_string_lossy()),
-        None => println!("{} unset", name),
-    }
-
     var
 }
 


### PR DESCRIPTION
I'm not sure of the history of this output, so I'm happy to be corrected,
however, this output doesn't have any effect, and it ends up printing
quite a bit of output when I am building.

I not using cargo, but rules_rust with bazel, so the suppression of this
may be different.