### PR TITLE
Fix ASN1_OCTET_STRING in bindings

### DIFF
--- a/openssl-sys/src/x509.rs
+++ b/openssl-sys/src/x509.rs
@@ -545,7 +545,7 @@ extern "C" {
     pub fn X509_EXTENSION_set_critical(ex: *mut X509_EXTENSION, crit: c_int) -> c_int;
     pub fn X509_EXTENSION_set_data(ex: *mut X509_EXTENSION, data: *mut ASN1_OCTET_STRING) -> c_int;
     pub fn X509_EXTENSION_get_object(ext: *mut X509_EXTENSION) -> *mut ASN1_OBJECT;
-    pub fn X509_EXTENSION_get_data(ext: *mut X509_EXTENSION) -> *mut ASN1_STRING;
+    pub fn X509_EXTENSION_get_data(ext: *mut X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 cfg_if! {
     if #[cfg(any(ossl110, libressl280))] {

--- a/openssl-sys/src/x509v3.rs
+++ b/openssl-sys/src/x509v3.rs
@@ -29,7 +29,7 @@ extern "C" {
 
 #[repr(C)]
 pub struct AUTHORITY_KEYID {
-    pub keyid: *mut ASN1_STRING,
+    pub keyid: *mut ASN1_OCTET_STRING,
     pub issuer: *mut stack_st_GENERAL_NAME,
     pub serial: *mut ASN1_INTEGER,
 }


### PR DESCRIPTION
In #1344 I used `ASN1_STRING` in places where openssl actually uses `ASN1_OCTET_STRING`; the checks don't detect that as in C this is a simple typedef.

As #1344 shouldn't be part of a release yet this still can be fixed afaict.