### PR TITLE
Silence clippy::match_like_matches_macro (would require rust 1.42)

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -270,6 +270,7 @@ due to this version mismatch.
 
 // parses a string that looks like "0x100020cfL"
 #[allow(deprecated)] // trim_right_matches is now trim_end_matches
+#[allow(clippy::match_like_matches_macro)] // matches macro requires rust 1.42.0
 fn parse_version(version: &str) -> u64 {
     // cut off the 0x prefix
     assert!(version.starts_with("0x"));

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -128,6 +128,7 @@ unsafe extern "C" fn bread<S: Read>(bio: *mut BIO, buf: *mut c_char, len: c_int)
     }
 }
 
+#[allow(clippy::match_like_matches_macro)] // matches macro requires rust 1.42.0
 fn retriable_error(err: &io::Error) -> bool {
     match err.kind() {
         io::ErrorKind::WouldBlock | io::ErrorKind::NotConnected => true,


### PR DESCRIPTION
Clippy from rust 1.47.0 [promotes](https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro) the [`matches!`](https://doc.rust-lang.org/core/macro.matches.html) macro, but using it would require rust 1.42.0.