### PR TITLE
Add and use ForeignTypeRefExt::from_const_ptr

### DIFF
--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -15,6 +15,7 @@ use std::ptr;
 use bn::{BigNum, BigNumRef};
 use error::ErrorStack;
 use pkey::{HasParams, HasPrivate, HasPublic, Private, Public};
+use util::ForeignTypeRefExt;
 use {cvt, cvt_p};
 
 generic_foreign_type_and_impl_send_sync! {
@@ -107,7 +108,7 @@ where
         unsafe {
             let mut pub_key = ptr::null();
             DSA_get0_key(self.as_ptr(), &mut pub_key, ptr::null_mut());
-            BigNumRef::from_ptr(pub_key as *mut _)
+            BigNumRef::from_const_ptr(pub_key)
         }
     }
 }
@@ -141,7 +142,7 @@ where
         unsafe {
             let mut priv_key = ptr::null();
             DSA_get0_key(self.as_ptr(), ptr::null_mut(), &mut priv_key);
-            BigNumRef::from_ptr(priv_key as *mut _)
+            BigNumRef::from_const_ptr(priv_key)
         }
     }
 }
@@ -164,7 +165,7 @@ where
         unsafe {
             let mut p = ptr::null();
             DSA_get0_pqg(self.as_ptr(), &mut p, ptr::null_mut(), ptr::null_mut());
-            BigNumRef::from_ptr(p as *mut _)
+            BigNumRef::from_const_ptr(p)
         }
     }
 
@@ -173,7 +174,7 @@ where
         unsafe {
             let mut q = ptr::null();
             DSA_get0_pqg(self.as_ptr(), ptr::null_mut(), &mut q, ptr::null_mut());
-            BigNumRef::from_ptr(q as *mut _)
+            BigNumRef::from_const_ptr(q)
         }
     }
 
@@ -182,7 +183,7 @@ where
         unsafe {
             let mut g = ptr::null();
             DSA_get0_pqg(self.as_ptr(), ptr::null_mut(), ptr::null_mut(), &mut g);
-            BigNumRef::from_ptr(g as *mut _)
+            BigNumRef::from_const_ptr(g)
         }
     }
 }

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -25,6 +25,7 @@ use bn::{BigNumContextRef, BigNumRef};
 use error::ErrorStack;
 use nid::Nid;
 use pkey::{HasParams, HasPrivate, HasPublic, Params, Private, Public};
+use util::ForeignTypeRefExt;
 use {cvt, cvt_n, cvt_p, init};
 
 /// Compressed or Uncompressed conversion
@@ -230,7 +231,7 @@ impl EcGroupRef {
     pub fn generator(&self) -> &EcPointRef {
         unsafe {
             let ptr = ffi::EC_GROUP_get0_generator(self.as_ptr());
-            EcPointRef::from_ptr(ptr as *mut _)
+            EcPointRef::from_const_ptr(ptr)
         }
     }
 
@@ -622,7 +623,7 @@ where
     pub fn private_key(&self) -> &BigNumRef {
         unsafe {
             let ptr = ffi::EC_KEY_get0_private_key(self.as_ptr());
-            BigNumRef::from_ptr(ptr as *mut _)
+            BigNumRef::from_const_ptr(ptr)
         }
     }
 }
@@ -639,7 +640,7 @@ where
     pub fn public_key(&self) -> &EcPointRef {
         unsafe {
             let ptr = ffi::EC_KEY_get0_public_key(self.as_ptr());
-            EcPointRef::from_ptr(ptr as *mut _)
+            EcPointRef::from_const_ptr(ptr)
         }
     }
 
@@ -678,7 +679,7 @@ where
     pub fn group(&self) -> &EcGroupRef {
         unsafe {
             let ptr = ffi::EC_KEY_get0_group(self.as_ptr());
-            EcGroupRef::from_ptr(ptr as *mut _)
+            EcGroupRef::from_const_ptr(ptr)
         }
     }
 

--- a/openssl/src/ecdsa.rs
+++ b/openssl/src/ecdsa.rs
@@ -10,6 +10,7 @@ use bn::{BigNum, BigNumRef};
 use ec::EcKeyRef;
 use error::ErrorStack;
 use pkey::{HasPrivate, HasPublic};
