### PR TITLE
Added missing email_protection method to ExtendedKeyUsage struct.

### DIFF
--- a/openssl/src/x509/extension.rs
+++ b/openssl/src/x509/extension.rs
@@ -290,6 +290,12 @@ impl ExtendedKeyUsage {
         self
     }
 
+    /// Sets the `emailProtection` flag to `true`.
+    pub fn email_protection(&mut self) -> &mut ExtendedKeyUsage {
+        self.email_protection = true;
+        self
+    }
+
     /// Sets the `timeStamping` flag to `true`.
     pub fn time_stamping(&mut self) -> &mut ExtendedKeyUsage {
         self.time_stamping = true;


### PR DESCRIPTION
The code appeared to be prepared to have such method on the ExtendedKeyUsage struct though it was not present. So I assumed it had just not been added yet. One could argue that the flag could be set through the ```other``` method and this is not necessary but then the code that refers to the ```emailProtection``` should be removed.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>