### PR TITLE
Add and use const_ptr_api macro in openssl-sys

### DIFF
--- a/openssl-sys/src/asn1.rs
+++ b/openssl-sys/src/asn1.rs
@@ -61,14 +61,8 @@ extern "C" {
     pub fn ASN1_TIME_set_string_X509(s: *mut ASN1_TIME, str: *const c_char) -> c_int;
 }
 
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn ASN1_STRING_to_UTF8(out: *mut *mut c_uchar, s: *const ASN1_STRING) -> c_int;
-        }
-    } else {
-        extern "C" {
-            pub fn ASN1_STRING_to_UTF8(out: *mut *mut c_uchar, s: *mut ASN1_STRING) -> c_int;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn ASN1_STRING_to_UTF8(out: *mut *mut c_uchar, s: #[const_ptr_if(any(ossl110, libressl280))] ASN1_STRING) -> c_int;
     }
 }

--- a/openssl-sys/src/bio.rs
+++ b/openssl-sys/src/bio.rs
@@ -60,17 +60,10 @@ pub unsafe fn BIO_get_mem_data(b: *mut BIO, pp: *mut *mut c_char) -> c_long {
     BIO_ctrl(b, BIO_CTRL_INFO, 0, pp as *mut c_void)
 }
 
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn BIO_s_file() -> *const BIO_METHOD;
-            pub fn BIO_new(type_: *const BIO_METHOD) -> *mut BIO;
-        }
-    } else {
-        extern "C" {
-            pub fn BIO_s_file() -> *mut BIO_METHOD;
-            pub fn BIO_new(type_: *mut BIO_METHOD) -> *mut BIO;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn BIO_s_file() -> #[const_ptr_if(any(ossl110, libressl280))] BIO_METHOD;
+        pub fn BIO_new(type_: #[const_ptr_if(any(ossl110, libressl280))] BIO_METHOD) -> *mut BIO;
     }
 }
 extern "C" {
@@ -88,26 +81,10 @@ extern "C" {
     pub fn BIO_free_all(b: *mut BIO);
 }
 
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn BIO_s_mem() -> *const BIO_METHOD;
-        }
-    } else {
-        extern "C" {
-            pub fn BIO_s_mem() -> *mut BIO_METHOD;
-        }
-    }
-}
-cfg_if! {
-    if #[cfg(any(ossl102, libressl280))] {
-        extern "C" {
-            pub fn BIO_new_mem_buf(buf: *const c_void, len: c_int) -> *mut BIO;
-        }
-    } else {
-        extern "C" {
-            pub fn BIO_new_mem_buf(buf: *mut c_void, len: c_int) -> *mut BIO;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn BIO_s_mem() -> #[const_ptr_if(any(ossl110, libressl280))] BIO_METHOD;
+        pub fn BIO_new_mem_buf(buf: #[const_ptr_if(any(ossl102, libressl280))] c_void, len: c_int) -> *mut BIO;
     }
 }
 

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -174,15 +174,9 @@ extern "C" {
         outl: *mut c_int,
     ) -> c_int;
 }
-cfg_if! {
-    if #[cfg(any(ossl111b, libressl280))] {
-        extern "C" {
-            pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> c_int;
-        }
-    } else {
-        extern "C" {
-            pub fn EVP_PKEY_size(pkey: *mut EVP_PKEY) -> c_int;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn EVP_PKEY_size(pkey: #[const_ptr_if(any(ossl111b, libressl280))] EVP_PKEY) -> c_int;
     }
 }
 cfg_if! {
@@ -206,23 +200,13 @@ cfg_if! {
         }
     }
 }
-cfg_if! {
-    if #[cfg(any(ossl102, libressl280))] {
-        extern "C" {
-            pub fn EVP_DigestVerifyFinal(
-                ctx: *mut EVP_MD_CTX,
-                sigret: *const c_uchar,
-                siglen: size_t,
-            ) -> c_int;
-        }
-    } else {
-        extern "C" {
-            pub fn EVP_DigestVerifyFinal(
-                ctx: *mut EVP_MD_CTX,
-                sigret: *mut c_uchar,
-                siglen: size_t,
-            ) -> c_int;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn EVP_DigestVerifyFinal(
+            ctx: *mut EVP_MD_CTX,
+            sigret: #[const_ptr_if(any(ossl102, libressl280))] c_uchar,
+            siglen: size_t,
+        ) -> c_int;
     }
 }
 
@@ -317,15 +301,9 @@ extern "C" {
 
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> c_int;
 }
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn EVP_PKEY_bits(key: *const EVP_PKEY) -> c_int;
-        }
-    } else {
-        extern "C" {
-            pub fn EVP_PKEY_bits(key: *mut EVP_PKEY) -> c_int;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn EVP_PKEY_bits(key: #[const_ptr_if(any(ossl110, libressl280))] EVP_PKEY) -> c_int;
     }
 }
 extern "C" {
@@ -456,15 +434,9 @@ extern "C" {
     ) -> c_int;
 }
 
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
-        }
-    } else {
-        extern "C" {
-            pub fn EVP_PKCS82PKEY(p8: *mut PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn EVP_PKCS82PKEY(p8: #[const_ptr_if(any(ossl110, libressl280))] PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
     }
 }
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -9,6 +9,7 @@
     unused_imports
 )]
 #![doc(html_root_url = "https://docs.rs/openssl-sys/0.9")]
