### PR TITLE
Add AEAD SRTP protection profiles

### DIFF
--- a/openssl-sys/src/srtp.rs
+++ b/openssl-sys/src/srtp.rs
@@ -9,6 +9,12 @@ pub const SRTP_AES128_F8_SHA1_32: c_ulong = 0x0004;
 pub const SRTP_NULL_SHA1_80: c_ulong = 0x0005;
 pub const SRTP_NULL_SHA1_32: c_ulong = 0x0006;
 
+/* AEAD SRTP protection profiles from RFC 7714 */
+#[cfg(ossl110)]
+pub const SRTP_AEAD_AES_128_GCM: c_ulong = 0x0007;
+#[cfg(ossl110)]
+pub const SRTP_AEAD_AES_256_GCM: c_ulong = 0x0008;
+
 extern "C" {
     pub fn SSL_CTX_set_tlsext_use_srtp(ctx: *mut SSL_CTX, profiles: *const c_char) -> c_int;
     pub fn SSL_set_tlsext_use_srtp(ssl: *mut SSL, profiles: *const c_char) -> c_int;

--- a/openssl/src/srtp.rs
+++ b/openssl/src/srtp.rs
@@ -44,6 +44,10 @@ impl SrtpProfileId {
     pub const SRTP_AES128_F8_SHA1_32: SrtpProfileId = SrtpProfileId(ffi::SRTP_AES128_F8_SHA1_32);
     pub const SRTP_NULL_SHA1_80: SrtpProfileId = SrtpProfileId(ffi::SRTP_NULL_SHA1_80);
     pub const SRTP_NULL_SHA1_32: SrtpProfileId = SrtpProfileId(ffi::SRTP_NULL_SHA1_32);
+    #[cfg(ossl110)]
+    pub const SRTP_AEAD_AES_128_GCM: SrtpProfileId = SrtpProfileId(ffi::SRTP_AEAD_AES_128_GCM);
+    #[cfg(ossl110)]
+    pub const SRTP_AEAD_AES_256_GCM: SrtpProfileId = SrtpProfileId(ffi::SRTP_AEAD_AES_256_GCM);
 
     /// Creates a `SrtpProfileId` from an integer representation.
     pub fn from_raw(value: c_ulong) -> SrtpProfileId {


### PR DESCRIPTION
Add missing AEAD SRTP profile constants. I tried to mimic the openssl header file structure for the -sys file. I'll _fix_ it if you don't like it.