+use util::ForeignTypeRefExt;
 use {cvt_n, cvt_p};
 
 foreign_type_and_impl_send_sync! {
@@ -45,7 +46,7 @@ impl EcdsaSig {
                 data.len() as c_int,
                 eckey.as_ptr(),
             ))?;
-            Ok(EcdsaSig::from_ptr(sig as *mut _))
+            Ok(EcdsaSig::from_ptr(sig))
         }
     }
 
@@ -60,7 +61,7 @@ impl EcdsaSig {
             let sig = cvt_p(ffi::ECDSA_SIG_new())?;
             ECDSA_SIG_set0(sig, r.as_ptr(), s.as_ptr());
             mem::forget((r, s));
-            Ok(EcdsaSig::from_ptr(sig as *mut _))
+            Ok(EcdsaSig::from_ptr(sig))
         }
     }
 
@@ -117,7 +118,7 @@ impl EcdsaSigRef {
         unsafe {
             let mut r = ptr::null();
             ECDSA_SIG_get0(self.as_ptr(), &mut r, ptr::null_mut());
-            BigNumRef::from_ptr(r as *mut _)
+            BigNumRef::from_const_ptr(r)
         }
     }
 
@@ -130,7 +131,7 @@ impl EcdsaSigRef {
         unsafe {
             let mut s = ptr::null();
             ECDSA_SIG_get0(self.as_ptr(), ptr::null_mut(), &mut s);
-            BigNumRef::from_ptr(s as *mut _)
+            BigNumRef::from_const_ptr(s)
         }
     }
 }

--- a/openssl/src/ocsp.rs
+++ b/openssl/src/ocsp.rs
@@ -8,6 +8,7 @@ use asn1::Asn1GeneralizedTimeRef;
 use error::ErrorStack;
 use hash::MessageDigest;
 use stack::StackRef;
+use util::ForeignTypeRefExt;
 use x509::store::X509StoreRef;
 use x509::{X509Ref, X509};
 use {cvt, cvt_p};
@@ -188,11 +189,7 @@ impl OcspBasicResponseRef {
                 &mut next_update,
             );
             if r == 1 {
-                let revocation_time = if revocation_time.is_null() {
-                    None
-                } else {
-                    Some(Asn1GeneralizedTimeRef::from_ptr(revocation_time))
-                };
+                let revocation_time = Asn1GeneralizedTimeRef::from_const_ptr_opt(revocation_time);
 
                 Some(OcspStatus {
                     status: OcspCertStatus(status),

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -10,6 +10,7 @@ use error::ErrorStack;
 use nid::Nid;
 use pkey::{HasPrivate, PKey, PKeyRef, Private};
 use stack::Stack;
+use util::ForeignTypeExt;
 use x509::{X509Ref, X509};
 use {cvt, cvt_p};
 
@@ -52,11 +53,7 @@ impl Pkcs12Ref {
             let pkey = PKey::from_ptr(pkey);
             let cert = X509::from_ptr(cert);
 
-            let chain = if chain.is_null() {
-                None
-            } else {
-                Some(Stack::from_ptr(chain))
-            };
+            let chain = Stack::from_ptr_opt(chain);
 
             Ok(ParsedPkcs12 { pkey, cert, chain })
         }

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -38,6 +38,7 @@ use std::ptr;
 use bn::{BigNum, BigNumRef};
 use error::ErrorStack;
 use pkey::{HasPrivate, HasPublic, Private, Public};
+use util::ForeignTypeRefExt;
 use {cvt, cvt_n, cvt_p};
 
 /// Type of encryption padding to use.
@@ -191,7 +192,7 @@ where
         unsafe {
             let mut d = ptr::null();
             RSA_get0_key(self.as_ptr(), ptr::null_mut(), ptr::null_mut(), &mut d);
-            BigNumRef::from_ptr(d as *mut _)
+            BigNumRef::from_const_ptr(d)
         }
     }
 
@@ -204,11 +205,7 @@ where
         unsafe {
             let mut p = ptr::null();
             RSA_get0_factors(self.as_ptr(), &mut p, ptr::null_mut());
-            if p.is_null() {
-                None
-            } else {
-                Some(BigNumRef::from_ptr(p as *mut _))
-            }
+            BigNumRef::from_const_ptr_opt(p)
         }
     }
 
@@ -221,11 +218,7 @@ where
         unsafe {
             let mut q = ptr::null();
             RSA_get0_factors(self.as_ptr(), ptr::null_mut(), &mut q);
-            if q.is_null() {
-                None
-            } else {
-                Some(BigNumRef::from_ptr(q as *mut _))
-            }
+            BigNumRef::from_const_ptr_opt(q)
         }
     }
 
