### PR TITLE
Add encrypt module and RSA OAEP support

### DIFF
--- a/openssl-sys/src/rsa.rs
+++ b/openssl-sys/src/rsa.rs
@@ -49,12 +49,25 @@ pub unsafe fn EVP_PKEY_CTX_set_rsa_mgf1_md(ctx: *mut EVP_PKEY_CTX, md: *mut EVP_
     )
 }
 
+pub unsafe fn EVP_PKEY_CTX_set_rsa_oaep_md(ctx: *mut EVP_PKEY_CTX, md: *mut EVP_MD) -> c_int {
+    EVP_PKEY_CTX_ctrl(
+        ctx,
+        EVP_PKEY_RSA,
+        EVP_PKEY_OP_TYPE_CRYPT,
+        EVP_PKEY_CTRL_RSA_OAEP_MD,
+        0,
+        md as *mut c_void,
+    )
+}
+
 pub const EVP_PKEY_CTRL_RSA_PADDING: c_int = EVP_PKEY_ALG_CTRL + 1;
 pub const EVP_PKEY_CTRL_RSA_PSS_SALTLEN: c_int = EVP_PKEY_ALG_CTRL + 2;
 
 pub const EVP_PKEY_CTRL_RSA_MGF1_MD: c_int = EVP_PKEY_ALG_CTRL + 5;
 
 pub const EVP_PKEY_CTRL_GET_RSA_PADDING: c_int = EVP_PKEY_ALG_CTRL + 6;
+
+pub const EVP_PKEY_CTRL_RSA_OAEP_MD: c_int = EVP_PKEY_ALG_CTRL + 9;
 
 pub const RSA_PKCS1_PADDING: c_int = 1;
 pub const RSA_SSLV23_PADDING: c_int = 2;

--- a/openssl-sys/src/rsa.rs
+++ b/openssl-sys/src/rsa.rs
@@ -49,6 +49,7 @@ pub unsafe fn EVP_PKEY_CTX_set_rsa_mgf1_md(ctx: *mut EVP_PKEY_CTX, md: *mut EVP_
     )
 }
 
