### PR TITLE
openssl-sys: declare_std_functions macro

### DIFF
--- a/openssl-sys/src/asn1.rs
+++ b/openssl-sys/src/asn1.rs
@@ -2,6 +2,8 @@ use libc::*;
 
 use *;
 
+pub enum ASN1_ITEM {}
+
 pub const V_ASN1_UTCTIME: c_int = 23;
 pub const V_ASN1_GENERALIZEDTIME: c_int = 24;
 
@@ -18,11 +20,38 @@ pub struct ASN1_ENCODING {
     pub modified: c_int,
 }
 
-extern "C" {
-    pub fn ASN1_OBJECT_free(x: *mut ASN1_OBJECT);
+declare_std_functions! {
+    type CType = ASN1_OBJECT;
+    fn free = ASN1_OBJECT_free;
 }
 
 stack!(stack_st_ASN1_OBJECT);
+
+declare_std_functions! {
+    type CType = ASN1_INTEGER;
+    fn free = ASN1_INTEGER_free;
+}
+
+declare_std_functions! {
+    type CType = ASN1_BIT_STRING;
+    fn free = ASN1_BIT_STRING_free;
+}
+
+declare_std_functions! {
+    type CType = ASN1_TIME;
+    fn new = ASN1_TIME_new;
+    fn free = ASN1_TIME_free;
+}
+
+declare_std_functions! {
+    type CType = ASN1_GENERALIZEDTIME;
+    fn free = ASN1_GENERALIZEDTIME_free;
+}
+
+declare_std_functions! {
+    type CType = ASN1_STRING;
+    fn free = ASN1_STRING_free;
+}
 
 extern "C" {
     pub fn ASN1_STRING_type_new(ty: c_int) -> *mut ASN1_STRING;
@@ -31,14 +60,9 @@ extern "C" {
     #[cfg(any(all(ossl101, not(ossl110)), libressl))]
     pub fn ASN1_STRING_data(x: *mut ASN1_STRING) -> *mut c_uchar;
 
-    pub fn ASN1_BIT_STRING_free(x: *mut ASN1_BIT_STRING);
-
-    pub fn ASN1_STRING_free(x: *mut ASN1_STRING);
     pub fn ASN1_STRING_length(x: *const ASN1_STRING) -> c_int;
 
-    pub fn ASN1_GENERALIZEDTIME_free(tm: *mut ASN1_GENERALIZEDTIME);
     pub fn ASN1_GENERALIZEDTIME_print(b: *mut BIO, tm: *const ASN1_GENERALIZEDTIME) -> c_int;
-    pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
     #[cfg(ossl102)]
     pub fn ASN1_TIME_diff(
         pday: *mut c_int,
@@ -46,11 +70,9 @@ extern "C" {
         from: *const ASN1_TIME,
         to: *const ASN1_TIME,
     ) -> c_int;
-    pub fn ASN1_TIME_free(tm: *mut ASN1_TIME);
     pub fn ASN1_TIME_print(b: *mut BIO, tm: *const ASN1_TIME) -> c_int;
     pub fn ASN1_TIME_set(from: *mut ASN1_TIME, to: time_t) -> *mut ASN1_TIME;
 
-    pub fn ASN1_INTEGER_free(x: *mut ASN1_INTEGER);
     pub fn ASN1_INTEGER_get(dest: *const ASN1_INTEGER) -> c_long;
     pub fn ASN1_INTEGER_set(dest: *mut ASN1_INTEGER, value: c_long) -> c_int;
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;

--- a/openssl-sys/src/bn.rs
+++ b/openssl-sys/src/bn.rs
@@ -7,14 +7,24 @@ pub type BN_ULONG = c_ulonglong;
 #[cfg(target_pointer_width = "32")]
 pub type BN_ULONG = c_uint;
 
+declare_std_functions! {
+    type CType = BN_CTX;
+    fn new = BN_CTX_new;
+    fn free = BN_CTX_free;
+}
+
+declare_std_functions! {
+    type CType = BIGNUM;
+    fn new = BN_new;
+    fn free = BN_free;
+    fn dup = BN_dup;
+}
+
 extern "C" {
-    pub fn BN_CTX_new() -> *mut BN_CTX;
-    pub fn BN_CTX_free(ctx: *mut BN_CTX);
     pub fn BN_rand(r: *mut BIGNUM, bits: c_int, top: c_int, bottom: c_int) -> c_int;
     pub fn BN_pseudo_rand(r: *mut BIGNUM, bits: c_int, top: c_int, bottom: c_int) -> c_int;
     pub fn BN_rand_range(r: *mut BIGNUM, range: *const BIGNUM) -> c_int;
     pub fn BN_pseudo_rand_range(r: *mut BIGNUM, range: *const BIGNUM) -> c_int;
-    pub fn BN_new() -> *mut BIGNUM;
     pub fn BN_num_bits(bn: *const BIGNUM) -> c_int;
     pub fn BN_clear_free(bn: *mut BIGNUM);
     pub fn BN_bin2bn(s: *const u8, size: c_int, ret: *mut BIGNUM) -> *mut BIGNUM;
@@ -76,7 +86,6 @@ extern "C" {
     pub fn BN_set_word(bn: *mut BIGNUM, n: BN_ULONG) -> c_int;
 
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> c_int;
-    pub fn BN_free(bn: *mut BIGNUM);
     pub fn BN_is_bit_set(a: *const BIGNUM, n: c_int) -> c_int;
     pub fn BN_lshift(r: *mut BIGNUM, a: *const BIGNUM, n: c_int) -> c_int;
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> c_int;
@@ -105,7 +114,6 @@ extern "C" {
         ctx: *mut BN_CTX,
     ) -> *mut BIGNUM;
     pub fn BN_clear(bn: *mut BIGNUM);
-    pub fn BN_dup(n: *const BIGNUM) -> *mut BIGNUM;
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> c_int;
     pub fn BN_set_bit(a: *mut BIGNUM, n: c_int) -> c_int;
     pub fn BN_clear_bit(a: *mut BIGNUM, n: c_int) -> c_int;

--- a/openssl-sys/src/dh.rs
+++ b/openssl-sys/src/dh.rs
@@ -1,12 +1,14 @@
 use *;
 
+declare_std_functions! {
+    type CType = DH;
+    fn new = DH_new;
+    fn free = DH_free;
+    fn d2i = d2i_DHparams;
+    fn i2d_constapi = i2d_DHparams;
+}
+
 extern "C" {
-    pub fn DH_new() -> *mut DH;
-    pub fn DH_free(dh: *mut DH);
-
-    pub fn d2i_DHparams(k: *mut *mut DH, pp: *mut *const c_uchar, length: c_long) -> *mut DH;
-    pub fn i2d_DHparams(dh: *const DH, pp: *mut *mut c_uchar) -> c_int;
-
     #[cfg(ossl102)]
     pub fn DH_get_1024_160() -> *mut DH;
     #[cfg(ossl102)]

--- a/openssl-sys/src/dsa.rs
+++ b/openssl-sys/src/dsa.rs
@@ -2,10 +2,18 @@ use libc::*;
 
 use *;
 
+declare_std_functions! {
+    type CType = DSA;
+    fn new = DSA_new;
+    fn free = DSA_free;
+    fn up_ref = DSA_up_ref;
+    fn d2i = d2i_DSAPublicKey;
+    fn i2d_constapi = i2d_DSAPublicKey;
+    fn d2i = d2i_DSAPrivateKey;
+    fn i2d_constapi = i2d_DSAPrivateKey;
+}
+
 extern "C" {
-    pub fn DSA_new() -> *mut DSA;
-    pub fn DSA_free(dsa: *mut DSA);
-    pub fn DSA_up_ref(dsa: *mut DSA) -> c_int;
     pub fn DSA_size(dsa: *const DSA) -> c_int;
     pub fn DSA_sign(
         dummy: c_int,
@@ -24,10 +32,6 @@ extern "C" {
         dsa: *mut DSA,
     ) -> c_int;
 
-    pub fn d2i_DSAPublicKey(a: *mut *mut DSA, pp: *mut *const c_uchar, length: c_long) -> *mut DSA;
-    pub fn d2i_DSAPrivateKey(a: *mut *mut DSA, pp: *mut *const c_uchar, length: c_long)
-        -> *mut DSA;
-
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: c_int,
@@ -39,8 +43,6 @@ extern "C" {
     ) -> c_int;
 
     pub fn DSA_generate_key(dsa: *mut DSA) -> c_int;
-    pub fn i2d_DSAPublicKey(a: *const DSA, pp: *mut *mut c_uchar) -> c_int;
-    pub fn i2d_DSAPrivateKey(a: *const DSA, pp: *mut *mut c_uchar) -> c_int;
 
     #[cfg(any(ossl110, libressl273))]
     pub fn DSA_get0_pqg(

--- a/openssl-sys/src/ec.rs
+++ b/openssl-sys/src/ec.rs
@@ -146,16 +146,18 @@ extern "C" {
         m: *const BIGNUM,
         ctx: *mut BN_CTX,
     ) -> c_int;
+}
 
-    pub fn EC_KEY_new() -> *mut EC_KEY;
+declare_std_functions! {
+    type CType = EC_KEY;
+    fn new = EC_KEY_new;
+    fn free = EC_KEY_free;
+    fn dup = EC_KEY_dup;
+    fn up_ref = EC_KEY_up_ref;
+}
 
+extern "C" {
     pub fn EC_KEY_new_by_curve_name(nid: c_int) -> *mut EC_KEY;
-
-    pub fn EC_KEY_free(key: *mut EC_KEY);
-
-    pub fn EC_KEY_dup(key: *const EC_KEY) -> *mut EC_KEY;
-
-    pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> c_int;
 
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 
@@ -192,11 +194,15 @@ cfg_if! {
     }
 }
 
+declare_std_functions! {
+    type CType = ECDSA_SIG;
+    fn new = ECDSA_SIG_new;
+    fn free = ECDSA_SIG_free;
+    fn d2i = d2i_ECDSA_SIG;
+    fn i2d_constapi = i2d_ECDSA_SIG;
+}
+
 extern "C" {
-    pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
-
-    pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
-
     #[cfg(any(ossl110, libressl273))]
     pub fn ECDSA_SIG_get0(sig: *const ECDSA_SIG, pr: *mut *const BIGNUM, ps: *mut *const BIGNUM);
 
@@ -215,12 +221,4 @@ extern "C" {
         sig: *const ECDSA_SIG,
         eckey: *mut EC_KEY,
     ) -> c_int;
-
-    pub fn d2i_ECDSA_SIG(
-        sig: *mut *mut ECDSA_SIG,
-        inp: *mut *const c_uchar,
-        length: c_long,
-    ) -> *mut ECDSA_SIG;
-
-    pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, out: *mut *mut c_uchar) -> c_int;
 }

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -38,18 +38,17 @@ extern "C" {
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> c_int;
 }
 
-cfg_if! {
-    if #[cfg(ossl110)] {
-        extern "C" {
-            pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
-            pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
-        }
-    } else {
-        extern "C" {
-            pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
-            pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
-        }
-    }
+declare_std_functions! {
+    type CType = EVP_MD_CTX;
+    #[cfg(any(ossl110, libressl270))]
+    fn new = EVP_MD_CTX_new;
+    #[cfg(any(ossl110, libressl270))]
+    fn free = EVP_MD_CTX_free;
+    // libressl kept those around as symbols; openssl #defines them
+    #[cfg(not(ossl110))]
+    fn new = EVP_MD_CTX_create;
+    #[cfg(not(ossl110))]
+    fn free = EVP_MD_CTX_destroy;
 }
 
 extern "C" {
@@ -328,6 +327,14 @@ cfg_if! {
         }
     }
 }
+declare_std_functions! {
+    type CType = EVP_PKEY;
+    fn new = EVP_PKEY_new;
+    fn free = EVP_PKEY_free;
+    #[cfg(any(ossl110, libressl270))]
+    fn up_ref = EVP_PKEY_up_ref;
+    fn d2i = d2i_AutoPrivateKey;
+}
 extern "C" {
     pub fn EVP_PKEY_assign(pkey: *mut EVP_PKEY, typ: c_int, key: *mut c_void) -> c_int;
 
@@ -336,17 +343,6 @@ extern "C" {
     pub fn EVP_PKEY_get1_DSA(k: *mut EVP_PKEY) -> *mut DSA;
     pub fn EVP_PKEY_get1_DH(k: *mut EVP_PKEY) -> *mut DH;
     pub fn EVP_PKEY_get1_EC_KEY(k: *mut EVP_PKEY) -> *mut EC_KEY;
-
-    pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
-    pub fn EVP_PKEY_free(k: *mut EVP_PKEY);
-    #[cfg(any(ossl110, libressl270))]
-    pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> c_int;
-
-    pub fn d2i_AutoPrivateKey(
-        a: *mut *mut EVP_PKEY,
-        pp: *mut *const c_uchar,
-        length: c_long,
-    ) -> *mut EVP_PKEY;
 
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> c_int;
 

--- a/openssl-sys/src/macros.rs
+++ b/openssl-sys/src/macros.rs
@@ -85,3 +85,233 @@ macro_rules! const_fn {
         )*
     }
 }
+
+// match DECLARE_ASN1_FUNCTIONS #define in openssl, and more functions with a
+// rather "standard" signature
+//
+//
+// The list below defines those signatures (the identifier after `# fn` for
+// functions and after `# static` for variables); those signatures can depend on
+// the usual cfg version flags.
+//
+// Assuming changes to those signatures are made in a consistent way in
+// openssl/libressl this should remove a lot of #[cfg] in the remaining part of
+// the bindings.
+//
+// Use with syntax like this:
+//
+// ```
+// declare_std_functions! {
+//     type CType = ASN1_FOOTYPE;
+//     static item = ASN1_FOOTYPE_it;
+//     fn new = ASN1_FOOTYPE_new;
+//     fn free = ASN1_FOOTYPE_free;
+//     fn dup = ASN1_FOOTYPE_dup;
+//     fn d2i = d2i_ASN1_FOOTYPE;
+//     fn i2d = i2d_ASN1_FOOTYPE;
+// }
+// ```
+//
+// While the syntax does not suggest it, you can define multiple functions for
+// the same signature like this:
+// ```
+//     fn d2i = d2i_FOOPublicKey;
+//     fn d2i = d2i_FOOPrivateKey;
+// ```
+macro_rules! declare_std_functions {
+    // each "item" should be exactly one 'static' or one 'fn', but the macro_rules parser is rather stubborn
+    (
+        type CType = $ctype:ty;
+        $(
+            $(#[$attr:meta])*
+            $(static $static_id:ident = $static_name:ident)*
+            $(fn $fn_id:ident = $fn_name:ident)*
+            ;
+        )*
+    ) => {
+        $(
+            declare_std_functions!(
+                (#
+                    $(static $static_id)*
+                    $(fn $fn_id)*
+                )
+                ($ctype) ($(#[$attr])*)
+                (
+                    $($static_name)*
+                    $($fn_name)*
+                )
+            );
+        )*
+    };
+    // impls for specific static $idents
+    ( (# static item) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub static $name: ASN1_ITEM;
+        }
+    };
+    // impls for specific fn $idents
+    ( (# fn new) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub fn $name() -> *mut $ctype;
+        }
+    };
+    ( (# fn free) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype);
+        }
+    };
+    ( (# fn dup_oldapi) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            // #[cfg(ossl3)] will take `x: *const $ctype`, but in older versions we need *mut
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype) -> *mut $ctype;
+        }
+    };
+    ( (# fn dup) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub fn $name(x: *const $ctype) -> *mut $ctype;
+        }
+    };
+    ( (# fn up_ref) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype) -> c_int;
+        }
+    };
+    ( (# fn d2i) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub fn $name(a: *mut *mut $ctype, pp: *mut *const c_uchar, length: c_long) -> *mut $ctype;
+        }
+    };
+    ( (# fn i2d_constapi) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            // some i2d functions always took a const ptr
+            $(#[$attr])*
+            pub fn $name(a: *const $ctype, out: *mut *mut c_uchar) -> c_int;
+        }
+    };
+    ( (# fn i2d) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            // with #[cfg(ossl3)] those will take `a: *const $ctype`
+            $(#[$attr])*
+            pub fn $name(a: *mut $ctype, out: *mut *mut c_uchar) -> c_int;
+        }
+    };
+    ( (# fn d2i_bio) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub fn $name(b: *mut BIO, x: *mut *mut $ctype) -> *mut $ctype;
+        }
+    };
+    ( (# fn i2d_bio) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            // with #[cfg(ossl3)] those will take `x: *const $ctype`
+            $(#[$attr])*
+            pub fn $name(b: *mut BIO, x: *mut $ctype) -> c_int;
+        }
+    };
+    // x509 extension stuff
+    ( (# fn ext_delete) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype, loc: c_int) -> *mut X509_EXTENSION;
+        }
+    };
+    ( (# fn ext_add) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype, ext: *mut X509_EXTENSION, loc: c_int) -> c_int;
+        }
+    };
+    ( (# fn ext_add1_i2d) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            $(#[$attr])*
+            pub fn $name(
+                x: *mut $ctype,
+                nid: c_int,
+                value: *mut c_void,
+                crit: c_int,
+                flags: c_ulong,
+            ) -> c_int;
+        }
+    };
+    ( (# fn ext_get_count) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            #[cfg(any(ossl110, libressl280))]
+            $(#[$attr])*
+            pub fn $name(x: *const $ctype) -> c_int;
+            #[cfg(not(any(ossl110, libressl280)))]
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype) -> c_int;
+        }
+    };
+    ( (# fn ext_get_by_NID) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            #[cfg(any(ossl110, libressl280))]
+            $(#[$attr])*
+            pub fn $name(x: *const $ctype, nid: c_int, lastpos: c_int) -> c_int;
+            #[cfg(not(any(ossl110, libressl280)))]
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype, nid: c_int, lastpos: c_int) -> c_int;
+        }
+    };
+    ( (# fn ext_get_by_OBJ) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            #[cfg(any(ossl110, libressl280))]
+            $(#[$attr])*
+            pub fn $name(x: *const $ctype, obj: *const ASN1_OBJECT, lastpos: c_int) -> c_int;
+            #[cfg(not(any(ossl110, libressl280)))]
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype, obj: *mut ASN1_OBJECT, lastpos: c_int) -> c_int;
+        }
+    };
+    ( (# fn ext_get_by_critical) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            #[cfg(any(ossl110, libressl280))]
+            $(#[$attr])*
+            pub fn $name(x: *const $ctype, crit: c_int, lastpos: c_int) -> c_int;
+            #[cfg(not(any(ossl110, libressl280)))]
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype, crit: c_int, lastpos: c_int) -> c_int;
+        }
+    };
+    ( (# fn ext_get) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            #[cfg(any(ossl110, libressl280))]
+            $(#[$attr])*
+            pub fn $name(x: *const $ctype, loc: c_int) -> *mut X509_EXTENSION;
+            #[cfg(not(any(ossl110, libressl280)))]
+            $(#[$attr])*
+            pub fn $name(x: *mut $ctype, loc: c_int) -> *mut X509_EXTENSION;
+        }
+    };
+    ( (# fn ext_get_d2i) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        extern "C" {
+            #[cfg(any(ossl110, libressl280))]
+            $(#[$attr])*
+            pub fn $name(
+                x: *const $ctype,
+                nid: c_int,
+                crit: *mut c_int,
+                idx: *mut c_int,
+            ) -> *mut c_void;
+            #[cfg(not(any(ossl110, libressl280)))]
+            $(#[$attr])*
+            pub fn $name(
+                x: *mut $ctype,
+                nid: c_int,
+                crit: *mut c_int,
+                idx: *mut c_int,
+            ) -> *mut c_void;
+        }
+    };
+    // handle unknown idents
+    ( (# $item_type:ident $ident:ident) ($ctype:ty) ($(#[$attr:meta])*) ($name:ident)) => {
+        compile_error!(concat!("unknown ASN.1 base ", stringify!($item_type), " ", stringify!($ident)));
+    };
+}

--- a/openssl-sys/src/ocsp.rs
+++ b/openssl-sys/src/ocsp.rs
@@ -64,6 +64,38 @@ cfg_if! {
     }
 }
 
+declare_std_functions! {
+    type CType = OCSP_BASICRESP;
+    fn new = OCSP_BASICRESP_new;
+    fn free = OCSP_BASICRESP_free;
+}
+
+declare_std_functions! {
+    type CType = OCSP_RESPONSE;
+    fn new = OCSP_RESPONSE_new;
+    fn free = OCSP_RESPONSE_free;
+    fn i2d = i2d_OCSP_RESPONSE;
+    fn d2i = d2i_OCSP_RESPONSE;
+}
+
+declare_std_functions! {
+    type CType = OCSP_ONEREQ;
+    fn free = OCSP_ONEREQ_free;
+}
+
+declare_std_functions! {
+    type CType = OCSP_CERTID;
+    fn free = OCSP_CERTID_free;
+}
+
+declare_std_functions! {
+    type CType = OCSP_REQUEST;
+    fn new = OCSP_REQUEST_new;
+    fn free = OCSP_REQUEST_free;
+    fn i2d = i2d_OCSP_REQUEST;
+    fn d2i = d2i_OCSP_REQUEST;
+}
+
 extern "C" {
     pub fn OCSP_request_add0_id(r: *mut OCSP_REQUEST, id: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 
@@ -87,27 +119,6 @@ extern "C" {
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 
     pub fn OCSP_response_create(status: c_int, bs: *mut OCSP_BASICRESP) -> *mut OCSP_RESPONSE;
-
-    pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
-    pub fn OCSP_BASICRESP_free(r: *mut OCSP_BASICRESP);
-    pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
-    pub fn OCSP_RESPONSE_free(r: *mut OCSP_RESPONSE);
-    pub fn i2d_OCSP_RESPONSE(a: *mut OCSP_RESPONSE, pp: *mut *mut c_uchar) -> c_int;
-    pub fn d2i_OCSP_RESPONSE(
-        a: *mut *mut OCSP_RESPONSE,
-        pp: *mut *const c_uchar,
-        length: c_long,
-    ) -> *mut OCSP_RESPONSE;
-    pub fn OCSP_ONEREQ_free(r: *mut OCSP_ONEREQ);
-    pub fn OCSP_CERTID_free(id: *mut OCSP_CERTID);
-    pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
-    pub fn OCSP_REQUEST_free(r: *mut OCSP_REQUEST);
-    pub fn i2d_OCSP_REQUEST(a: *mut OCSP_REQUEST, pp: *mut *mut c_uchar) -> c_int;
-    pub fn d2i_OCSP_REQUEST(
-        a: *mut *mut OCSP_REQUEST,
-        pp: *mut *const c_uchar,
-        length: c_long,
-    ) -> *mut OCSP_REQUEST;
 
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,

--- a/openssl-sys/src/pkcs12.rs
+++ b/openssl-sys/src/pkcs12.rs
@@ -4,11 +4,15 @@ use *;
 
 pub enum PKCS12 {}
 
-extern "C" {
-    pub fn PKCS12_free(p12: *mut PKCS12);
-    pub fn i2d_PKCS12(a: *mut PKCS12, buf: *mut *mut u8) -> c_int;
-    pub fn d2i_PKCS12(a: *mut *mut PKCS12, pp: *mut *const u8, length: c_long) -> *mut PKCS12;
+declare_std_functions! {
+    type CType = PKCS12;
+    fn free = PKCS12_free;
+    fn d2i = d2i_PKCS12;
+    fn i2d = i2d_PKCS12;
+    fn i2d_bio = i2d_PKCS12_bio;
+}
 
+extern "C" {
     pub fn PKCS12_parse(
         p12: *mut PKCS12,
         pass: *const c_char,
@@ -49,8 +53,4 @@ cfg_if! {
             ) -> *mut PKCS12;
         }
     }
-}
-
-extern "C" {
-    pub fn i2d_PKCS12_bio(b: *mut BIO, a: *mut PKCS12) -> c_int;
 }

--- a/openssl-sys/src/pkcs7.rs
+++ b/openssl-sys/src/pkcs7.rs
@@ -28,11 +28,14 @@ pub const PKCS7_REUSE_DIGEST: c_int = 0x8000;
 #[cfg(not(any(ossl101, ossl102, libressl)))]
 pub const PKCS7_NO_DUAL_CONTENT: c_int = 0x10000;
 
+declare_std_functions! {
+    type CType = PKCS7;
+    fn free = PKCS7_free;
+    fn d2i = d2i_PKCS7;
+    fn i2d = i2d_PKCS7;
+}
+
 extern "C" {
-    pub fn d2i_PKCS7(a: *mut *mut PKCS7, pp: *mut *const c_uchar, length: c_long) -> *mut PKCS7;
-
-    pub fn i2d_PKCS7(a: *mut PKCS7, buf: *mut *mut u8) -> c_int;
-
     pub fn PKCS7_encrypt(
         certs: *mut stack_st_X509,
         b: *mut BIO,
@@ -64,8 +67,6 @@ extern "C" {
         data: *mut BIO,
         flags: c_int,
     ) -> c_int;
-
-    pub fn PKCS7_free(pkcs7: *mut PKCS7);
 
     pub fn SMIME_write_PKCS7(
         out: *mut BIO,

--- a/openssl-sys/src/rsa.rs
+++ b/openssl-sys/src/rsa.rs
@@ -63,8 +63,18 @@ pub const RSA_PKCS1_OAEP_PADDING: c_int = 4;
 pub const RSA_X931_PADDING: c_int = 5;
 pub const RSA_PKCS1_PSS_PADDING: c_int = 6;
 
+declare_std_functions! {
+    type CType = RSA;
+    fn new = RSA_new;
+    fn free = RSA_free;
+    fn up_ref = RSA_up_ref;
+    fn d2i = d2i_RSAPublicKey;
+    fn i2d_constapi = i2d_RSAPublicKey;
+    fn d2i = d2i_RSAPrivateKey;
+    fn i2d_constapi = i2d_RSAPrivateKey;
+}
+
 extern "C" {
-    pub fn RSA_new() -> *mut RSA;
     pub fn RSA_size(k: *const RSA) -> c_int;
 
     #[cfg(any(ossl110, libressl273))]
@@ -144,13 +154,6 @@ extern "C" {
         pad: c_int,
     ) -> c_int;
     pub fn RSA_check_key(r: *const ::RSA) -> c_int;
-    pub fn RSA_free(rsa: *mut RSA);
-    pub fn RSA_up_ref(rsa: *mut RSA) -> c_int;
-
-    pub fn i2d_RSAPublicKey(k: *const RSA, buf: *mut *mut u8) -> c_int;
-    pub fn d2i_RSAPublicKey(k: *mut *mut RSA, buf: *mut *const u8, len: c_long) -> *mut RSA;
-    pub fn i2d_RSAPrivateKey(k: *const RSA, buf: *mut *mut u8) -> c_int;
-    pub fn d2i_RSAPrivateKey(k: *mut *mut RSA, buf: *mut *const u8, len: c_long) -> *mut RSA;
 
     pub fn RSA_sign(
         t: c_int,

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -899,12 +899,15 @@ pub unsafe fn SSL_get_max_proto_version(s: *mut SSL) -> c_int {
     SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, ptr::null_mut()) as c_int
 }
 
+declare_std_functions! {
+    type CType = SSL_CTX;
+    fn free = SSL_CTX_free;
+    #[cfg(any(ossl110, libressl273))]
+    fn up_ref = SSL_CTX_up_ref;
+}
 extern "C" {
     pub fn SSL_CTX_set_cipher_list(ssl: *mut SSL_CTX, s: *const c_char) -> c_int;
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
-    pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
-    #[cfg(any(ossl110, libressl273))]
-    pub fn SSL_CTX_up_ref(x: *mut SSL_CTX) -> c_int;
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
 
@@ -922,6 +925,16 @@ cfg_if! {
         }
     }
 }
+
+declare_std_functions! {
+    type CType = SSL_SESSION;
+    fn free = SSL_SESSION_free;
+    #[cfg(any(ossl110, libressl273))]
+    fn up_ref = SSL_SESSION_up_ref;
+    fn d2i = d2i_SSL_SESSION;
+    fn i2d = i2d_SSL_SESSION;
+}
+
 extern "C" {
     #[cfg(ossl111)]
     pub fn SSL_CIPHER_get_handshake_digest(cipher: *const ::SSL_CIPHER) -> *const ::EVP_MD;
@@ -980,18 +993,9 @@ extern "C" {
     pub fn SSL_SESSION_get_max_early_data(ctx: *const SSL_SESSION) -> u32;
 
     pub fn SSL_SESSION_get_id(s: *const SSL_SESSION, len: *mut c_uint) -> *const c_uchar;
-    #[cfg(any(ossl110, libressl273))]
-    pub fn SSL_SESSION_up_ref(ses: *mut SSL_SESSION) -> c_int;
-    pub fn SSL_SESSION_free(s: *mut SSL_SESSION);
-    pub fn i2d_SSL_SESSION(s: *mut SSL_SESSION, pp: *mut *mut c_uchar) -> c_int;
     pub fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int;
     pub fn SSL_CTX_add_session(ctx: *mut SSL_CTX, session: *mut SSL_SESSION) -> c_int;
     pub fn SSL_CTX_remove_session(ctx: *mut SSL_CTX, session: *mut SSL_SESSION) -> c_int;
-    pub fn d2i_SSL_SESSION(
-        a: *mut *mut SSL_SESSION,
-        pp: *mut *const c_uchar,
-        len: c_long,
-    ) -> *mut SSL_SESSION;
 
     pub fn SSL_get_peer_certificate(ssl: *const SSL) -> *mut X509;
 

--- a/openssl-sys/src/x509.rs
+++ b/openssl-sys/src/x509.rs
@@ -170,6 +170,64 @@ pub enum X509_LOOKUP {}
 
 stack!(stack_st_X509_LOOKUP);
 
+declare_std_functions! {
+    type CType = X509;
+    fn new = X509_new;
+    fn free = X509_free;
+    #[cfg(any(ossl110, libressl273))]
+    fn up_ref = X509_up_ref;
+    fn d2i = d2i_X509;
+    fn i2d = i2d_X509;
+    fn i2d_bio = i2d_X509_bio;
+    fn ext_delete = X509_delete_ext;
+    fn ext_add = X509_add_ext;
+    fn ext_add1_i2d = X509_add1_ext_i2d;
+    fn ext_get_count = X509_get_ext_count;
+    fn ext_get_by_NID = X509_get_ext_by_NID;
+    fn ext_get_by_OBJ = X509_get_ext_by_OBJ;
+    fn ext_get_by_critical = X509_get_ext_by_critical;
+    fn ext_get = X509_get_ext;
+    fn ext_get_d2i = X509_get_ext_d2i;
+}
+
+declare_std_functions! {
+    type CType = X509_REQ;
+    fn new = X509_REQ_new;
+    fn free = X509_REQ_free;
+    fn d2i = d2i_X509_REQ;
+    fn i2d = i2d_X509_REQ;
+    fn i2d_bio = i2d_X509_REQ_bio;
+}
+
+declare_std_functions! {
+    type CType = EVP_PKEY;
+    fn d2i = d2i_PUBKEY;
+    fn i2d = i2d_PUBKEY;
+    fn i2d = i2d_PrivateKey;
+    fn i2d_bio = i2d_PUBKEY_bio;
+    fn i2d_bio = i2d_PrivateKey_bio;
+}
+
+declare_std_functions! {
+    type CType = RSA;
+    fn d2i = d2i_RSA_PUBKEY;
+    fn i2d = i2d_RSA_PUBKEY;
+}
+
+declare_std_functions! {
+    type CType = DSA;
+    fn d2i = d2i_DSA_PUBKEY;
+    fn i2d = i2d_DSA_PUBKEY;
+}
+
+declare_std_functions! {
+    type CType = EC_KEY;
+    fn d2i = d2i_EC_PUBKEY;
+    fn i2d = i2d_EC_PUBKEY;
+    fn d2i = d2i_ECPrivateKey;
+    fn i2d = i2d_ECPrivateKey;
+}
+
 extern "C" {
     pub fn X509_verify_cert_error_string(n: c_long) -> *const c_char;
 
@@ -183,32 +241,6 @@ extern "C" {
     ) -> c_int;
 
     pub fn X509_REQ_sign(x: *mut X509_REQ, pkey: *mut EVP_PKEY, md: *const EVP_MD) -> c_int;
-
-    pub fn i2d_X509_bio(b: *mut BIO, x: *mut X509) -> c_int;
-    pub fn i2d_X509_REQ_bio(b: *mut BIO, x: *mut X509_REQ) -> c_int;
-    pub fn i2d_PrivateKey_bio(b: *mut BIO, x: *mut EVP_PKEY) -> c_int;
-    pub fn i2d_PUBKEY_bio(b: *mut BIO, x: *mut EVP_PKEY) -> c_int;
-
-    pub fn i2d_PUBKEY(k: *mut EVP_PKEY, buf: *mut *mut u8) -> c_int;
-    pub fn d2i_PUBKEY(k: *mut *mut EVP_PKEY, buf: *mut *const u8, len: c_long) -> *mut EVP_PKEY;
-    pub fn d2i_RSA_PUBKEY(k: *mut *mut RSA, buf: *mut *const u8, len: c_long) -> *mut RSA;
-    pub fn i2d_RSA_PUBKEY(k: *mut RSA, buf: *mut *mut u8) -> c_int;
-    pub fn d2i_DSA_PUBKEY(k: *mut *mut DSA, pp: *mut *const c_uchar, length: c_long) -> *mut DSA;
-    pub fn i2d_DSA_PUBKEY(a: *mut DSA, pp: *mut *mut c_uchar) -> c_int;
-    pub fn d2i_EC_PUBKEY(
-        a: *mut *mut EC_KEY,
-        pp: *mut *const c_uchar,
-        length: c_long,
-    ) -> *mut EC_KEY;
-    pub fn i2d_EC_PUBKEY(a: *mut EC_KEY, pp: *mut *mut c_uchar) -> c_int;
-    pub fn i2d_PrivateKey(k: *mut EVP_PKEY, buf: *mut *mut u8) -> c_int;
-
-    pub fn d2i_ECPrivateKey(
-        k: *mut *mut EC_KEY,
-        pp: *mut *const c_uchar,
-        length: c_long,
-    ) -> *mut EC_KEY;
-    pub fn i2d_ECPrivateKey(ec_key: *mut EC_KEY, pp: *mut *mut c_uchar) -> c_int;
 }
 
 cfg_if! {
@@ -233,40 +265,107 @@ cfg_if! {
     }
 }
 
+declare_std_functions! {
+    type CType = X509_REVOKED;
+    fn new = X509_REVOKED_new;
+    fn free = X509_REVOKED_free;
+    #[cfg(any(ossl110, libressl270))]
+    fn dup_oldapi = X509_REVOKED_dup;
+    fn d2i = d2i_X509_REVOKED;
+    fn i2d = i2d_X509_REVOKED;
+    fn ext_delete = X509_REVOKED_delete_ext;
+    fn ext_add = X509_REVOKED_add_ext;
+    fn ext_add1_i2d = X509_REVOKED_add1_ext_i2d;
+    fn ext_get_count = X509_REVOKED_get_ext_count;
+    fn ext_get_by_NID = X509_REVOKED_get_ext_by_NID;
+    fn ext_get_by_OBJ = X509_REVOKED_get_ext_by_OBJ;
+    fn ext_get_by_critical = X509_REVOKED_get_ext_by_critical;
+    fn ext_get = X509_REVOKED_get_ext;
+    fn ext_get_d2i = X509_REVOKED_get_ext_d2i;
+}
+
+declare_std_functions! {
+    type CType = X509_CRL;
+    fn new = X509_CRL_new;
+    fn free = X509_CRL_free;
+    #[cfg(any(ossl110, libressl270))]
+    fn up_ref = X509_CRL_up_ref;
+    fn d2i = d2i_X509_CRL;
+    fn i2d = i2d_X509_CRL;
+    fn ext_delete = X509_CRL_delete_ext;
+    fn ext_add = X509_CRL_add_ext;
+    fn ext_add1_i2d = X509_CRL_add1_ext_i2d;
+    fn ext_get_count = X509_CRL_get_ext_count;
+    fn ext_get_by_NID = X509_CRL_get_ext_by_NID;
+    fn ext_get_by_OBJ = X509_CRL_get_ext_by_OBJ;
+    fn ext_get_by_critical = X509_CRL_get_ext_by_critical;
+    fn ext_get = X509_CRL_get_ext;
+    fn ext_get_d2i = X509_CRL_get_ext_d2i;
+}
+
+declare_std_functions! {
+    type CType = stack_st_X509_EXTENSION;
+    // add defined for `*mut stack_st_X509_EXTENSION`
+    fn ext_delete = X509v3_delete_ext;
+    // fn ext_get_count_constapi = X509v3_get_ext_count;
+    // fn ext_get_by_NID_constapi = X509v3_get_ext_by_NID;
+    #[cfg(any(ossl110, libressl280))]
+    fn ext_get_by_OBJ = X509v3_get_ext_by_OBJ;
+    // fn ext_get_by_critical_constapi = X509v3_get_ext_by_critical;
+    // fn ext_get = X509v3_get_ext;
+    // fn ext_get_d2i -> x509v3.rs
+}
+extern "C" {
+    // always used *const STACK but *mut ASN1_OBJECT in old versions
+    #[cfg(not(any(ossl110, libressl280)))]
+    pub fn X509v3_get_ext_by_OBJ(
+        x: *const stack_st_X509_EXTENSION,
+        obj: *mut ASN1_OBJECT,
+        lastpos: c_int,
+    ) -> c_int;
+    // these getters always used *const STACK
+    pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> c_int;
+    pub fn X509v3_get_ext_by_NID(
+        x: *const stack_st_X509_EXTENSION,
+        nid: c_int,
+        lastpos: c_int,
+    ) -> c_int;
+    pub fn X509v3_get_ext_by_critical(
+        x: *const stack_st_X509_EXTENSION,
+        crit: c_int,
+        lastpos: c_int,
+    ) -> c_int;
+    pub fn X509v3_get_ext(x: *const stack_st_X509_EXTENSION, loc: c_int) -> *mut X509_EXTENSION;
+    // return value non-standard scheme (others return c_int)
+    pub fn X509v3_add_ext(
+        x: *mut *mut stack_st_X509_EXTENSION,
+        ex: *mut X509_EXTENSION,
+        loc: c_int,
+    ) -> *mut stack_st_X509_EXTENSION;
+}
+
 extern "C" {
     pub fn X509_gmtime_adj(time: *mut ASN1_TIME, adj: c_long) -> *mut ASN1_TIME;
 
     pub fn X509_to_X509_REQ(x: *mut X509, pkey: *mut EVP_PKEY, md: *const EVP_MD) -> *mut X509_REQ;
 
     pub fn X509_ALGOR_free(x: *mut X509_ALGOR);
+}
 
-    pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
-    pub fn X509_REVOKED_free(x: *mut X509_REVOKED);
-    #[cfg(any(ossl110, libressl270))]
-    pub fn X509_REVOKED_dup(rev: *mut X509_REVOKED) -> *mut X509_REVOKED;
-    pub fn d2i_X509_REVOKED(
-        a: *mut *mut X509_REVOKED,
-        pp: *mut *const c_uchar,
-        length: c_long,
-    ) -> *mut X509_REVOKED;
-    pub fn i2d_X509_REVOKED(x: *mut X509_REVOKED, buf: *mut *mut u8) -> c_int;
-    pub fn X509_CRL_new() -> *mut X509_CRL;
-    pub fn X509_CRL_free(x: *mut X509_CRL);
-    pub fn d2i_X509_CRL(
-        a: *mut *mut X509_CRL,
-        pp: *mut *const c_uchar,
-        length: c_long,
-    ) -> *mut X509_CRL;
-    pub fn i2d_X509_CRL(x: *mut X509_CRL, buf: *mut *mut u8) -> c_int;
+declare_std_functions! {
+    type CType = X509_NAME;
+    fn new = X509_NAME_new;
+    fn free = X509_NAME_free;
+}
 
-    pub fn X509_REQ_new() -> *mut X509_REQ;
-    pub fn X509_REQ_free(x: *mut X509_REQ);
-    pub fn d2i_X509_REQ(
-        a: *mut *mut X509_REQ,
-        pp: *mut *const c_uchar,
-        length: c_long,
-    ) -> *mut X509_REQ;
-    pub fn i2d_X509_REQ(x: *mut X509_REQ, buf: *mut *mut u8) -> c_int;
+declare_std_functions! {
+    type CType = X509_NAME_ENTRY;
+    fn free = X509_NAME_ENTRY_free;
+}
+
+declare_std_functions! {
+    type CType = X509_EXTENSION;
+    fn free = X509_EXTENSION_free;
 }
 
 cfg_if! {
@@ -291,18 +390,6 @@ cfg_if! {
 extern "C" {
     #[cfg(ossl102)]
     pub fn X509_get_signature_nid(x: *const X509) -> c_int;
-
-    pub fn X509_EXTENSION_free(ext: *mut X509_EXTENSION);
-
-    pub fn X509_NAME_ENTRY_free(x: *mut X509_NAME_ENTRY);
-
-    pub fn X509_NAME_new() -> *mut X509_NAME;
-    pub fn X509_NAME_free(x: *mut X509_NAME);
-
-    pub fn X509_new() -> *mut X509;
-    pub fn X509_free(x: *mut X509);
-    pub fn i2d_X509(x: *mut X509, buf: *mut *mut u8) -> c_int;
-    pub fn d2i_X509(a: *mut *mut X509, pp: *mut *const c_uchar, length: c_long) -> *mut X509;
 
     pub fn X509_get_pubkey(x: *mut X509) -> *mut EVP_PKEY;
 
@@ -369,8 +456,6 @@ extern "C" {
     pub fn X509_getm_notBefore(x: *const X509) -> *mut ASN1_TIME;
     #[cfg(any(ossl110, libressl273))]
     pub fn X509_getm_notAfter(x: *const X509) -> *mut ASN1_TIME;
-    #[cfg(any(ossl110, libressl273))]
-    pub fn X509_up_ref(x: *mut X509) -> c_int;
 
     #[cfg(any(ossl110, libressl270))]
     pub fn X509_REVOKED_get0_serialNumber(req: *const X509_REVOKED) -> *const ASN1_INTEGER;
@@ -417,8 +502,6 @@ extern "C" {
     pub fn X509_CRL_set_issuer_name(crl: *mut X509_CRL, name: *mut X509_NAME) -> c_int;
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> c_int;
 
-    #[cfg(any(ossl110, libressl270))]
-    pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> c_int;
     pub fn X509_CRL_add0_revoked(crl: *mut X509_CRL, rev: *mut X509_REVOKED) -> c_int;
 }
 cfg_if! {
@@ -504,64 +587,7 @@ extern "C" {
     ) -> c_int;
 }
 
-// "raw" X509_EXTENSION related functions
 extern "C" {
-    // in X509
-    pub fn X509_delete_ext(x: *mut X509, loc: c_int) -> *mut X509_EXTENSION;
-    pub fn X509_add_ext(x: *mut X509, ext: *mut X509_EXTENSION, loc: c_int) -> c_int;
-    pub fn X509_add1_ext_i2d(
-        x: *mut X509,
-        nid: c_int,
-        value: *mut c_void,
-        crit: c_int,
-        flags: c_ulong,
-    ) -> c_int;
-    // in X509_CRL
-    pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: c_int) -> *mut X509_EXTENSION;
-    pub fn X509_CRL_add_ext(x: *mut X509_CRL, ext: *mut X509_EXTENSION, loc: c_int) -> c_int;
-    pub fn X509_CRL_add1_ext_i2d(
-        x: *mut X509_CRL,
-        nid: c_int,
-        value: *mut c_void,
-        crit: c_int,
-        flags: c_ulong,
-    ) -> c_int;
-    // in X509_REVOKED
-    pub fn X509_REVOKED_delete_ext(x: *mut X509_REVOKED, loc: c_int) -> *mut X509_EXTENSION;
-    pub fn X509_REVOKED_add_ext(
-        x: *mut X509_REVOKED,
-        ext: *mut X509_EXTENSION,
-        loc: c_int,
-    ) -> c_int;
-    pub fn X509_REVOKED_add1_ext_i2d(
-        x: *mut X509_REVOKED,
-        nid: c_int,
-        value: *mut c_void,
-        crit: c_int,
-        flags: c_ulong,
-    ) -> c_int;
-    // X509_EXTENSION stack
-    // - these getters always used *const STACK
-    pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> c_int;
-    pub fn X509v3_get_ext_by_NID(
-        x: *const stack_st_X509_EXTENSION,
-        nid: c_int,
-        lastpos: c_int,
-    ) -> c_int;
-    pub fn X509v3_get_ext_by_critical(
-        x: *const stack_st_X509_EXTENSION,
-        crit: c_int,
-        lastpos: c_int,
-    ) -> c_int;
-    pub fn X509v3_get_ext(x: *const stack_st_X509_EXTENSION, loc: c_int) -> *mut X509_EXTENSION;
-    pub fn X509v3_delete_ext(x: *mut stack_st_X509_EXTENSION, loc: c_int) -> *mut X509_EXTENSION;
-    pub fn X509v3_add_ext(
-        x: *mut *mut stack_st_X509_EXTENSION,
-        ex: *mut X509_EXTENSION,
-        loc: c_int,
-    ) -> *mut stack_st_X509_EXTENSION;
-    // - X509V3_add1_i2d in x509v3.rs
-    // X509_EXTENSION itself
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: c_int,
@@ -576,90 +602,12 @@ extern "C" {
 cfg_if! {
     if #[cfg(any(ossl110, libressl280))] {
         extern "C" {
-            // in X509
-            pub fn X509_get_ext_count(x: *const X509) -> c_int;
-            pub fn X509_get_ext_by_NID(x: *const X509, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext_by_OBJ(x: *const X509, obj: *const ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext_by_critical(x: *const X509, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext(x: *const X509, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_get_ext_d2i(
-                x: *const ::X509,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // in X509_CRL
-            pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> c_int;
-            pub fn X509_CRL_get_ext_by_NID(x: *const X509_CRL, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext_by_OBJ(x: *const X509_CRL, obj: *const ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext_by_critical(x: *const X509_CRL, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_CRL_get_ext_d2i(
-                x: *const ::X509_CRL,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // in X509_REVOKED
-            pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_NID(x: *const X509_REVOKED, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_OBJ(x: *const X509_REVOKED, obj: *const ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_critical(x: *const X509_REVOKED, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext(x: *const X509_REVOKED, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_REVOKED_get_ext_d2i(
-                x: *const ::X509_REVOKED,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // X509_EXTENSION stack
-            pub fn X509v3_get_ext_by_OBJ(x: *const stack_st_X509_EXTENSION, obj: *const ASN1_OBJECT, lastpos: c_int) -> c_int;
-            // X509_EXTENSION itself
             pub fn X509_EXTENSION_create_by_OBJ(ex: *mut *mut X509_EXTENSION, obj: *const ASN1_OBJECT, crit: c_int, data: *mut ASN1_OCTET_STRING) -> *mut X509_EXTENSION;
             pub fn X509_EXTENSION_set_object(ex: *mut X509_EXTENSION, obj: *const ASN1_OBJECT) -> c_int;
             pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> c_int;
         }
     } else {
         extern "C" {
-            // in X509
-            pub fn X509_get_ext_count(x: *mut X509) -> c_int;
-            pub fn X509_get_ext_by_NID(x: *mut X509, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext_by_OBJ(x: *mut X509, obj: *mut ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext_by_critical(x: *mut X509, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext(x: *mut X509, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_get_ext_d2i(
-                x: *mut ::X509,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // in X509_CRL
-            pub fn X509_CRL_get_ext_count(x: *mut X509_CRL) -> c_int;
-            pub fn X509_CRL_get_ext_by_NID(x: *mut X509_CRL, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext_by_OBJ(x: *mut X509_CRL, obj: *mut ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext_by_critical(x: *mut X509_CRL, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext(x: *mut X509_CRL, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_CRL_get_ext_d2i(
-                x: *mut ::X509_CRL,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // in X509_REVOKED
-            pub fn X509_REVOKED_get_ext_count(x: *mut X509_REVOKED) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_NID(x: *mut X509_REVOKED, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_OBJ(x: *mut X509_REVOKED, obj: *mut ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_critical(x: *mut X509_REVOKED, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext(x: *mut X509_REVOKED, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_REVOKED_get_ext_d2i(
-                x: *mut ::X509_REVOKED,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // X509_EXTENSION stack
-            pub fn X509v3_get_ext_by_OBJ(x: *const stack_st_X509_EXTENSION, obj: *mut ASN1_OBJECT, lastpos: c_int) -> c_int;
-            // X509_EXTENSION itself
             pub fn X509_EXTENSION_create_by_OBJ(ex: *mut *mut X509_EXTENSION, obj: *mut ASN1_OBJECT, crit: c_int, data: *mut ASN1_OCTET_STRING) -> *mut X509_EXTENSION;
             pub fn X509_EXTENSION_set_object(ex: *mut X509_EXTENSION, obj: *mut ASN1_OBJECT) -> c_int;
             pub fn X509_EXTENSION_get_critical(ex: *mut X509_EXTENSION) -> c_int;
@@ -677,14 +625,10 @@ extern "C" {
     pub fn X509_OBJECT_get0_X509(x: *const X509_OBJECT) -> *mut X509;
 }
 
-cfg_if! {
-    if #[cfg(ossl110)] {
-        extern "C" {
-            pub fn X509_OBJECT_free(a: *mut X509_OBJECT);
-        }
-    } else {
-        extern "C" {
-            pub fn X509_OBJECT_free_contents(a: *mut X509_OBJECT);
-        }
-    }
+declare_std_functions! {
+    type CType = X509_OBJECT;
+    #[cfg(ossl110)]
+    fn free = X509_OBJECT_free;
+    #[cfg(not(ossl110))]
+    fn free = X509_OBJECT_free_contents;
 }

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -95,13 +95,19 @@ cfg_if! {
     }
 }
 
+declare_std_functions! {
+    type CType = X509_STORE;
+    fn new = X509_STORE_new;
+    fn free = X509_STORE_free;
+}
+
+declare_std_functions! {
+    type CType = X509_STORE_CTX;
+    fn new = X509_STORE_CTX_new;
+    fn free = X509_STORE_CTX_free;
+}
+
 extern "C" {
-    pub fn X509_STORE_new() -> *mut X509_STORE;
-    pub fn X509_STORE_free(store: *mut X509_STORE);
-
-    pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
-
-    pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,

--- a/openssl-sys/src/x509v3.rs
+++ b/openssl-sys/src/x509v3.rs
@@ -106,22 +106,10 @@ extern "C" {
 cfg_if! {
     if #[cfg(any(ossl110, libressl280))] {
         extern "C" {
-            pub fn X509V3_get_d2i(
-                x: *const stack_st_X509_EXTENSION,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
             pub fn X509V3_extensions_print(out: *mut BIO, title: *const c_char, exts: *const stack_st_X509_EXTENSION, flag: c_ulong, indent: c_int) -> c_int;
         }
     } else {
         extern "C" {
-            pub fn X509V3_get_d2i(
-                x: *mut stack_st_X509_EXTENSION,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
             pub fn X509V3_extensions_print(out: *mut BIO, title: *mut c_char, exts: *mut stack_st_X509_EXTENSION, flag: c_ulong, indent: c_int) -> c_int;
         }
     }
@@ -189,16 +177,19 @@ pub const XKU_DVCS: u32 = 0x80;
 #[cfg(ossl110)]
 pub const XKU_ANYEKU: u32 = 0x100;
 
+declare_std_functions! {
+    type CType = stack_st_X509_EXTENSION;
+    fn ext_get_d2i = X509V3_get_d2i;
+}
+
+declare_std_functions! {
+    type CType = *mut stack_st_X509_EXTENSION;
+    fn ext_add1_i2d = X509V3_add1_i2d;
+}
+
 extern "C" {
     pub fn X509V3_EXT_d2i(ext: *mut X509_EXTENSION) -> *mut c_void;
     pub fn X509V3_EXT_i2d(ext_nid: c_int, crit: c_int, ext: *mut c_void) -> *mut X509_EXTENSION;
-    pub fn X509V3_add1_i2d(
-        x: *mut *mut stack_st_X509_EXTENSION,
-        nid: c_int,
-        value: *mut c_void,
-        crit: c_int,
-        flags: c_ulong,
-    ) -> c_int;
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *mut X509_EXTENSION,


### PR DESCRIPTION
Hi,

I have been looking for a way to handle the `*mut _` -> `*const _` changes in openssl / libressl in a sane way; duplicating all the imports seemed a bad thing.

With proc-macros one could probably invent real crazy syntax, but that would add a lot of dependencies for `openssl-sys`.

The best thing I could come up with was to define signature schemes (with a single type parameter), which can then be applied using a macro syntax I borrowed from foreign_types. (Macros are not allowed in type position (and name/ident?), so I couldn't get any other "fix this type signature" attempts working).

This will probably add a big merge conflict with the `openssl-300` branch, but hopefully makes the process easier in the long run.

Also this changes `u8` to `c_uchar` in a few `d2i_*` and `i2d_` functions; I think this shouldn't break anything (`libc::c_uchar` should be an alias for `u8`), but is actually the proper signature.

I checked the imported functions on my local system with my [systest-api-items branch](https://github.com/stbuehler/rust-openssl/tree/systest-api-items), which is based on my [ctest out-items branch](https://github.com/stbuehler/ctest/tree/out-items). After `sed -e 's#uint8_t#unsigned char#'` the items look the same before and after this PR.