@@ -238,11 +231,7 @@ where
         unsafe {
             let mut dp = ptr::null();
             RSA_get0_crt_params(self.as_ptr(), &mut dp, ptr::null_mut(), ptr::null_mut());
-            if dp.is_null() {
-                None
-            } else {
-                Some(BigNumRef::from_ptr(dp as *mut _))
-            }
+            BigNumRef::from_const_ptr_opt(dp)
         }
     }
 
@@ -255,11 +244,7 @@ where
         unsafe {
             let mut dq = ptr::null();
             RSA_get0_crt_params(self.as_ptr(), ptr::null_mut(), &mut dq, ptr::null_mut());
-            if dq.is_null() {
-                None
-            } else {
-                Some(BigNumRef::from_ptr(dq as *mut _))
-            }
+            BigNumRef::from_const_ptr_opt(dq)
         }
     }
 
@@ -272,11 +257,7 @@ where
         unsafe {
             let mut qi = ptr::null();
             RSA_get0_crt_params(self.as_ptr(), ptr::null_mut(), ptr::null_mut(), &mut qi);
-            if qi.is_null() {
-                None
-            } else {
-                Some(BigNumRef::from_ptr(qi as *mut _))
-            }
+            BigNumRef::from_const_ptr_opt(qi)
         }
     }
 
@@ -415,7 +396,7 @@ where
         unsafe {
             let mut n = ptr::null();
             RSA_get0_key(self.as_ptr(), &mut n, ptr::null_mut(), ptr::null_mut());
-            BigNumRef::from_ptr(n as *mut _)
+            BigNumRef::from_const_ptr(n)
         }
     }
 
@@ -428,7 +409,7 @@ where
         unsafe {
             let mut e = ptr::null();
             RSA_get0_key(self.as_ptr(), ptr::null_mut(), &mut e, ptr::null_mut());
-            BigNumRef::from_ptr(e as *mut _)
+            BigNumRef::from_const_ptr(e)
         }
     }
 }

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -28,6 +28,7 @@ use ssl::{
     SniError, Ssl, SslAlert, SslContext, SslContextRef, SslRef, SslSession, SslSessionRef,
     SESSION_CTX_INDEX,
 };
+use util::ForeignTypeRefExt;
 #[cfg(ossl111)]
 use x509::X509Ref;
 use x509::{X509StoreContext, X509StoreContextRef};