+#![recursion_limit = "128"] // configure fixed limit across all rust versions
 
 extern crate libc;
 

--- a/openssl-sys/src/macros.rs
+++ b/openssl-sys/src/macros.rs
@@ -85,3 +85,212 @@ macro_rules! const_fn {
         )*
     }
 }
+
+// openssl changes `*mut` to `*const` in certain parameters in certain versions;
+// in C this is ABI and (mostly) API compatible.
+//
+// We need to handle this explicitly, and this macro helps annotate which
+// parameter got converted in which version.
+//
+// Input is:
+//    extern "C" {
+//        #[attributes...]
+//        pub fn name(args) -> rettype; // `-> rettype` optional
+//        // more functions...
+//    }
+//
+// This macro replaces `#[const_ptr_if(...)]` in types with `*const` or `*mut`
+// (depending on the inner cfg flags)
+//
+// Walks through all argument and return types, but only finds inner types of
+// `*const` and `*mut`; doesn't walk arrays or generics.
+//
+// NOTE: can't abstract `pub` as `$fn_vis:vis`, as ctest macro handling doesn't
+// support it (old syntax crate). But we really only need `pub` anyway.
+//
+// NOTE: ctest seams to simply ignore macros it can't expand (whatever the
+// reason)
+macro_rules! const_ptr_api {
+    // ----------------------------------------------------------------
+    // (partialarg): partial argument, waiting for "final" argument type
+    // MAGIC PART 1: hande conditional const ptr in argument type
+    ( (partialarg)
+        { $(#[$fn_attr:meta])* pub fn $fn_name:ident }
+        $args_packed:tt
+        [ $($part_arg:tt)* ]
+        [ #[const_ptr_if( $($cfg:tt)* )] $($arg_rem:tt)* ]
+        $ret_packed:tt
+    ) => {
+        const_ptr_api!( (partialarg) { #[cfg($($cfg)*)]      $(#[$fn_attr])* pub fn $fn_name } $args_packed [ $($part_arg)* *const ] [ $($arg_rem)* ] $ret_packed );
+        const_ptr_api!( (partialarg) { #[cfg(not($($cfg)*))] $(#[$fn_attr])* pub fn $fn_name } $args_packed [ $($part_arg)* *mut   ] [ $($arg_rem)* ] $ret_packed );
+    };
+    // continue partial argument with `*mut` pointer (might need special const handling in inner type)
+    ( (partialarg)
+        $def_packed:tt
+        $args_packed:tt
+        [ $($part_arg:tt)* ]
+        [ *mut $($arg_rem:tt)* ]
+        $ret_packed:tt
+    ) => {
+        const_ptr_api!( (partialarg) $def_packed $args_packed [ $($part_arg)* *mut ] [ $($arg_rem)* ] $ret_packed );
+    };
+    // continue partial argument with `*const` pointer (might need special const handling in inner type)
+    ( (partialarg)
+        $def_packed:tt
+        $args_packed:tt
+        [ $($part_arg:tt)* ]
+        [ *const $($arg_rem:tt)* ]
+        $ret_packed:tt
+    ) => {
+        const_ptr_api!( (partialarg) $def_packed $args_packed [ $($part_arg)* *const ] [ $($arg_rem)* ] $ret_packed );
+    };
+    // finish partial argument with trailing comma
+    ( (partialarg)
+        $def_packed:tt
+        { $($args_tt:tt)* }
+        [ $($part_arg:tt)* ]
+        [ $arg_ty:ty, $($arg_rem:tt)* ]
+        $ret_packed:tt
+    ) => {
+        const_ptr_api!( (parseargs) $def_packed { $($args_tt)* { $($part_arg)* $arg_ty } } [ $($arg_rem)* ] $ret_packed );
+    };
+    // finish final partial argument (no trailing comma)
+    ( (partialarg)
+        $def_packed:tt
+        { $($args_tt:tt)* }
+        [ $($part_arg:tt)* ]
+        [ $arg_ty:ty ]
+        $ret_packed:tt
+    ) => {
+        const_ptr_api!( (parseargs) $def_packed { $($args_tt)* { $($part_arg)* $arg_ty } } [ ] $ret_packed );
+    };
+
+    // ----------------------------------------------------------------
+    // (parseargs): parsing arguments
+    // start next argument
+    ( (parseargs)
+        $def_packed:tt
+        $args_packed:tt
+        [ $arg_name:ident : $($arg_rem:tt)* ]
+        $ret_packed:tt
+    ) => {
+        const_ptr_api!( (partialarg) $def_packed $args_packed [ $arg_name: ] [ $($arg_rem)* ] $ret_packed );
+    };
+    // end of arguments, there is a return type; start parsing it
+    ( (parseargs)
+        $def_packed:tt
+        $args_packed:tt
+        [ ]
+        [ -> $($rem:tt)* ]
+    ) => {
+        const_ptr_api!( (partialret) $def_packed $args_packed [] [ $($rem)* ] );
+    };
+    // end of arguments, no return type
+    ( (parseargs)
+        $def_packed:tt
+        $args_packed:tt
+        [ ]
+        [ ]
+    ) => {
+        const_ptr_api!( (generate) $def_packed $args_packed { () } );
+    };
+
+    // ----------------------------------------------------------------
+    // (partialret): have partial return type, waiting for final return type
+    // MAGIC PART 2: hande conditional const ptr in return type
+    ( (partialret)
+        { $(#[$fn_attr:meta])* pub fn $fn_name:ident }
+        $args_packed:tt
+        [ $($part_ret:tt)* ]
+        [ #[const_ptr_if( $($cfg:tt)* )] $($rem:tt)* ]
+    ) => {
+        const_ptr_api!( (partialret) { #[cfg($($cfg)*)]      $(#[$fn_attr])* pub fn $fn_name } $args_packed [ $($part_ret)* *const ] [ $($rem)* ] );
+        const_ptr_api!( (partialret) { #[cfg(not($($cfg)*))] $(#[$fn_attr])* pub fn $fn_name } $args_packed [ $($part_ret)* *mut   ] [ $($rem)* ] );
+    };
+    // `* mut` part in return type; continue parsing to find inner conditional const ptr
+    ( (partialret)
+        $def_packed:tt
+        $args_packed:tt
+        [ $($part_ret:tt)* ]
+        [ *mut $($rem:tt)* ]
+    ) => {
+        const_ptr_api!( (partialret) $def_packed $args_packed [ $($part_ret)* *mut ] [ $($rem)* ] );
+    };
+    // `* const` part in return type; continue parsing to find inner conditional const ptr
+    ( (partialret)
+        $def_packed:tt
+        $args_packed:tt
+        [ $($part_ret:tt)* ]
+        [ *const $($rem:tt)* ]
+    ) => {
+        const_ptr_api!( (partialret) $def_packed $args_packed [ $($part_ret)* *const ] [ $($rem)* ] );
+    };
+    // final part of return type
+    ( (partialret)
+        $def_packed:tt
+        $args_packed:tt
+        [ $($part_ret:tt)* ]
+        [ $ret_ty:ty ]
+    ) => {
+        const_ptr_api!( (generate) $def_packed $args_packed { $($part_ret)* $ret_ty } );
+    };
+
+    // ----------------------------------------------------------------
+    // generate
+    ( (generate)
+        { $(#[$fn_attr:meta])* pub fn $fn_name:ident }
+        { $({ $arg_name:ident: $($arg_ty:tt)* })* }
+        { $ret_ty:ty }
+    ) => {
+        extern "C" {
+            $(#[$fn_attr])*
+            pub fn $fn_name( $(
+                $arg_name: $($arg_ty)*
+            ),* ) -> $ret_ty;
+        }
+    };
+
+    // ----------------------------------------------------------------
+    // (fn): gather tokens for return type until ";"
+    // found end; start parsing current function, and parse remaining functions
+    ( (fn)
+        $def_packed:tt
+        $arg_tts_packed:tt
+        $ret_packed:tt
+        [ ; $($rem:tt)* ]
+    ) => {
+        const_ptr_api!( (parseargs) $def_packed {} $arg_tts_packed $ret_packed );
+        const_ptr_api!( (extern) [ $($rem)* ] );
+    };
+    // not ";" - all other tokens are part of the return type.
+    // don't expand return type yet; otherwise we'd have to remember in which branch `rem` needs
+    // to be used to parse further functions.
+    ( (fn)
+        $def_packed:tt
+        $arg_tts_packed:tt
+        [ $($ret_tt:tt)* ]
+        [ $tt:tt $($rem:tt)* ]
+    ) => {
+        const_ptr_api!( (fn) $def_packed $arg_tts_packed [ $($ret_tt)* $tt ] [ $($rem)* ] );
+    };
+
+    // ----------------------------------------------------------------
+    // (extern): in extern block, find next function
+    // try to split into functions as fast as possible to reduce recursion depth
+    ( (extern) [
+        $(#[$fn_attr:meta])*
+        pub fn $fn_name:ident( $($arg_rem:tt)* ) $($rem:tt)*
+    ] ) => {
+        const_ptr_api!( (fn)
+            { $(#[$fn_attr])* pub fn $fn_name } [ $($arg_rem)* ] [] [ $($rem)* ]
+        );
+    };
+    // end of extern block
+    ( (extern) [] ) => {};
+
+    // ----------------------------------------------------------------
+    // macro start; find extern block
+    ( extern "C" { $($rem:tt)* } ) => {
+        const_ptr_api!( (extern) [ $($rem)* ] );
+    };
+}

--- a/openssl-sys/src/ocsp.rs
+++ b/openssl-sys/src/ocsp.rs
@@ -44,23 +44,13 @@ pub const V_OCSP_CERTSTATUS_UNKNOWN: c_int = 2;
 
 pub enum OCSP_BASICRESP {}
 
-cfg_if! {
-    if #[cfg(any(ossl110, libressl281))] {
-        extern "C" {
-            pub fn OCSP_cert_to_id(
-                dgst: *const EVP_MD,
-                subject: *const X509,
-                issuer: *const X509,
-            ) -> *mut OCSP_CERTID;
-        }
-    } else {
-        extern "C" {
-            pub fn OCSP_cert_to_id(
-                dgst: *const EVP_MD,
-                subject: *mut X509,
-                issuer: *mut X509,
-            ) -> *mut ::OCSP_CERTID;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn OCSP_cert_to_id(
+            dgst: *const EVP_MD,
+            subject: #[const_ptr_if(any(ossl110, libressl281))] X509,
+            issuer: #[const_ptr_if(any(ossl110, libressl281))] X509,
+        ) -> *mut OCSP_CERTID;
     }
 }
 

--- a/openssl-sys/src/pkcs12.rs
+++ b/openssl-sys/src/pkcs12.rs
@@ -17,37 +17,20 @@ extern "C" {
         ca: *mut *mut stack_st_X509,
     ) -> c_int;
 }
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn PKCS12_create(
-                pass: *const c_char,
-                friendly_name: *const c_char,
-                pkey: *mut EVP_PKEY,
-                cert: *mut X509,
-                ca: *mut stack_st_X509,
-                nid_key: c_int,
-                nid_cert: c_int,
-                iter: c_int,
-                mac_iter: c_int,
-                keytype: c_int,
-            ) -> *mut PKCS12;
-        }
-    } else {
-        extern "C" {
-            pub fn PKCS12_create(
-                pass: *mut c_char,
-                friendly_name: *mut c_char,
-                pkey: *mut EVP_PKEY,
-                cert: *mut X509,
-                ca: *mut stack_st_X509,
-                nid_key: c_int,
-                nid_cert: c_int,
-                iter: c_int,
-                mac_iter: c_int,
-                keytype: c_int,
-            ) -> *mut PKCS12;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn PKCS12_create(
+            pass: #[const_ptr_if(any(ossl110, libressl280))] c_char,
+            friendly_name: #[const_ptr_if(any(ossl110, libressl280))] c_char,
+            pkey: *mut EVP_PKEY,
+            cert: *mut X509,
+            ca: *mut stack_st_X509,
+            nid_key: c_int,
+            nid_cert: c_int,
+            iter: c_int,
+            mac_iter: c_int,
+            keytype: c_int,
+        ) -> *mut PKCS12;
     }
 }
 

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -478,6 +478,7 @@ extern "C" {
     );
 }
 cfg_if! {
+    // const change in passed function pointer signature
     if #[cfg(any(ossl110, libressl280))] {
         extern "C" {
             pub fn SSL_CTX_sess_set_get_cb(
@@ -509,6 +510,7 @@ extern "C" {
 }
 
 cfg_if! {
+    // const change in passed function pointer signature
     if #[cfg(any(ossl110, libressl280))] {
         extern "C" {
             pub fn SSL_CTX_set_cookie_verify_cb(
@@ -681,15 +683,10 @@ extern "C" {
     pub fn SSL_get_verify_mode(s: *const SSL) -> c_int;
 }
 
-cfg_if! {
-    if #[cfg(ossl111)] {
-        extern "C" {
-            pub fn SSL_is_init_finished(s: *const SSL) -> c_int;
-        }
-    } else if #[cfg(ossl110)] {
-        extern "C" {
-            pub fn SSL_is_init_finished(s: *mut SSL) -> c_int;
-        }
+const_ptr_api! {
+    extern "C" {
+        #[cfg(ossl110)]
+        pub fn SSL_is_init_finished(s: #[const_ptr_if(ossl111)] SSL) -> c_int;
     }
 }
 
@@ -911,15 +908,9 @@ extern "C" {
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
     pub fn SSL_CIPHER_get_bits(cipher: *const SSL_CIPHER, alg_bits: *mut c_int) -> c_int;
 }
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const c_char;
-        }
-    } else {
-        extern "C" {
-            pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *mut c_char;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> #[const_ptr_if(any(ossl110, libressl280))] c_char;
     }
 }
 extern "C" {
@@ -1160,15 +1151,9 @@ extern "C" {
     ) -> c_int;
 }
 
-cfg_if! {
-    if #[cfg(ossl111b)] {
-        extern "C" {
-            pub fn SSL_get_ssl_method(ssl: *const SSL) -> *const SSL_METHOD;
-        }
-    } else {
-        extern "C" {
-            pub fn SSL_get_ssl_method(ssl: *mut SSL) -> *const SSL_METHOD;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn SSL_get_ssl_method(ssl: #[const_ptr_if(ossl111b)] SSL) -> *const SSL_METHOD;
     }
 }
 
@@ -1187,15 +1172,9 @@ extern "C" {
 
     pub fn SSL_get_certificate(ssl: *const SSL) -> *mut X509;
 }
-cfg_if! {
-    if #[cfg(any(ossl102, libressl280))] {
-        extern "C" {
-            pub fn SSL_get_privatekey(ssl: *const SSL) -> *mut EVP_PKEY;
-        }
-    } else {
-        extern "C" {
-            pub fn SSL_get_privatekey(ssl: *mut SSL) -> *mut EVP_PKEY;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn SSL_get_privatekey(ssl: #[const_ptr_if(any(ossl102, libressl280))] SSL) -> *mut EVP_PKEY;
     }
 }
 
@@ -1339,14 +1318,11 @@ cfg_if! {
         extern "C" {
             pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const libc::c_void;
         }
-    } else if #[cfg(osslconf = "OPENSSL_NO_COMP")] {
-    } else if #[cfg(ossl111b)] {
-        extern "C" {
-            pub fn SSL_get_current_compression(ssl: *const SSL) -> *const COMP_METHOD;
-        }
-    } else {
-        extern "C" {
-            pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const COMP_METHOD;
+    } else if #[cfg(not(osslconf = "OPENSSL_NO_COMP"))] {
+        const_ptr_api! {
+            extern "C" {
+                pub fn SSL_get_current_compression(ssl: #[const_ptr_if(ossl111b)] SSL) -> *const COMP_METHOD;
+            }
         }
     }
 }
@@ -1370,13 +1346,11 @@ extern "C" {
 }
 
 cfg_if! {
-    if #[cfg(ossl111c)] {
-        extern "C" {
-            pub fn SSL_session_reused(ssl: *const SSL) -> c_int;
-        }
-    } else if #[cfg(ossl110)] {
-        extern "C" {
-            pub fn SSL_session_reused(ssl: *mut SSL) -> c_int;
+    if #[cfg(ossl110)] {
+        const_ptr_api! {
+            extern "C" {
+                pub fn SSL_session_reused(ssl: #[const_ptr_if(ossl111c)] SSL) -> c_int;
+            }
         }
     } else {
         pub unsafe fn SSL_session_reused(ssl: *mut SSL) -> c_int {
@@ -1384,15 +1358,10 @@ cfg_if! {
         }
     }
 }
-cfg_if! {
-    if #[cfg(any(ossl110f, libressl273))] {
-        extern "C" {
-            pub fn SSL_is_server(s: *const SSL) -> c_int;
-        }
-    } else if #[cfg(ossl102)] {
-        extern "C" {
-            pub fn SSL_is_server(s: *mut SSL) -> c_int;
-        }
+const_ptr_api! {
+    extern "C" {
+        #[cfg(any(ossl102, libressl273))]
+        pub fn SSL_is_server(s: #[const_ptr_if(any(ossl110f, libressl273))] SSL) -> c_int;
     }
 }
 

--- a/openssl-sys/src/x509.rs
+++ b/openssl-sys/src/x509.rs
@@ -211,25 +211,15 @@ extern "C" {
     pub fn i2d_ECPrivateKey(ec_key: *mut EC_KEY, pp: *mut *mut c_uchar) -> c_int;
 }
 
-cfg_if! {
-    if #[cfg(ossl110)] {
-        extern "C" {
-            pub fn X509_ALGOR_get0(
-                paobj: *mut *const ASN1_OBJECT,
-                pptype: *mut c_int,
-                ppval: *mut *const c_void,
-                alg: *const X509_ALGOR,
-            );
-        }
-    } else if #[cfg(ossl102)] {
-        extern "C" {
-            pub fn X509_ALGOR_get0(
-                paobj: *mut *mut ASN1_OBJECT,
-                pptype: *mut c_int,
-                ppval: *mut *mut c_void,
-                alg: *mut X509_ALGOR,
-            );
-        }
+const_ptr_api! {
+    extern "C" {
+        #[cfg(ossl102)]
+        pub fn X509_ALGOR_get0(
+            paobj: *mut #[const_ptr_if(ossl110)] ASN1_OBJECT,
+            pptype: *mut c_int,
+            ppval: *mut #[const_ptr_if(ossl110)] c_void,
+            alg: #[const_ptr_if(ossl110)] X509_ALGOR,
+        );
     }
 }
 
@@ -269,23 +259,14 @@ extern "C" {
     pub fn i2d_X509_REQ(x: *mut X509_REQ, buf: *mut *mut u8) -> c_int;
 }
 
-cfg_if! {
-    if #[cfg(any(ossl110, libressl273))] {
-        extern "C" {
-            pub fn X509_get0_signature(
-                psig: *mut *const ASN1_BIT_STRING,
-                palg: *mut *const X509_ALGOR,
-                x: *const X509,
-            );
-        }
-    } else if #[cfg(ossl102)] {
-        extern "C" {
-            pub fn X509_get0_signature(
-                psig: *mut *mut ASN1_BIT_STRING,
-                palg: *mut *mut X509_ALGOR,
-                x: *const X509,
-            );
-        }
+const_ptr_api! {
+    extern "C" {
+        #[cfg(any(ossl102, libressl273))]
+        pub fn X509_get0_signature(
+            psig: *mut #[const_ptr_if(any(ossl110, libressl273))] ASN1_BIT_STRING,
+            palg: *mut #[const_ptr_if(any(ossl110, libressl273))] X509_ALGOR,
+            x: *const X509,
+        );
     }
 }
 extern "C" {
@@ -313,29 +294,17 @@ extern "C" {
 
     pub fn X509_subject_name_hash(x: *mut ::X509) -> c_ulong;
 }
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn X509_get_issuer_name(x: *const ::X509) -> *mut ::X509_NAME;
-        }
-    } else {
-        extern "C" {
-            pub fn X509_get_issuer_name(x: *mut ::X509) -> *mut ::X509_NAME;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_get_issuer_name(x: #[const_ptr_if(any(ossl110, libressl280))] ::X509) -> *mut ::X509_NAME;
     }
 }
 extern "C" {
     pub fn X509_set_subject_name(x: *mut X509, name: *mut X509_NAME) -> c_int;
 }
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn X509_get_subject_name(x: *const ::X509) -> *mut ::X509_NAME;
-        }
-    } else {
-        extern "C" {
-            pub fn X509_get_subject_name(x: *mut ::X509) -> *mut ::X509_NAME;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_get_subject_name(x: #[const_ptr_if(any(ossl110, libressl280))] ::X509) -> *mut ::X509_NAME;
     }
 }
 cfg_if! {
@@ -436,60 +405,26 @@ cfg_if! {
     }
 }
 
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn X509_NAME_entry_count(n: *const X509_NAME) -> c_int;
-        }
-    } else {
-        extern "C" {
-            pub fn X509_NAME_entry_count(n: *mut X509_NAME) -> c_int;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_NAME_entry_count(n: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME) -> c_int;
+        pub fn X509_NAME_get_index_by_NID(n: #[const_ptr_if(libressl280)] X509_NAME, nid: c_int, last_pos: c_int) -> c_int;
     }
 }
-
-cfg_if! {
-    if #[cfg(libressl280)] {
-        extern "C" {
-            pub fn X509_NAME_get_index_by_NID(n: *const X509_NAME, nid: c_int, last_pos: c_int) -> c_int;
-        }
-    } else {
-        extern "C" {
-            pub fn X509_NAME_get_index_by_NID(n: *mut X509_NAME, nid: c_int, last_pos: c_int) -> c_int;
-        }
-    }
-}
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn X509_NAME_get_entry(n: *const X509_NAME, loc: c_int) -> *mut X509_NAME_ENTRY;
-            pub fn X509_NAME_add_entry_by_NID(
-                x: *mut X509_NAME,
-                field: c_int,
-                ty: c_int,
-                bytes: *const c_uchar,
-                len: c_int,
-                loc: c_int,
-                set: c_int,
-            ) -> c_int;
-            pub fn X509_NAME_ENTRY_get_object(ne: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
-            pub fn X509_NAME_ENTRY_get_data(ne: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
-        }
-    } else {
-        extern "C" {
-            pub fn X509_NAME_get_entry(n: *mut X509_NAME, loc: c_int) -> *mut X509_NAME_ENTRY;
-            pub fn X509_NAME_add_entry_by_NID(
-                x: *mut X509_NAME,
-                field: c_int,
-                ty: c_int,
-                bytes: *mut c_uchar,
-                len: c_int,
-                loc: c_int,
-                set: c_int,
-            ) -> c_int;
-            pub fn X509_NAME_ENTRY_get_object(ne: *mut X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
-            pub fn X509_NAME_ENTRY_get_data(ne: *mut X509_NAME_ENTRY) -> *mut ASN1_STRING;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_NAME_get_entry(n: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME, loc: c_int) -> *mut X509_NAME_ENTRY;
+        pub fn X509_NAME_add_entry_by_NID(
+            x: *mut X509_NAME,
+            field: c_int,
+            ty: c_int,
+            bytes: #[const_ptr_if(any(ossl110, libressl280))] c_uchar,
+            len: c_int,
+            loc: c_int,
+            set: c_int,
+        ) -> c_int;
+        pub fn X509_NAME_ENTRY_get_object(ne: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
+        pub fn X509_NAME_ENTRY_get_data(ne: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME_ENTRY) -> *mut ASN1_STRING;
     }
 }
 extern "C" {
@@ -573,97 +508,50 @@ extern "C" {
     pub fn X509_EXTENSION_get_object(ext: *mut X509_EXTENSION) -> *mut ASN1_OBJECT;
     pub fn X509_EXTENSION_get_data(ext: *mut X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            // in X509
-            pub fn X509_get_ext_count(x: *const X509) -> c_int;
-            pub fn X509_get_ext_by_NID(x: *const X509, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext_by_OBJ(x: *const X509, obj: *const ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext_by_critical(x: *const X509, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext(x: *const X509, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_get_ext_d2i(
-                x: *const ::X509,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // in X509_CRL
-            pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> c_int;
-            pub fn X509_CRL_get_ext_by_NID(x: *const X509_CRL, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext_by_OBJ(x: *const X509_CRL, obj: *const ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext_by_critical(x: *const X509_CRL, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_CRL_get_ext_d2i(
-                x: *const ::X509_CRL,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // in X509_REVOKED
-            pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_NID(x: *const X509_REVOKED, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_OBJ(x: *const X509_REVOKED, obj: *const ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_critical(x: *const X509_REVOKED, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext(x: *const X509_REVOKED, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_REVOKED_get_ext_d2i(
-                x: *const ::X509_REVOKED,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // X509_EXTENSION stack
-            pub fn X509v3_get_ext_by_OBJ(x: *const stack_st_X509_EXTENSION, obj: *const ASN1_OBJECT, lastpos: c_int) -> c_int;
-            // X509_EXTENSION itself
-            pub fn X509_EXTENSION_create_by_OBJ(ex: *mut *mut X509_EXTENSION, obj: *const ASN1_OBJECT, crit: c_int, data: *mut ASN1_OCTET_STRING) -> *mut X509_EXTENSION;
-            pub fn X509_EXTENSION_set_object(ex: *mut X509_EXTENSION, obj: *const ASN1_OBJECT) -> c_int;
-            pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> c_int;
-        }
-    } else {
-        extern "C" {
-            // in X509
-            pub fn X509_get_ext_count(x: *mut X509) -> c_int;
-            pub fn X509_get_ext_by_NID(x: *mut X509, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext_by_OBJ(x: *mut X509, obj: *mut ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext_by_critical(x: *mut X509, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_get_ext(x: *mut X509, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_get_ext_d2i(
-                x: *mut ::X509,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // in X509_CRL
-            pub fn X509_CRL_get_ext_count(x: *mut X509_CRL) -> c_int;
-            pub fn X509_CRL_get_ext_by_NID(x: *mut X509_CRL, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext_by_OBJ(x: *mut X509_CRL, obj: *mut ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext_by_critical(x: *mut X509_CRL, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_CRL_get_ext(x: *mut X509_CRL, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_CRL_get_ext_d2i(
-                x: *mut ::X509_CRL,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // in X509_REVOKED
-            pub fn X509_REVOKED_get_ext_count(x: *mut X509_REVOKED) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_NID(x: *mut X509_REVOKED, nid: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_OBJ(x: *mut X509_REVOKED, obj: *mut ASN1_OBJECT, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext_by_critical(x: *mut X509_REVOKED, crit: c_int, lastpos: c_int) -> c_int;
-            pub fn X509_REVOKED_get_ext(x: *mut X509_REVOKED, loc: c_int) -> *mut X509_EXTENSION;
-            pub fn X509_REVOKED_get_ext_d2i(
-                x: *mut ::X509_REVOKED,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            // X509_EXTENSION stack
-            pub fn X509v3_get_ext_by_OBJ(x: *const stack_st_X509_EXTENSION, obj: *mut ASN1_OBJECT, lastpos: c_int) -> c_int;
-            // X509_EXTENSION itself
-            pub fn X509_EXTENSION_create_by_OBJ(ex: *mut *mut X509_EXTENSION, obj: *mut ASN1_OBJECT, crit: c_int, data: *mut ASN1_OCTET_STRING) -> *mut X509_EXTENSION;
-            pub fn X509_EXTENSION_set_object(ex: *mut X509_EXTENSION, obj: *mut ASN1_OBJECT) -> c_int;
-            pub fn X509_EXTENSION_get_critical(ex: *mut X509_EXTENSION) -> c_int;
-        }
+const_ptr_api! {
+    extern "C" {
+        // in X509
+        pub fn X509_get_ext_count(x: #[const_ptr_if(any(ossl110, libressl280))] X509) -> c_int;
+        pub fn X509_get_ext_by_NID(x: #[const_ptr_if(any(ossl110, libressl280))] X509, nid: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_get_ext_by_OBJ(x: #[const_ptr_if(any(ossl110, libressl280))] X509, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, lastpos: c_int) -> c_int;
+        pub fn X509_get_ext_by_critical(x: #[const_ptr_if(any(ossl110, libressl280))] X509, crit: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_get_ext(x: #[const_ptr_if(any(ossl110, libressl280))] X509, loc: c_int) -> *mut X509_EXTENSION;
+        pub fn X509_get_ext_d2i(
+            x: #[const_ptr_if(any(ossl110, libressl280))] ::X509,
+            nid: c_int,
+            crit: *mut c_int,
+            idx: *mut c_int,
+        ) -> *mut c_void;
+        // in X509_CRL
+        pub fn X509_CRL_get_ext_count(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL) -> c_int;
+        pub fn X509_CRL_get_ext_by_NID(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL, nid: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_CRL_get_ext_by_OBJ(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, lastpos: c_int) -> c_int;
+        pub fn X509_CRL_get_ext_by_critical(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL, crit: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_CRL_get_ext(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL, loc: c_int) -> *mut X509_EXTENSION;
+        pub fn X509_CRL_get_ext_d2i(
+            x: #[const_ptr_if(any(ossl110, libressl280))] ::X509_CRL,
+            nid: c_int,
+            crit: *mut c_int,
+            idx: *mut c_int,
+        ) -> *mut c_void;
+        // in X509_REVOKED
+        pub fn X509_REVOKED_get_ext_count(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED) -> c_int;
+        pub fn X509_REVOKED_get_ext_by_NID(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED, nid: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_REVOKED_get_ext_by_OBJ(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, lastpos: c_int) -> c_int;
+        pub fn X509_REVOKED_get_ext_by_critical(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED, crit: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_REVOKED_get_ext(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED, loc: c_int) -> *mut X509_EXTENSION;
+        pub fn X509_REVOKED_get_ext_d2i(
+            x: #[const_ptr_if(any(ossl110, libressl280))] ::X509_REVOKED,
+            nid: c_int,
+            crit: *mut c_int,
+            idx: *mut c_int,
+        ) -> *mut c_void;
+        // X509_EXTENSION stack
+        pub fn X509v3_get_ext_by_OBJ(x: *const stack_st_X509_EXTENSION, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, lastpos: c_int) -> c_int;
+        // X509_EXTENSION itself
+        pub fn X509_EXTENSION_create_by_OBJ(ex: *mut *mut X509_EXTENSION, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, crit: c_int, data: *mut ASN1_OCTET_STRING) -> *mut X509_EXTENSION;
+        pub fn X509_EXTENSION_set_object(ex: *mut X509_EXTENSION, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT) -> c_int;
+        pub fn X509_EXTENSION_get_critical(ex: #[const_ptr_if(any(ossl110, libressl280))] X509_EXTENSION) -> c_int;
     }
 }
 

--- a/openssl-sys/src/x509v3.rs
+++ b/openssl-sys/src/x509v3.rs
@@ -51,37 +51,20 @@ pub const X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS: c_uint = 0x10;
 #[cfg(ossl110)]
 pub const X509_CHECK_FLAG_NEVER_CHECK_SUBJECT: c_uint = 0x20;
 
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn X509V3_EXT_nconf_nid(
-                conf: *mut CONF,
-                ctx: *mut X509V3_CTX,
-                ext_nid: c_int,
-                value: *const c_char,
-            ) -> *mut X509_EXTENSION;
-            pub fn X509V3_EXT_nconf(
-                conf: *mut CONF,
-                ctx: *mut X509V3_CTX,
-                name: *const c_char,
-                value: *const c_char,
-            ) -> *mut X509_EXTENSION;
-        }
-    } else {
-        extern "C" {
-            pub fn X509V3_EXT_nconf_nid(
-                conf: *mut CONF,
-                ctx: *mut X509V3_CTX,
-                ext_nid: c_int,
-                value: *mut c_char,
-            ) -> *mut X509_EXTENSION;
-            pub fn X509V3_EXT_nconf(
-                conf: *mut CONF,
-                ctx: *mut X509V3_CTX,
-                name: *mut c_char,
-                value: *mut c_char,
-            ) -> *mut X509_EXTENSION;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn X509V3_EXT_nconf_nid(
+            conf: *mut CONF,
+            ctx: *mut X509V3_CTX,
+            ext_nid: c_int,
+            value: #[const_ptr_if(any(ossl110, libressl280))] c_char,
+        ) -> *mut X509_EXTENSION;
+        pub fn X509V3_EXT_nconf(
+            conf: *mut CONF,
+            ctx: *mut X509V3_CTX,
+            name: #[const_ptr_if(any(ossl110, libressl280))] c_char,
+            value: #[const_ptr_if(any(ossl110, libressl280))] c_char,
+        ) -> *mut X509_EXTENSION;
     }
 }
 
@@ -103,27 +86,15 @@ extern "C" {
     pub fn X509_get1_ocsp(x: *mut X509) -> *mut stack_st_OPENSSL_STRING;
 }
 
-cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
-        extern "C" {
-            pub fn X509V3_get_d2i(
-                x: *const stack_st_X509_EXTENSION,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            pub fn X509V3_extensions_print(out: *mut BIO, title: *const c_char, exts: *const stack_st_X509_EXTENSION, flag: c_ulong, indent: c_int) -> c_int;
-        }
-    } else {
-        extern "C" {
-            pub fn X509V3_get_d2i(
-                x: *mut stack_st_X509_EXTENSION,
-                nid: c_int,
-                crit: *mut c_int,
-                idx: *mut c_int,
-            ) -> *mut c_void;
-            pub fn X509V3_extensions_print(out: *mut BIO, title: *mut c_char, exts: *mut stack_st_X509_EXTENSION, flag: c_ulong, indent: c_int) -> c_int;
-        }
+const_ptr_api! {
+    extern "C" {
+        pub fn X509V3_get_d2i(
+            x: #[const_ptr_if(any(ossl110, libressl280))] stack_st_X509_EXTENSION,
+            nid: c_int,
+            crit: *mut c_int,
+            idx: *mut c_int,
+        ) -> *mut c_void;
+        pub fn X509V3_extensions_print(out: *mut BIO, title: #[const_ptr_if(any(ossl110, libressl280))] c_char, exts: #[const_ptr_if(any(ossl110, libressl280))] stack_st_X509_EXTENSION, flag: c_ulong, indent: c_int) -> c_int;
     }
 }
 


### PR DESCRIPTION
Alternative approach to #1348; actually tries to parse fn declarations and magically inserts `*const` or `*mut`.