### PR TITLE
Support for enabling CRL-based certificate revocation checking

### DIFF
--- a/openssl-sys/src/ossl_typ.rs
+++ b/openssl-sys/src/ossl_typ.rs
@@ -342,6 +342,8 @@ cfg_if! {
     }
 }
 
+pub enum X509_LOOKUP_METHOD {}
+
 pub enum X509_NAME {}
 
 cfg_if! {

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -1004,6 +1004,9 @@ extern "C" {
     pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
 
     #[cfg(any(ossl102, libressl261))]
+    pub fn SSL_CTX_get0_param(ctx: *mut SSL_CTX) -> *mut X509_VERIFY_PARAM;
+
+    #[cfg(any(ossl102, libressl261))]
     pub fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
 }
 

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -95,6 +95,29 @@ cfg_if! {
     }
 }
 
+pub const X509_V_FLAG_CB_ISSUER_CHECK: c_ulong = 0x0;
+pub const X509_V_FLAG_USE_CHECK_TIME: c_ulong = 0x2;
+pub const X509_V_FLAG_CRL_CHECK: c_ulong = 0x4;
+pub const X509_V_FLAG_CRL_CHECK_ALL: c_ulong = 0x8;
+pub const X509_V_FLAG_IGNORE_CRITICAL: c_ulong = 0x10;
+pub const X509_V_FLAG_X509_STRICT: c_ulong = 0x20;
+pub const X509_V_FLAG_ALLOW_PROXY_CERTS: c_ulong = 0x40;
+pub const X509_V_FLAG_POLICY_CHECK: c_ulong = 0x80;
+pub const X509_V_FLAG_EXPLICIT_POLICY: c_ulong = 0x100;
+pub const X509_V_FLAG_INHIBIT_ANY: c_ulong = 0x200;
+pub const X509_V_FLAG_INHIBIT_MAP: c_ulong = 0x400;
+pub const X509_V_FLAG_NOTIFY_POLICY: c_ulong = 0x800;
+pub const X509_V_FLAG_EXTENDED_CRL_SUPPORT: c_ulong = 0x1000;
+pub const X509_V_FLAG_USE_DELTAS: c_ulong = 0x2000;
+pub const X509_V_FLAG_CHECK_SS_SIGNATURE: c_ulong = 0x4000;
+pub const X509_V_FLAG_TRUSTED_FIRST: c_ulong = 0x8000;
+pub const X509_V_FLAG_SUITEB_128_LOS_ONLY: c_ulong = 0x10000;
+pub const X509_V_FLAG_SUITEB_192_LOS: c_ulong = 0x20000;
+pub const X509_V_FLAG_SUITEB_128_LOS: c_ulong = 0x30000;
+pub const X509_V_FLAG_PARTIAL_CHAIN: c_ulong = 0x80000;
+pub const X509_V_FLAG_NO_ALT_CHAINS: c_ulong = 0x100000;
+pub const X509_V_FLAG_NO_CHECK_TIME: c_ulong = 0x200000;
+
 extern "C" {
     pub fn X509_STORE_new() -> *mut X509_STORE;
     pub fn X509_STORE_free(store: *mut X509_STORE);
@@ -135,6 +158,13 @@ cfg_if! {
 extern "C" {
     #[cfg(any(ossl102, libressl261))]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
+
+    #[cfg(any(ossl102, libressl261))]
+    pub fn X509_VERIFY_PARAM_set_flags(param: *mut X509_VERIFY_PARAM, flags: c_ulong) -> c_int;
+    #[cfg(any(ossl102, libressl261))]
+    pub fn X509_VERIFY_PARAM_clear_flags(param: *mut X509_VERIFY_PARAM, flags: c_ulong) -> c_int;
+    #[cfg(any(ossl102, libressl261))]
+    pub fn X509_VERIFY_PARAM_get_flags(param: *mut X509_VERIFY_PARAM) -> c_ulong;
 
     #[cfg(any(ossl102, libressl261))]
     pub fn X509_VERIFY_PARAM_set1_host(

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -119,6 +119,32 @@ pub const X509_V_FLAG_NO_ALT_CHAINS: c_ulong = 0x100000;
 pub const X509_V_FLAG_NO_CHECK_TIME: c_ulong = 0x200000;
 
 extern "C" {
+    pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
+    pub fn X509_LOOKUP_ctrl(
+        ctx: *mut X509_LOOKUP,
+        cmd: c_int,
+        argc: *const c_char,
+        argl: c_long,
+        ret: *mut *mut c_char,
+    ) -> c_int;
+}
+
+pub unsafe fn X509_LOOKUP_add_dir(
+    ctx: *mut X509_LOOKUP,
+    name: *const c_char,
+    _type: c_int,
+) -> c_int {
+    const X509_L_ADD_DIR: c_int = 2;
+    X509_LOOKUP_ctrl(
+        ctx,
+        X509_L_ADD_DIR,
+        name,
+        _type as c_long,
+        std::ptr::null_mut(),
+    )
+}
+
+extern "C" {
     pub fn X509_STORE_new() -> *mut X509_STORE;
     pub fn X509_STORE_free(store: *mut X509_STORE);
 
@@ -134,6 +160,11 @@ extern "C" {
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x: *mut X509) -> c_int;
+
+    pub fn X509_STORE_add_lookup(
+        store: *mut X509_STORE,
+        meth: *mut X509_LOOKUP_METHOD,
+    ) -> *mut X509_LOOKUP;
 
     pub fn X509_STORE_set_default_paths(store: *mut X509_STORE) -> c_int;
 

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -95,6 +95,9 @@ cfg_if! {
     }
 }
 
+#[cfg(not(ossl110))]
+pub const X509_V_FLAG_CB_ISSUER_CHECK: c_ulong = 0x1;
+#[cfg(ossl110)]
 pub const X509_V_FLAG_CB_ISSUER_CHECK: c_ulong = 0x0;
 pub const X509_V_FLAG_USE_CHECK_TIME: c_ulong = 0x2;
 pub const X509_V_FLAG_CRL_CHECK: c_ulong = 0x4;
@@ -110,12 +113,19 @@ pub const X509_V_FLAG_NOTIFY_POLICY: c_ulong = 0x800;
 pub const X509_V_FLAG_EXTENDED_CRL_SUPPORT: c_ulong = 0x1000;
 pub const X509_V_FLAG_USE_DELTAS: c_ulong = 0x2000;
 pub const X509_V_FLAG_CHECK_SS_SIGNATURE: c_ulong = 0x4000;
+#[cfg(ossl102)]
 pub const X509_V_FLAG_TRUSTED_FIRST: c_ulong = 0x8000;
+#[cfg(ossl102)]
 pub const X509_V_FLAG_SUITEB_128_LOS_ONLY: c_ulong = 0x10000;
+#[cfg(ossl102)]
 pub const X509_V_FLAG_SUITEB_192_LOS: c_ulong = 0x20000;
+#[cfg(ossl102)]
 pub const X509_V_FLAG_SUITEB_128_LOS: c_ulong = 0x30000;
+#[cfg(ossl102)]
 pub const X509_V_FLAG_PARTIAL_CHAIN: c_ulong = 0x80000;
+#[cfg(ossl110)]
 pub const X509_V_FLAG_NO_ALT_CHAINS: c_ulong = 0x100000;
+#[cfg(ossl110)]
 pub const X509_V_FLAG_NO_CHECK_TIME: c_ulong = 0x200000;
 
 extern "C" {

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -119,6 +119,12 @@ pub const X509_V_FLAG_NO_ALT_CHAINS: c_ulong = 0x100000;
 pub const X509_V_FLAG_NO_CHECK_TIME: c_ulong = 0x200000;
 
 extern "C" {
+    #[cfg(ossl110)]
+    pub fn X509_LOOKUP_meth_free(method: *mut X509_LOOKUP_METHOD);
+}
+
+extern "C" {
+    pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
     pub fn X509_LOOKUP_hash_dir() -> *mut X509_LOOKUP_METHOD;
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1342,6 +1342,18 @@ impl SslContextBuilder {
         unsafe { X509StoreBuilderRef::from_ptr_mut(ffi::SSL_CTX_get_cert_store(self.as_ptr())) }
     }
 
+    /// Returns a mutable reference to the X509 verification configuration.
+    ///
+    /// Requires OpenSSL 1.0.2 or newer.
+    ///
+    /// This corresponds to [`SSL_CTX_get0_param`].
+    ///
+    /// [`SSL_CTX_get0_param`]: https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_get0_param.html
+    #[cfg(any(ossl102, libressl261))]
+    pub fn verify_param_mut(&mut self) -> &mut X509VerifyParamRef {
+        unsafe { X509VerifyParamRef::from_ptr_mut(ffi::SSL_CTX_get0_param(self.as_ptr())) }
+    }
+
     /// Sets the callback dealing with OCSP stapling.
     ///
     /// On the client side, this callback is responsible for validating the OCSP status response
@@ -1994,18 +2006,6 @@ impl SslContextRef {
     pub fn verify_mode(&self) -> SslVerifyMode {
         let mode = unsafe { ffi::SSL_CTX_get_verify_mode(self.as_ptr()) };
         SslVerifyMode::from_bits(mode).expect("SSL_CTX_get_verify_mode returned invalid mode")
-    }
-
-    /// Returns a mutable reference to the X509 verification configuration.
-    ///
-    /// Requires OpenSSL 1.0.2 or newer.
-    ///
-    /// This corresponds to [`SSL_CTX_get0_param`].
-    ///
-    /// [`SSL_CTX_get0_param`]: https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_get0_param.html
-    #[cfg(any(ossl102, libressl261))]
-    pub fn param_mut(&mut self) -> &mut X509VerifyParamRef {
-        unsafe { X509VerifyParamRef::from_ptr_mut(ffi::SSL_CTX_get0_param(self.as_ptr())) }
     }
 }
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1342,6 +1342,18 @@ impl SslContextBuilder {
         unsafe { X509StoreBuilderRef::from_ptr_mut(ffi::SSL_CTX_get_cert_store(self.as_ptr())) }
     }
 
+    /// Returns a reference to the X509 verification configuration.
+    ///
+    /// Requires OpenSSL 1.0.2 or newer.
+    ///
+    /// This corresponds to [`SSL_CTX_get0_param`].
+    ///
+    /// [`SSL_CTX_get0_param`]: https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_get0_param.html
+    #[cfg(any(ossl102, libressl261))]
+    pub fn verify_param(&self) -> &X509VerifyParamRef {
+        unsafe { X509VerifyParamRef::from_ptr(ffi::SSL_CTX_get0_param(self.as_ptr())) }
+    }
+
     /// Returns a mutable reference to the X509 verification configuration.
     ///
     /// Requires OpenSSL 1.0.2 or newer.

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1995,6 +1995,18 @@ impl SslContextRef {
         let mode = unsafe { ffi::SSL_CTX_get_verify_mode(self.as_ptr()) };
         SslVerifyMode::from_bits(mode).expect("SSL_CTX_get_verify_mode returned invalid mode")
     }
+
+    /// Returns a mutable reference to the X509 verification configuration.
+    ///
+    /// Requires OpenSSL 1.0.2 or newer.
+    ///
+    /// This corresponds to [`SSL_CTX_get0_param`].
+    ///
+    /// [`SSL_CTX_get0_param`]: https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_get0_param.html
+    #[cfg(any(ossl102, libressl261))]
+    pub fn param_mut(&mut self) -> &mut X509VerifyParamRef {
+        unsafe { X509VerifyParamRef::from_ptr_mut(ffi::SSL_CTX_get0_param(self.as_ptr())) }
+    }
 }
 
 /// Information about the state of a cipher.

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -159,9 +159,9 @@ impl X509LookupRef {
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::X509_LOOKUP_METHOD;
-    fn drop = |method| {
+    fn drop = |_method| {
         #[cfg(ossl110)]
-        ffi::X509_LOOKUP_meth_free(method);
+        ffi::X509_LOOKUP_meth_free(_method);
     };
 
     /// Method used to look up certificates and CRLs.

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -102,7 +102,7 @@ impl X509StoreBuilderRef {
     /// [`X509_STORE_add_lookup`]: https://www.openssl.org/docs/man1.1.1/man3/X509_STORE_add_lookup.html
     pub fn add_lookup(
         &mut self,
-        method: &X509LookupMethodRef,
+        method: &'static X509LookupMethodRef,
     ) -> Result<&mut X509LookupRef, ErrorStack> {
         let lookup = unsafe { ffi::X509_STORE_add_lookup(self.as_ptr(), method.as_ptr()) };
         cvt_p(lookup).map(|ptr| unsafe { X509LookupRef::from_ptr_mut(ptr) })

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -119,13 +119,12 @@ generic_foreign_type_and_impl_send_sync! {
     pub struct X509LookupRef<T>;
 }
 
-/// Marker type for lookup methods that can be pointed at a directory, i.e.
-/// ones that support [`X509_LOOKUP_ctrl`] with the `X509_L_ADD_DIR` command.
+/// Marker type corresponding to the [`X509_LOOKUP_hash_dir`] lookup method.
 ///
-/// [`X509_LOOKUP_ctrl`]: https://www.openssl.org/docs/man1.1.1/man3/X509_LOOKUP_ctrl.html
-pub struct AddDir;
+/// [`X509_LOOKUP_hash_dir`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_LOOKUP_hash_dir.html
+pub struct HashDir;
 
-impl X509Lookup<AddDir> {
+impl X509Lookup<HashDir> {
     /// Lookup method that loads certificates and CRLs on demand and caches
     /// them in memory once they are loaded. As of OpenSSL 1.0.0, it also
     /// checks for newer CRLs upon each lookup, so that newer CRLs are used as
@@ -134,12 +133,12 @@ impl X509Lookup<AddDir> {
     /// This corresponds to [`X509_LOOKUP_hash_dir`].
     ///
     /// [`X509_LOOKUP_hash_dir`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_LOOKUP_hash_dir.html
-    pub fn hash_dir() -> &'static X509LookupMethodRef<AddDir> {
+    pub fn hash_dir() -> &'static X509LookupMethodRef<HashDir> {
         unsafe { X509LookupMethodRef::from_ptr(ffi::X509_LOOKUP_hash_dir()) }
     }
 }
 
-impl X509LookupRef<AddDir> {
+impl X509LookupRef<HashDir> {
     /// Specifies a directory from which certificates and CRLs will be loaded
     /// on-demand. Must be used with `X509Lookup::hash_dir`.
     ///

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -126,9 +126,9 @@ pub struct HashDir;
 
 impl X509Lookup<HashDir> {
     /// Lookup method that loads certificates and CRLs on demand and caches
-    /// them in memory once they are loaded. As of OpenSSL 1.0.0, it also
-    /// checks for newer CRLs upon each lookup, so that newer CRLs are used as
-    /// soon as they appear in the directory.
+    /// them in memory once they are loaded. It also checks for newer CRLs upon
+    /// each lookup, so that newer CRLs are used as soon as they appear in the
+    /// directory.
     ///
     /// This corresponds to [`X509_LOOKUP_hash_dir`].
     ///

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -26,35 +26,35 @@ bitflags! {
 bitflags! {
     /// Flags used to verify an `X509` certificate chain.
     pub struct X509VerifyFlags: c_ulong {
-        const X509_V_FLAG_CB_ISSUER_CHECK = ffi::X509_V_FLAG_CB_ISSUER_CHECK;
-        const X509_V_FLAG_USE_CHECK_TIME = ffi::X509_V_FLAG_USE_CHECK_TIME;
-        const X509_V_FLAG_CRL_CHECK = ffi::X509_V_FLAG_CRL_CHECK;
-        const X509_V_FLAG_CRL_CHECK_ALL = ffi::X509_V_FLAG_CRL_CHECK_ALL;
-        const X509_V_FLAG_IGNORE_CRITICAL = ffi::X509_V_FLAG_X509_STRICT;
-        const X509_V_FLAG_X509_STRICT = ffi::X509_V_FLAG_IGNORE_CRITICAL;
-        const X509_V_FLAG_ALLOW_PROXY_CERTS = ffi::X509_V_FLAG_ALLOW_PROXY_CERTS;
-        const X509_V_FLAG_POLICY_CHECK = ffi::X509_V_FLAG_POLICY_CHECK;
-        const X509_V_FLAG_EXPLICIT_POLICY = ffi::X509_V_FLAG_EXPLICIT_POLICY;
-        const X509_V_FLAG_INHIBIT_ANY = ffi::X509_V_FLAG_INHIBIT_ANY;
-        const X509_V_FLAG_INHIBIT_MAP = ffi::X509_V_FLAG_INHIBIT_MAP;
-        const X509_V_FLAG_NOTIFY_POLICY = ffi::X509_V_FLAG_NOTIFY_POLICY;
-        const X509_V_FLAG_EXTENDED_CRL_SUPPORT = ffi::X509_V_FLAG_EXTENDED_CRL_SUPPORT;
-        const X509_V_FLAG_USE_DELTAS = ffi::X509_V_FLAG_USE_DELTAS;
-        const X509_V_FLAG_CHECK_SS_SIGNATURE = ffi::X509_V_FLAG_CHECK_SS_SIGNATURE;
+        const CB_ISSUER_CHECK = ffi::X509_V_FLAG_CB_ISSUER_CHECK;
+        const USE_CHECK_TIME = ffi::X509_V_FLAG_USE_CHECK_TIME;
+        const CRL_CHECK = ffi::X509_V_FLAG_CRL_CHECK;
+        const CRL_CHECK_ALL = ffi::X509_V_FLAG_CRL_CHECK_ALL;
+        const IGNORE_CRITICAL = ffi::X509_V_FLAG_X509_STRICT;
+        const X509_STRICT = ffi::X509_V_FLAG_IGNORE_CRITICAL;
+        const ALLOW_PROXY_CERTS = ffi::X509_V_FLAG_ALLOW_PROXY_CERTS;
+        const POLICY_CHECK = ffi::X509_V_FLAG_POLICY_CHECK;
+        const EXPLICIT_POLICY = ffi::X509_V_FLAG_EXPLICIT_POLICY;
+        const INHIBIT_ANY = ffi::X509_V_FLAG_INHIBIT_ANY;
+        const INHIBIT_MAP = ffi::X509_V_FLAG_INHIBIT_MAP;
+        const NOTIFY_POLICY = ffi::X509_V_FLAG_NOTIFY_POLICY;
+        const EXTENDED_CRL_SUPPORT = ffi::X509_V_FLAG_EXTENDED_CRL_SUPPORT;
+        const USE_DELTAS = ffi::X509_V_FLAG_USE_DELTAS;
+        const CHECK_SS_SIGNATURE = ffi::X509_V_FLAG_CHECK_SS_SIGNATURE;
         #[cfg(ossl102)]
-        const X509_V_FLAG_TRUSTED_FIRST = ffi::X509_V_FLAG_TRUSTED_FIRST;
+        const TRUSTED_FIRST = ffi::X509_V_FLAG_TRUSTED_FIRST;
         #[cfg(ossl102)]
-        const X509_V_FLAG_SUITEB_128_LOS_ONLY = ffi::X509_V_FLAG_SUITEB_128_LOS_ONLY;
+        const SUITEB_128_LOS_ONLY = ffi::X509_V_FLAG_SUITEB_128_LOS_ONLY;
         #[cfg(ossl102)]
-        const X509_V_FLAG_SUITEB_192_LOS = ffi::X509_V_FLAG_SUITEB_128_LOS;
+        const SUITEB_192_LOS = ffi::X509_V_FLAG_SUITEB_128_LOS;
         #[cfg(ossl102)]
-        const X509_V_FLAG_SUITEB_128_LOS = ffi::X509_V_FLAG_SUITEB_192_LOS;
+        const SUITEB_128_LOS = ffi::X509_V_FLAG_SUITEB_192_LOS;
         #[cfg(ossl102)]
-        const X509_V_FLAG_PARTIAL_CHAIN = ffi::X509_V_FLAG_PARTIAL_CHAIN;
+        const PARTIAL_CHAIN = ffi::X509_V_FLAG_PARTIAL_CHAIN;
         #[cfg(ossl110)]
-        const X509_V_FLAG_NO_ALT_CHAINS = ffi::X509_V_FLAG_NO_ALT_CHAINS;
+        const NO_ALT_CHAINS = ffi::X509_V_FLAG_NO_ALT_CHAINS;
         #[cfg(ossl110)]
-        const X509_V_FLAG_NO_CHECK_TIME = ffi::X509_V_FLAG_NO_CHECK_TIME;
+        const NO_CHECK_TIME = ffi::X509_V_FLAG_NO_CHECK_TIME;
     }
 }
 

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -1,6 +1,6 @@
 use ffi;
 use foreign_types::ForeignTypeRef;
-use libc::c_uint;
+use libc::{c_uint, c_ulong};
 use std::net::IpAddr;
 
 use cvt;
@@ -20,6 +20,34 @@ bitflags! {
 
         #[deprecated(since = "0.10.6", note = "renamed to NO_WILDCARDS")]
         const FLAG_NO_WILDCARDS = ffi::X509_CHECK_FLAG_NO_WILDCARDS;
+    }
+}
+
+bitflags! {
+    /// Flags used to verify an `X509` certificate chain.
+    pub struct X509VerifyFlags: c_ulong {
+        const X509_V_FLAG_CB_ISSUER_CHECK = ffi::X509_V_FLAG_CB_ISSUER_CHECK;
+        const X509_V_FLAG_USE_CHECK_TIME = ffi::X509_V_FLAG_USE_CHECK_TIME;
+        const X509_V_FLAG_CRL_CHECK = ffi::X509_V_FLAG_CRL_CHECK;
+        const X509_V_FLAG_CRL_CHECK_ALL = ffi::X509_V_FLAG_CRL_CHECK_ALL;
+        const X509_V_FLAG_IGNORE_CRITICAL = ffi::X509_V_FLAG_X509_STRICT;
+        const X509_V_FLAG_X509_STRICT = ffi::X509_V_FLAG_IGNORE_CRITICAL;
+        const X509_V_FLAG_ALLOW_PROXY_CERTS = ffi::X509_V_FLAG_ALLOW_PROXY_CERTS;
+        const X509_V_FLAG_POLICY_CHECK = ffi::X509_V_FLAG_POLICY_CHECK;
+        const X509_V_FLAG_EXPLICIT_POLICY = ffi::X509_V_FLAG_EXPLICIT_POLICY;
+        const X509_V_FLAG_INHIBIT_ANY = ffi::X509_V_FLAG_INHIBIT_ANY;
+        const X509_V_FLAG_INHIBIT_MAP = ffi::X509_V_FLAG_INHIBIT_MAP;
+        const X509_V_FLAG_NOTIFY_POLICY = ffi::X509_V_FLAG_NOTIFY_POLICY;
+        const X509_V_FLAG_EXTENDED_CRL_SUPPORT = ffi::X509_V_FLAG_EXTENDED_CRL_SUPPORT;
+        const X509_V_FLAG_USE_DELTAS = ffi::X509_V_FLAG_USE_DELTAS;
+        const X509_V_FLAG_CHECK_SS_SIGNATURE = ffi::X509_V_FLAG_CHECK_SS_SIGNATURE;
+        const X509_V_FLAG_TRUSTED_FIRST = ffi::X509_V_FLAG_TRUSTED_FIRST;
+        const X509_V_FLAG_SUITEB_128_LOS_ONLY = ffi::X509_V_FLAG_SUITEB_128_LOS_ONLY;
+        const X509_V_FLAG_SUITEB_192_LOS = ffi::X509_V_FLAG_SUITEB_128_LOS;
+        const X509_V_FLAG_SUITEB_128_LOS = ffi::X509_V_FLAG_SUITEB_192_LOS;
+        const X509_V_FLAG_PARTIAL_CHAIN = ffi::X509_V_FLAG_PARTIAL_CHAIN;
+        const X509_V_FLAG_NO_ALT_CHAINS = ffi::X509_V_FLAG_NO_ALT_CHAINS;
+        const X509_V_FLAG_NO_CHECK_TIME = ffi::X509_V_FLAG_NO_CHECK_TIME;
     }
 }
 
@@ -43,6 +71,40 @@ impl X509VerifyParamRef {
         unsafe {
             ffi::X509_VERIFY_PARAM_set_hostflags(self.as_ptr(), hostflags.bits);
         }
+    }
+
+    /// Set verification flags.
+    ///
+    /// This corresponds to [`X509_VERIFY_PARAM_set_flags`].
+    ///
+    /// [`X509_VERIFY_PARAM_set_flags`]: https://www.openssl.org/docs/man1.0.2/crypto/X509_VERIFY_PARAM_set_flags.html
+    pub fn set_flags(&mut self, flags: X509VerifyFlags) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::X509_VERIFY_PARAM_set_flags(self.as_ptr(), flags.bits)).map(|_| ()) }
+    }
+
+    /// Clear verification flags.
+    ///
+    /// This corresponds to [`X509_VERIFY_PARAM_clear_flags`].
+    ///
+    /// [`X509_VERIFY_PARAM_clear_flags`]: https://www.openssl.org/docs/man1.0.2/crypto/X509_VERIFY_PARAM_clear_flags.html
+    pub fn clear_flags(&mut self, flags: X509VerifyFlags) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::X509_VERIFY_PARAM_clear_flags(
+                self.as_ptr(),
+                flags.bits,
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Gets verification flags.
+    ///
+    /// This corresponds to [`X509_VERIFY_PARAM_get_flags`].
+    ///
+    /// [`X509_VERIFY_PARAM_get_flags`]: https://www.openssl.org/docs/man1.0.2/crypto/X509_VERIFY_PARAM_get_flags.html
+    pub fn get_flags(&mut self) -> X509VerifyFlags {
+        let bits = unsafe { ffi::X509_VERIFY_PARAM_get_flags(self.as_ptr()) };
+        X509VerifyFlags { bits }
     }
 
     /// Set the expected DNS hostname.

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -41,12 +41,19 @@ bitflags! {
         const X509_V_FLAG_EXTENDED_CRL_SUPPORT = ffi::X509_V_FLAG_EXTENDED_CRL_SUPPORT;
         const X509_V_FLAG_USE_DELTAS = ffi::X509_V_FLAG_USE_DELTAS;
         const X509_V_FLAG_CHECK_SS_SIGNATURE = ffi::X509_V_FLAG_CHECK_SS_SIGNATURE;
+        #[cfg(ossl102)]
         const X509_V_FLAG_TRUSTED_FIRST = ffi::X509_V_FLAG_TRUSTED_FIRST;
+        #[cfg(ossl102)]
         const X509_V_FLAG_SUITEB_128_LOS_ONLY = ffi::X509_V_FLAG_SUITEB_128_LOS_ONLY;
+        #[cfg(ossl102)]
         const X509_V_FLAG_SUITEB_192_LOS = ffi::X509_V_FLAG_SUITEB_128_LOS;
+        #[cfg(ossl102)]
         const X509_V_FLAG_SUITEB_128_LOS = ffi::X509_V_FLAG_SUITEB_192_LOS;
+        #[cfg(ossl102)]
         const X509_V_FLAG_PARTIAL_CHAIN = ffi::X509_V_FLAG_PARTIAL_CHAIN;
+        #[cfg(ossl110)]
         const X509_V_FLAG_NO_ALT_CHAINS = ffi::X509_V_FLAG_NO_ALT_CHAINS;
+        #[cfg(ossl110)]
         const X509_V_FLAG_NO_CHECK_TIME = ffi::X509_V_FLAG_NO_CHECK_TIME;
     }
 }


### PR DESCRIPTION
Adds bindings for APIs needed to enable revocation checking with CRLs looked up by the `X509_LOOKUP_hash_dir` method, namely:
* `X509_LOOKUP` and `X509_LOOKUP_METHOD`
* `X509_VERIFY_PARAM` (setting verification flags)

There's a lot of API surface that still isn't covered, especially around lookup methods--this is just the minimal set of additions needed to get things working.