@@ -424,7 +425,7 @@ pub unsafe extern "C" fn raw_keylog<F>(ssl: *const ffi::SSL, line: *const c_char
 where
     F: Fn(&SslRef, &str) + 'static + Sync + Send,
 {
-    let ssl = SslRef::from_ptr(ssl as *mut _);
+    let ssl = SslRef::from_const_ptr(ssl);
     let callback = ssl
         .ssl_context()
         .ex_data(SslContext::cached_ex_index::<F>())

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -93,6 +93,7 @@ use ssl::bio::BioMethod;
 use ssl::callbacks::*;
 use ssl::error::InnerError;
 use stack::{Stack, StackRef};
+use util::{ForeignTypeExt, ForeignTypeRefExt};
 use x509::store::{X509Store, X509StoreBuilderRef, X509StoreRef};
 #[cfg(any(ossl102, libressl261))]
 use x509::verify::X509VerifyParamRef;
@@ -1865,11 +1866,7 @@ impl SslContextRef {
     pub fn certificate(&self) -> Option<&X509Ref> {
         unsafe {
             let ptr = ffi::SSL_CTX_get0_certificate(self.as_ptr());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(X509Ref::from_ptr(ptr))
-            }
+            X509Ref::from_const_ptr_opt(ptr)
         }
     }
 
@@ -1884,11 +1881,7 @@ impl SslContextRef {
     pub fn private_key(&self) -> Option<&PKeyRef<Private>> {
         unsafe {
             let ptr = ffi::SSL_CTX_get0_privatekey(self.as_ptr());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(PKeyRef::from_ptr(ptr))
-            }
+            PKeyRef::from_const_ptr_opt(ptr)
         }
     }
 
@@ -1908,8 +1901,7 @@ impl SslContextRef {
         unsafe {
             let mut chain = ptr::null_mut();
             ffi::SSL_CTX_get_extra_chain_certs(self.as_ptr(), &mut chain);
-            assert!(!chain.is_null());
-            StackRef::from_ptr(chain)
+            StackRef::from_const_ptr_opt(chain).expect("extra chain certs must not be null")
         }
     }
 
@@ -2578,11 +2570,7 @@ impl SslRef {
         unsafe {
             let ptr = ffi::SSL_get_current_cipher(self.as_ptr());
 
-            if ptr.is_null() {
-                None
-            } else {
-                Some(SslCipherRef::from_ptr(ptr as *mut _))
-            }
+            SslCipherRef::from_const_ptr_opt(ptr)
         }
     }
 
@@ -2637,11 +2625,7 @@ impl SslRef {
     pub fn peer_certificate(&self) -> Option<X509> {
         unsafe {
             let ptr = ffi::SSL_get_peer_certificate(self.as_ptr());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(X509::from_ptr(ptr))
-            }
+            X509::from_ptr_opt(ptr)
         }
     }
 
@@ -2656,11 +2640,7 @@ impl SslRef {
     pub fn peer_cert_chain(&self) -> Option<&StackRef<X509>> {
         unsafe {
             let ptr = ffi::SSL_get_peer_cert_chain(self.as_ptr());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(StackRef::from_ptr(ptr))
-            }
+            StackRef::from_const_ptr_opt(ptr)
         }
     }
 
@@ -2680,11 +2660,7 @@ impl SslRef {
     pub fn verified_chain(&self) -> Option<&StackRef<X509>> {
         unsafe {
             let ptr = ffi::SSL_get0_verified_chain(self.as_ptr());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(StackRef::from_ptr(ptr))
-            }
+            StackRef::from_const_ptr_opt(ptr)
         }
     }
 
@@ -2696,11 +2672,7 @@ impl SslRef {
     pub fn certificate(&self) -> Option<&X509Ref> {
         unsafe {
             let ptr = ffi::SSL_get_certificate(self.as_ptr());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(X509Ref::from_ptr(ptr))
-            }
+            X509Ref::from_const_ptr_opt(ptr)
         }
     }
 
@@ -2712,11 +2684,7 @@ impl SslRef {
     pub fn private_key(&self) -> Option<&PKeyRef<Private>> {
         unsafe {
             let ptr = ffi::SSL_get_privatekey(self.as_ptr());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(PKeyRef::from_ptr(ptr))
-            }
+            PKeyRef::from_const_ptr_opt(ptr)
         }
     }
 
@@ -2812,11 +2780,7 @@ impl SslRef {
         unsafe {
             let chain = ffi::SSL_get_srtp_profiles(self.as_ptr());
 
-            if chain.is_null() {
-                None
-            } else {
-                Some(StackRef::from_ptr(chain))
-            }
+            StackRef::from_const_ptr_opt(chain)
         }
     }
 
@@ -2831,11 +2795,7 @@ impl SslRef {
         unsafe {
             let profile = ffi::SSL_get_selected_srtp_profile(self.as_ptr());
 
-            if profile.is_null() {
-                None
-            } else {
-                Some(SrtpProtectionProfileRef::from_ptr(profile as *mut _))
-            }
+            SrtpProtectionProfileRef::from_const_ptr_opt(profile)
         }
     }
 
@@ -2943,11 +2903,7 @@ impl SslRef {
     pub fn session(&self) -> Option<&SslSessionRef> {
         unsafe {
             let p = ffi::SSL_get_session(self.as_ptr());
-            if p.is_null() {
-                None
-            } else {
-                Some(SslSessionRef::from_ptr(p))
-            }
+            SslSessionRef::from_const_ptr_opt(p)
         }
     }
 

--- a/openssl/src/stack.rs
+++ b/openssl/src/stack.rs
@@ -10,6 +10,7 @@ use std::mem;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 
 use error::ErrorStack;
+use util::ForeignTypeExt;
 use {cvt, cvt_p};
 
 cfg_if! {
@@ -249,11 +250,7 @@ impl<T: Stackable> StackRef<T> {
     pub fn pop(&mut self) -> Option<T> {
         unsafe {
             let ptr = OPENSSL_sk_pop(self.as_stack());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(T::from_ptr(ptr as *mut _))
-            }
+            T::from_ptr_opt(ptr as *mut _)
         }
     }
 

--- a/openssl/src/util.rs
+++ b/openssl/src/util.rs
@@ -1,3 +1,4 @@
+use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_char, c_int, c_void};
 use std::any::Any;
 use std::panic::{self, AssertUnwindSafe};
@@ -65,3 +66,29 @@ where
         }
     }
 }
