### PR TITLE
compiles on openbsd-current (6.7-6.8 interregnum)

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -221,6 +221,7 @@ See rust-openssl README for more information:
             (3, 1, 0) => ('3', '1', '0'),
             (3, 1, _) => ('3', '1', 'x'),
             (3, 2, 0) => ('3', '2', '0'),
+            (3, 2, _) => ('3', '2', 'x'),
             _ => version_error(),
         };
 


### PR DESCRIPTION
This small adjustment allows rust-openssl to build without fault on the latest OpenBSD snapshot, circa today.