+#[cfg(any(ossl102, libressl310))]
 pub unsafe fn EVP_PKEY_CTX_set_rsa_oaep_md(ctx: *mut EVP_PKEY_CTX, md: *mut EVP_MD) -> c_int {
     EVP_PKEY_CTX_ctrl(
         ctx,
@@ -67,6 +68,7 @@ pub const EVP_PKEY_CTRL_RSA_MGF1_MD: c_int = EVP_PKEY_ALG_CTRL + 5;
 
 pub const EVP_PKEY_CTRL_GET_RSA_PADDING: c_int = EVP_PKEY_ALG_CTRL + 6;
 
+#[cfg(any(ossl102, libressl310))]
 pub const EVP_PKEY_CTRL_RSA_OAEP_MD: c_int = EVP_PKEY_ALG_CTRL + 9;
 
 pub const RSA_PKCS1_PADDING: c_int = 1;

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -1,0 +1,342 @@
+use std::{marker::PhantomData, ptr};
+
+use error::ErrorStack;
+use foreign_types::ForeignTypeRef;
+use hash::MessageDigest;
+use pkey::{HasPrivate, HasPublic, PKeyRef};
+use rsa::Padding;
+use {cvt, cvt_p};
+
+pub struct Encrypter<'a> {
+    pctx: *mut ffi::EVP_PKEY_CTX,
+    _p: PhantomData<&'a ()>,
+}
+
+unsafe impl<'a> Sync for Encrypter<'a> {}
+unsafe impl<'a> Send for Encrypter<'a> {}
+
+impl<'a> Drop for Encrypter<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::EVP_PKEY_CTX_free(self.pctx);
+        }
+    }
+}
+
+impl<'a> Encrypter<'a> {
+    /// Creates a new `Encrypter`.
+    ///
+    /// OpenSSL documentation at [`EVP_PKEY_encrypt_init`].
+    ///
+    /// [`EVP_PKEY_encrypt_init`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt_init.html
+    pub fn new<T>(pkey: &'a PKeyRef<T>) -> Result<Encrypter<'a>, ErrorStack>
+    where
+        T: HasPublic,
+    {
+        Self::new_intern(pkey)
+    }
+
+    fn new_intern<T>(pkey: &'a PKeyRef<T>) -> Result<Encrypter<'a>, ErrorStack>
+    where
+        T: HasPublic,
+    {
+        unsafe {
+            ffi::init();
+
+            let pctx = cvt_p(ffi::EVP_PKEY_CTX_new(pkey.as_ptr(), ptr::null_mut()))?;
+            let r = ffi::EVP_PKEY_encrypt_init(pctx);
+            if r != 1 {
+                ffi::EVP_PKEY_CTX_free(pctx);
+                return Err(ErrorStack::get());
+            }
+
+            Ok(Encrypter {
+                pctx,
+                _p: PhantomData,
+            })
+        }
+    }
+
+    /// Returns the RSA padding mode in use.
+    ///
+    /// This is only useful for RSA keys.
+    ///
+    /// This corresponds to `EVP_PKEY_CTX_get_rsa_padding`.
+    pub fn rsa_padding(&self) -> Result<Padding, ErrorStack> {
+        unsafe {
+            let mut pad = 0;
+            cvt(ffi::EVP_PKEY_CTX_get_rsa_padding(self.pctx, &mut pad))
+                .map(|_| Padding::from_raw(pad))
+        }
+    }
+
+    /// Sets the RSA padding mode.
+    ///
+    /// This is only useful for RSA keys.
+    ///
+    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_padding`].
+    ///
+    /// [`EVP_PKEY_CTX_set_rsa_padding`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_CTX_set_rsa_padding.html
+    pub fn set_rsa_padding(&mut self, padding: Padding) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_CTX_set_rsa_padding(
+                self.pctx,
+                padding.as_raw(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Sets the RSA MGF1 algorithm.
+    ///
+    /// This is only useful for RSA keys.
+    ///
+    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_mgf1_md`].
+    ///
+    /// [`EVP_PKEY_CTX_set_rsa_mgf1_md`]: https://www.openssl.org/docs/manmaster/man7/RSA-PSS.html
+    pub fn set_rsa_mgf1_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_CTX_set_rsa_mgf1_md(
+                self.pctx,
+                md.as_ptr() as *mut _,
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Sets the RSA OAEP algorithm.
+    ///
+    /// This is only useful for RSA keys.
+    ///
+    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
+    ///
+    /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
+    pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_CTX_set_rsa_oaep_md(
+                self.pctx,
+                md.as_ptr() as *mut _,
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Performs public key encryption.
+    ///
+    /// This corresponds to [`EVP_PKEY_encrypt`].
+    ///
+    /// [`EVP_PKEY_encrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt.html
+    pub fn encrypt(&self, from: &[u8], to: &mut [u8]) -> Result<usize, ErrorStack> {
+        let mut written = to.len();
+        unsafe {
+            cvt(ffi::EVP_PKEY_encrypt(
+                self.pctx,
+                to.as_mut_ptr(),
+                &mut written,
+                from.as_ptr(),
+                from.len(),
+            ))?;
+        }
+
+        Ok(written)
+    }
+}
+pub struct Decrypter<'a> {
+    pctx: *mut ffi::EVP_PKEY_CTX,
+    _p: PhantomData<&'a ()>,
+}
+
+unsafe impl<'a> Sync for Decrypter<'a> {}
+unsafe impl<'a> Send for Decrypter<'a> {}
+
+impl<'a> Drop for Decrypter<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::EVP_PKEY_CTX_free(self.pctx);
+        }
+    }
+}
+
+impl<'a> Decrypter<'a> {
+    /// Creates a new `Decrypter`.
+    ///
+    /// OpenSSL documentation at [`EVP_PKEY_decrypt_init`].
+    ///
+    /// [`EVP_PKEY_decrypt_init`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_decrypt_init.html
+    pub fn new<T>(pkey: &'a PKeyRef<T>) -> Result<Decrypter<'a>, ErrorStack>
+    where
+        T: HasPrivate,
+    {
+        Self::new_intern(pkey)
+    }
+
+    fn new_intern<T>(pkey: &'a PKeyRef<T>) -> Result<Decrypter<'a>, ErrorStack>
+    where
+        T: HasPrivate,
+    {
+        unsafe {
+            ffi::init();
+
+            let pctx = cvt_p(ffi::EVP_PKEY_CTX_new(pkey.as_ptr(), ptr::null_mut()))?;
+            let r = ffi::EVP_PKEY_decrypt_init(pctx);
+            if r != 1 {
+                ffi::EVP_PKEY_CTX_free(pctx);
+                return Err(ErrorStack::get());
+            }
+
+            Ok(Decrypter {
+                pctx,
+                _p: PhantomData,
+            })
+        }
+    }
+
+    /// Returns the RSA padding mode in use.
+    ///
+    /// This is only useful for RSA keys.
+    ///
+    /// This corresponds to `EVP_PKEY_CTX_get_rsa_padding`.
+    pub fn rsa_padding(&self) -> Result<Padding, ErrorStack> {
+        unsafe {
+            let mut pad = 0;
+            cvt(ffi::EVP_PKEY_CTX_get_rsa_padding(self.pctx, &mut pad))
+                .map(|_| Padding::from_raw(pad))
+        }
+    }
+
+    /// Sets the RSA padding mode.
+    ///
+    /// This is only useful for RSA keys.
+    ///
+    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_padding`].
+    ///
+    /// [`EVP_PKEY_CTX_set_rsa_padding`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_CTX_set_rsa_padding.html
+    pub fn set_rsa_padding(&mut self, padding: Padding) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_CTX_set_rsa_padding(
+                self.pctx,
+                padding.as_raw(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Sets the RSA MGF1 algorithm.
+    ///
+    /// This is only useful for RSA keys.
+    ///
+    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_mgf1_md`].
+    ///
+    /// [`EVP_PKEY_CTX_set_rsa_mgf1_md`]: https://www.openssl.org/docs/manmaster/man7/RSA-PSS.html
+    pub fn set_rsa_mgf1_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_CTX_set_rsa_mgf1_md(
+                self.pctx,
+                md.as_ptr() as *mut _,
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Sets the RSA OAEP algorithm.
+    ///
+    /// This is only useful for RSA keys.
+    ///
+    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
+    ///
+    /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
+    pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_CTX_set_rsa_oaep_md(
+                self.pctx,
+                md.as_ptr() as *mut _,
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Performs public key decryption.
+    ///
+    /// This corresponds to [`EVP_PKEY_decrypt`].
+    ///
+    /// [`EVP_PKEY_decrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_decrypt.html
+    pub fn decrypt(&self, from: &[u8], to: &mut [u8]) -> Result<usize, ErrorStack> {
+        let mut written = to.len();
+        unsafe {
+            cvt(ffi::EVP_PKEY_decrypt(
+                self.pctx,
+                to.as_mut_ptr(),
+                &mut written,
+                from.as_ptr(),
+                from.len(),
+            ))?;
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use hex::FromHex;
+
+    use encrypt::{Decrypter, Encrypter};
+    use hash::MessageDigest;
+    use pkey::PKey;
+    use rsa::{Padding, Rsa};
+
+    const INPUT: &str =
+        "65794a68624763694f694a53557a49314e694a392e65794a7063334d694f694a71623255694c41304b49434a6c\
+         654841694f6a457a4d4441344d546b7a4f44417344516f67496d6830644841364c79396c654746746347786c4c\
+         6d4e76625339706331397962323930496a7030636e566c6651";
+
+    #[test]
+    fn rsa_encrypt_decrypt() {
+        let key = include_bytes!("../test/rsa.pem");
+        let private_key = Rsa::private_key_from_pem(key).unwrap();
+        let pkey = PKey::from_rsa(private_key).unwrap();
+
+        let mut encrypter = Encrypter::new(&pkey).unwrap();
+        encrypter.set_rsa_padding(Padding::PKCS1).unwrap();
+        let input = Vec::from_hex(INPUT).unwrap();
+        let mut encoded = vec![0u8; INPUT.len() * 3];
+        let encoded_len = encrypter.encrypt(&input, &mut encoded).unwrap();
+        let encoded = &encoded[..encoded_len];
+
+        let mut decrypter = Decrypter::new(&pkey).unwrap();
+        decrypter.set_rsa_padding(Padding::PKCS1).unwrap();
+        let mut decoded = vec![0u8; encoded.len()];
+        let decoded_len = decrypter.decrypt(&encoded, &mut decoded).unwrap();
+        let decoded = &decoded[..decoded_len];
+
+        assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn rsa_encrypt_decrypt_with_sha256() {
+        let key = include_bytes!("../test/rsa.pem");
+        let private_key = Rsa::private_key_from_pem(key).unwrap();
+        let pkey = PKey::from_rsa(private_key).unwrap();
+
+        let md = MessageDigest::sha256();
+
+        let mut encrypter = Encrypter::new(&pkey).unwrap();
+        encrypter.set_rsa_padding(Padding::PKCS1_OAEP).unwrap();
+        encrypter.set_rsa_oaep_md(md).unwrap();
+        encrypter.set_rsa_mgf1_md(md).unwrap();
+        let input = Vec::from_hex(INPUT).unwrap();
+        let mut encoded = vec![0u8; INPUT.len() * 3];
+        let encoded_len = encrypter.encrypt(&input, &mut encoded).unwrap();
+        let encoded = &encoded[..encoded_len];
+
+        let mut decrypter = Decrypter::new(&pkey).unwrap();
+        decrypter.set_rsa_padding(Padding::PKCS1_OAEP).unwrap();
+        decrypter.set_rsa_oaep_md(md).unwrap();
+        decrypter.set_rsa_mgf1_md(md).unwrap();
+        let mut decoded = vec![0u8; encoded.len()];
+        let decoded_len = decrypter.decrypt(&encoded, &mut decoded).unwrap();
+        let decoded = &decoded[..decoded_len];
+
+        assert_eq!(decoded, input);
+    }
+}

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -118,6 +118,32 @@ impl<'a> Encrypter<'a> {
     /// Performs public key encryption.
     ///
     /// In order to know the size needed for the output buffer, use [`encrypt_len`](Encrypter::encrypt_len).
+    /// Note that the length of the output buffer can be greater of the length of the encoded data.
+    /// ```
+    /// # use openssl::{
+    /// #   encrypt::Encrypter,
+    /// #   pkey::PKey,
+    /// #   rsa::{Rsa, Padding},
+    /// # };
+    /// #
+    /// # let key = include_bytes!("../test/rsa.pem");
+    /// # let private_key = Rsa::private_key_from_pem(key).unwrap();
+    /// # let pkey = PKey::from_rsa(private_key).unwrap();
+    /// # let input = b"hello world".to_vec();
+    /// #
+    /// let mut encrypter = Encrypter::new(&pkey).unwrap();
+    /// encrypter.set_rsa_padding(Padding::PKCS1).unwrap();
+    ///
+    /// // Get the length of the output buffer
+    /// let buffer_len = encrypter.encrypt_len(&input).unwrap();
+    /// let mut encoded = vec![0u8; buffer_len];
+    ///
+    /// // Encode the data and get its length
+    /// let encoded_len = encrypter.encrypt(&input, &mut encoded).unwrap();
+    ///
+    /// // Use only the part of the buffer with the encoded data
+    /// let encoded = &encoded[..encoded_len];
+    /// ```
     ///
     /// This corresponds to [`EVP_PKEY_encrypt`].
     ///
@@ -268,6 +294,47 @@ impl<'a> Decrypter<'a> {
     /// Performs public key decryption.
     ///
     /// In order to know the size needed for the output buffer, use [`decrypt_len`](Decrypter::decrypt_len).
+    /// Note that the length of the output buffer can be greater of the length of the decoded data.
+    /// ```
+    /// # use openssl::{
+    /// #   encrypt::Decrypter,
+    /// #   pkey::PKey,
+    /// #   rsa::{Rsa, Padding},
+    /// # };
+    /// #
+    /// # const INPUT: &[u8] = b"\
+    /// #     \x26\xa1\xc1\x13\xc5\x7f\xb4\x9f\xa0\xb4\xde\x61\x5e\x2e\xc6\xfb\x76\x5c\xd1\x2b\x5f\
+    /// #     \x1d\x36\x60\xfa\xf8\xe8\xb3\x21\xf4\x9c\x70\xbc\x03\xea\xea\xac\xce\x4b\xb3\xf6\x45\
+    /// #     \xcc\xb3\x80\x9e\xa8\xf7\xc3\x5d\x06\x12\x7a\xa3\x0c\x30\x67\xf1\xe7\x94\x6c\xf6\x26\
+    /// #     \xac\x28\x17\x59\x69\xe1\xdc\xed\x7e\xc0\xe9\x62\x57\x49\xce\xdd\x13\x07\xde\x18\x03\
+    /// #     \x0f\x9d\x61\x65\xb9\x23\x8c\x78\x4b\xad\x23\x49\x75\x47\x64\xa0\xa0\xa2\x90\xc1\x49\
+    /// #     \x1b\x05\x24\xc2\xe9\x2c\x0d\x49\x78\x72\x61\x72\xed\x8b\x6f\x8a\xe8\xca\x05\x5c\x58\
+    /// #     \xd6\x95\xd6\x7b\xe3\x2d\x0d\xaa\x3e\x6d\x3c\x9a\x1c\x1d\xb4\x6c\x42\x9d\x9a\x82\x55\
+    /// #     \xd9\xde\xc8\x08\x7b\x17\xac\xd7\xaf\x86\x7b\x69\x9e\x3c\xf4\x5e\x1c\x39\x52\x6d\x62\
+    /// #     \x50\x51\xbd\xa6\xc8\x4e\xe9\x34\xf0\x37\x0d\xa9\xa9\x77\xe6\xf5\xc2\x47\x2d\xa8\xee\
+    /// #     \x3f\x69\x78\xff\xa9\xdc\x70\x22\x20\x9a\x5c\x9b\x70\x15\x90\xd3\xb4\x0e\x54\x9e\x48\
+    /// #     \xed\xb6\x2c\x88\xfc\xb4\xa9\x37\x10\xfa\x71\xb2\xec\x75\xe7\xe7\x0e\xf4\x60\x2c\x7b\
+    /// #     \x58\xaf\xa0\x53\xbd\x24\xf1\x12\xe3\x2e\x99\x25\x0a\x54\x54\x9d\xa1\xdb\xca\x41\x85\
+    /// #     \xf4\x62\x78\x64";
+    /// #
+    /// # let key = include_bytes!("../test/rsa.pem");
+    /// # let private_key = Rsa::private_key_from_pem(key).unwrap();
+    /// # let pkey = PKey::from_rsa(private_key).unwrap();
+    /// # let input = INPUT.to_vec();
+    /// #
+    /// let mut decrypter = Decrypter::new(&pkey).unwrap();
+    /// decrypter.set_rsa_padding(Padding::PKCS1).unwrap();
+    ///
+    /// // Get the length of the output buffer
+    /// let buffer_len = decrypter.decrypt_len(&input).unwrap();
+    /// let mut decoded = vec![0u8; buffer_len];
+    ///
+    /// // Decrypt the data and get its length
+    /// let decoded_len = decrypter.decrypt(&input, &mut decoded).unwrap();
+    ///
+    /// // Use only the part of the buffer with the decrypted data
+    /// let decoded = &decoded[..decoded_len];
+    /// ```
     ///
     /// This corresponds to [`EVP_PKEY_decrypt`].
     ///

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -117,6 +117,8 @@ impl<'a> Encrypter<'a> {
 
     /// Performs public key encryption.
     ///
+    /// In order to know the size needed for the output buffer, use [`encrypt_len`](Encrypter::encrypt_len).
+    ///
     /// This corresponds to [`EVP_PKEY_encrypt`].
     ///
     /// [`EVP_PKEY_encrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt.html
@@ -126,6 +128,26 @@ impl<'a> Encrypter<'a> {
             cvt(ffi::EVP_PKEY_encrypt(
                 self.pctx,
                 to.as_mut_ptr(),
+                &mut written,
+                from.as_ptr(),
+                from.len(),
+            ))?;
+        }
+
+        Ok(written)
+    }
+
+    /// Gets the size of the buffer needed to encrypt the input data.
+    ///
+    /// This corresponds to [`EVP_PKEY_encrypt`] called with a null pointer as output argument.
+    ///
+    /// [`EVP_PKEY_encrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt.html
+    pub fn encrypt_len(&self, from: &[u8]) -> Result<usize, ErrorStack> {
+        let mut written = 0;
+        unsafe {
+            cvt(ffi::EVP_PKEY_encrypt(
+                self.pctx,
+                ptr::null_mut(),
                 &mut written,
                 from.as_ptr(),
                 from.len(),
@@ -245,6 +267,8 @@ impl<'a> Decrypter<'a> {
 
     /// Performs public key decryption.
     ///
+    /// In order to know the size needed for the output buffer, use [`decrypt_len`](Decrypter::decrypt_len).
+    ///
     /// This corresponds to [`EVP_PKEY_decrypt`].
     ///
     /// [`EVP_PKEY_decrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_decrypt.html
@@ -254,6 +278,26 @@ impl<'a> Decrypter<'a> {
             cvt(ffi::EVP_PKEY_decrypt(
                 self.pctx,
                 to.as_mut_ptr(),
+                &mut written,
+                from.as_ptr(),
+                from.len(),
+            ))?;
+        }
+
+        Ok(written)
+    }
+
+    /// Gets the size of the buffer needed to decrypt the input data.
+    ///
+    /// This corresponds to [`EVP_PKEY_decrypt`] called with a null pointer as output argument.
+    ///
+    /// [`EVP_PKEY_decrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_decrypt.html
+    pub fn decrypt_len(&self, from: &[u8]) -> Result<usize, ErrorStack> {
+        let mut written = 0;
+        unsafe {
+            cvt(ffi::EVP_PKEY_decrypt(
+                self.pctx,
+                ptr::null_mut(),
                 &mut written,
                 from.as_ptr(),
                 from.len(),

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -33,13 +33,6 @@ impl<'a> Encrypter<'a> {
     where
         T: HasPublic,
     {
-        Self::new_intern(pkey)
-    }
-
-    fn new_intern<T>(pkey: &'a PKeyRef<T>) -> Result<Encrypter<'a>, ErrorStack>
-    where
-        T: HasPublic,
-    {
         unsafe {
             ffi::init();
 
@@ -164,13 +157,6 @@ impl<'a> Decrypter<'a> {
     ///
     /// [`EVP_PKEY_decrypt_init`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_decrypt_init.html
     pub fn new<T>(pkey: &'a PKeyRef<T>) -> Result<Decrypter<'a>, ErrorStack>
-    where
-        T: HasPrivate,
-    {
-        Self::new_intern(pkey)
-    }
-
-    fn new_intern<T>(pkey: &'a PKeyRef<T>) -> Result<Decrypter<'a>, ErrorStack>
     where
         T: HasPrivate,
     {

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -331,13 +331,15 @@ mod test {
         let mut encrypter = Encrypter::new(&pkey).unwrap();
         encrypter.set_rsa_padding(Padding::PKCS1).unwrap();
         let input = Vec::from_hex(INPUT).unwrap();
-        let mut encoded = vec![0u8; INPUT.len() * 3];
+        let buffer_len = encrypter.encrypt_len(&input).unwrap();
+        let mut encoded = vec![0u8; buffer_len];
         let encoded_len = encrypter.encrypt(&input, &mut encoded).unwrap();
         let encoded = &encoded[..encoded_len];
 
         let mut decrypter = Decrypter::new(&pkey).unwrap();
         decrypter.set_rsa_padding(Padding::PKCS1).unwrap();
-        let mut decoded = vec![0u8; encoded.len()];
+        let buffer_len = decrypter.decrypt_len(&encoded).unwrap();
+        let mut decoded = vec![0u8; buffer_len];
         let decoded_len = decrypter.decrypt(&encoded, &mut decoded).unwrap();
         let decoded = &decoded[..decoded_len];
 
@@ -358,7 +360,8 @@ mod test {
         encrypter.set_rsa_oaep_md(md).unwrap();
         encrypter.set_rsa_mgf1_md(md).unwrap();
         let input = Vec::from_hex(INPUT).unwrap();
-        let mut encoded = vec![0u8; INPUT.len() * 3];
+        let buffer_len = encrypter.encrypt_len(&input).unwrap();
+        let mut encoded = vec![0u8; buffer_len];
         let encoded_len = encrypter.encrypt(&input, &mut encoded).unwrap();
         let encoded = &encoded[..encoded_len];
 
@@ -366,7 +369,8 @@ mod test {
         decrypter.set_rsa_padding(Padding::PKCS1_OAEP).unwrap();
         decrypter.set_rsa_oaep_md(md).unwrap();
         decrypter.set_rsa_mgf1_md(md).unwrap();
-        let mut decoded = vec![0u8; encoded.len()];
+        let buffer_len = decrypter.decrypt_len(&encoded).unwrap();
+        let mut decoded = vec![0u8; buffer_len];
         let decoded_len = decrypter.decrypt(&encoded, &mut decoded).unwrap();
         let decoded = &decoded[..decoded_len];
 

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -104,6 +104,7 @@ impl<'a> Encrypter<'a> {
     /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
     ///
     /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
+    #[cfg(any(ossl102, libressl310))]
     pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_oaep_md(
@@ -231,6 +232,7 @@ impl<'a> Decrypter<'a> {
     /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
     ///
     /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
+    #[cfg(any(ossl102, libressl310))]
     pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_oaep_md(
@@ -299,6 +301,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(any(ossl102, libressl310))]
     fn rsa_encrypt_decrypt_with_sha256() {
         let key = include_bytes!("../test/rsa.pem");
         let private_key = Rsa::private_key_from_pem(key).unwrap();

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -309,7 +309,7 @@ mod test {
         let decoded_len = decrypter.decrypt(&encoded, &mut decoded).unwrap();
         let decoded = &decoded[..decoded_len];
 
-        assert_eq!(decoded, input);
+        assert_eq!(decoded, &*input);
     }
 
     #[test]
@@ -337,6 +337,6 @@ mod test {
         let decoded_len = decrypter.decrypt(&encoded, &mut decoded).unwrap();
         let decoded = &decoded[..decoded_len];
 
-        assert_eq!(decoded, input);
+        assert_eq!(decoded, &*input);
     }
 }

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -151,6 +151,7 @@ pub mod dh;
 pub mod dsa;
 pub mod ec;
 pub mod ecdsa;
+pub mod encrypt;
 pub mod envelope;
 pub mod error;
 pub mod ex_data;


### PR DESCRIPTION
Introduce a new module `encrypt`, with the two structs `Encrypter` and `Decrypter`, pretty similar to `Signer` and `Verifier`. With the introduction of  `EVP_PKEY_CTX_set_rsa_oaep_md` in `openssl-sys`, this new abstraction allows to perform RSA OAEP encryption and decryption without directly relying of `unsafe` calls.

As already discussed with @sfackler, there is a pretty good amount of code duplication, there is a good opportunity to use traits to abstract away _sign_ and _encrypt_ algorithms (i.e. OAEP can only be used for encryption, PSS only for signing). This PR could be a good starting point to analyze the current situation and, maybe, to understand how in the future the abstractions could be improved.

I would like some feedback, mostly because I could have missed some potential problem. Let me know what you think and just tell me what's missing.

Closes #1383 

**EDIT**: I forgot to mention: I _copied_ the API from `Signer`/`Verifier`, but I think that having to preallocate a buffer without knowing the exact size needed is pretty inconvenient. IMHO two versions of `encrypt` and `decrypt` should be provided, one that returns a `Vec<u8>`, the other that takes a buffer. I would like to hear your opinion about naming, because if I follow something like `encrypt(in: &[u8]) -> Vec<u8>` and `encrypt_buf(in: &[u8], out: &mut [u8])` (which would be my approach), I will immediately break the API convention of `Signer`/`Verifier`. Moreover, I also think that taking a `&mut Vec<u8>` could be convenient, to allow automatic buffer resizing, but on the other hand some questions would rise: the `vec` should be automatically cleared if non-empty? Or it should follow the same principles of [`Read::read_to_end`](https://doc.rust-lang.org/std/io/trait.Read.html#method.read_to_end) and similar?

P.S.: there is an issue about invalid C compiler parameters, which breaks the CI because `-Werror` is enabled, you probably already know that.

## TODO
- [x] Module documentation