+
+pub trait ForeignTypeExt: ForeignType {
+    unsafe fn from_ptr_opt(ptr: *mut Self::CType) -> Option<Self> {
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self::from_ptr(ptr))
+        }
+    }
+}
+impl<FT: ForeignType> ForeignTypeExt for FT {}
+
+pub trait ForeignTypeRefExt: ForeignTypeRef {
+    unsafe fn from_const_ptr<'a>(ptr: *const Self::CType) -> &'a Self {
+        Self::from_ptr(ptr as *mut Self::CType)
+    }
+
+    unsafe fn from_const_ptr_opt<'a>(ptr: *const Self::CType) -> Option<&'a Self> {
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self::from_const_ptr(ptr as *mut Self::CType))
+        }
+    }
+}
+impl<FT: ForeignTypeRef> ForeignTypeRefExt for FT {}

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -31,6 +31,7 @@ use pkey::{HasPrivate, HasPublic, PKey, PKeyRef, Public};
 use ssl::SslRef;
 use stack::{Stack, StackRef, Stackable};
 use string::OpensslString;
+use util::{ForeignTypeExt, ForeignTypeRefExt};
 use {cvt, cvt_n, cvt_p};
 
 #[cfg(any(ossl102, libressl261))]
@@ -181,11 +182,7 @@ impl X509StoreContextRef {
     pub fn current_cert(&self) -> Option<&X509Ref> {
         unsafe {
             let ptr = ffi::X509_STORE_CTX_get_current_cert(self.as_ptr());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(X509Ref::from_ptr(ptr))
-            }
+            X509Ref::from_const_ptr_opt(ptr)
         }
     }
 
@@ -393,8 +390,7 @@ impl X509Ref {
     pub fn subject_name(&self) -> &X509NameRef {
         unsafe {
             let name = ffi::X509_get_subject_name(self.as_ptr());
-            assert!(!name.is_null());
-            X509NameRef::from_ptr(name)
+            X509NameRef::from_const_ptr_opt(name).expect("subject name must not be null")
         }
     }
 
@@ -413,8 +409,7 @@ impl X509Ref {
     pub fn issuer_name(&self) -> &X509NameRef {
         unsafe {
             let name = ffi::X509_get_issuer_name(self.as_ptr());
-            assert!(!name.is_null());
-            X509NameRef::from_ptr(name)
+            X509NameRef::from_const_ptr_opt(name).expect("issuer name must not be null")
         }
     }
 
@@ -431,11 +426,7 @@ impl X509Ref {
                 ptr::null_mut(),
                 ptr::null_mut(),
             );
-            if stack.is_null() {
-                None
-            } else {
-                Some(Stack::from_ptr(stack as *mut _))
-            }
+            Stack::from_ptr_opt(stack as *mut _)
         }
     }
 
@@ -452,11 +443,7 @@ impl X509Ref {
                 ptr::null_mut(),
                 ptr::null_mut(),
             );
-            if stack.is_null() {
-                None
-            } else {
-                Some(Stack::from_ptr(stack as *mut _))
-            }
+            Stack::from_ptr_opt(stack as *mut _)
         }
     }
 
@@ -500,8 +487,7 @@ impl X509Ref {
     pub fn not_after(&self) -> &Asn1TimeRef {
         unsafe {
             let date = X509_getm_notAfter(self.as_ptr());
-            assert!(!date.is_null());
-            Asn1TimeRef::from_ptr(date)
+            Asn1TimeRef::from_const_ptr_opt(date).expect("not_after must not be null")
         }
     }
 
@@ -509,8 +495,7 @@ impl X509Ref {
     pub fn not_before(&self) -> &Asn1TimeRef {
         unsafe {
             let date = X509_getm_notBefore(self.as_ptr());
-            assert!(!date.is_null());
-            Asn1TimeRef::from_ptr(date)
+            Asn1TimeRef::from_const_ptr_opt(date).expect("not_before must not be null")
         }
     }
 
@@ -519,8 +504,7 @@ impl X509Ref {
         unsafe {
             let mut signature = ptr::null();
             X509_get0_signature(&mut signature, ptr::null_mut(), self.as_ptr());
-            assert!(!signature.is_null());
-            Asn1BitStringRef::from_ptr(signature as *mut _)
+            Asn1BitStringRef::from_const_ptr_opt(signature).expect("signature must not be null")
         }
     }
 
@@ -529,8 +513,8 @@ impl X509Ref {
         unsafe {
             let mut algor = ptr::null();
             X509_get0_signature(ptr::null_mut(), &mut algor, self.as_ptr());
-            assert!(!algor.is_null());
-            X509AlgorithmRef::from_ptr(algor as *mut _)
+            X509AlgorithmRef::from_const_ptr_opt(algor)
+                .expect("signature algorithm must not be null")
         }
     }
 
@@ -573,8 +557,7 @@ impl X509Ref {
     pub fn serial_number(&self) -> &Asn1IntegerRef {
         unsafe {
             let r = ffi::X509_get_serialNumber(self.as_ptr());
-            assert!(!r.is_null());
-            Asn1IntegerRef::from_ptr(r)
+            Asn1IntegerRef::from_const_ptr_opt(r).expect("serial number must not be null")
         }
     }
 
@@ -940,9 +923,8 @@ impl<'a> Iterator for X509NameEntries<'a> {
             }
 
             let entry = ffi::X509_NAME_get_entry(self.name.as_ptr(), self.loc);
-            assert!(!entry.is_null());
 
-            Some(X509NameEntryRef::from_ptr(entry))
+            Some(X509NameEntryRef::from_const_ptr_opt(entry).expect("entry must not be null"))
         }
     }
 }
@@ -1186,8 +1168,7 @@ impl X509ReqRef {
     pub fn subject_name(&self) -> &X509NameRef {
         unsafe {
             let name = X509_REQ_get_subject_name(self.as_ptr());
-            assert!(!name.is_null());
-            X509NameRef::from_ptr(name)
+            X509NameRef::from_const_ptr_opt(name).expect("subject name must not be null")
         }
     }
 
@@ -1383,8 +1364,7 @@ impl X509AlgorithmRef {
         unsafe {
             let mut oid = ptr::null();
             X509_ALGOR_get0(&mut oid, ptr::null_mut(), ptr::null_mut(), self.as_ptr());
-            assert!(!oid.is_null());
-            Asn1ObjectRef::from_ptr(oid as *mut _)
+            Asn1ObjectRef::from_const_ptr_opt(oid).expect("algorithm oid must not be null")
         }
     }
 }
@@ -1403,11 +1383,7 @@ impl X509ObjectRef {
     pub fn x509(&self) -> Option<&X509Ref> {
         unsafe {
             let ptr = X509_OBJECT_get0_X509(self.as_ptr());
-            if ptr.is_null() {
-                None
-            } else {
-                Some(X509Ref::from_ptr(ptr))
-            }
+            X509Ref::from_const_ptr_opt(ptr)
         }
     }
 }


### PR DESCRIPTION
1. `X::from_ptr(p as *mut _)` is dangerous, as it not only casts `*const X::CType` to `*mut X::CType`, but any `*const U` to `*mut X::CType`.
   Add and use a extension trait to provide `from_const_ptr`.
2. Often null pointers are returned as `Option<...>`; refactor the checks into `from_const_ptr_opt` for refs and `from_ptr_opt` for owned data.
3. `assert!(!p.is_null())` is easy to mistype as `assert!(p.is_null());`.
   Use `X::from(_const)?ptr_opt(...).expect("...")` instead.