### PR TITLE
Allow construction of unconnected SslStreams.

### DIFF
--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -24,8 +24,8 @@ pub struct StreamState<S> {
 pub struct BioMethod(BIO_METHOD);
 
 impl BioMethod {
-    fn new<S: Read + Write>() -> BioMethod {
-        BioMethod(BIO_METHOD::new::<S>())
+    fn new<S: Read + Write>() -> Result<BioMethod, ErrorStack> {
+        BIO_METHOD::new::<S>().map(BioMethod)
     }
 }
 
@@ -33,7 +33,7 @@ unsafe impl Sync for BioMethod {}
 unsafe impl Send for BioMethod {}
 
 pub fn new<S: Read + Write>(stream: S) -> Result<(*mut BIO, BioMethod), ErrorStack> {
-    let method = BioMethod::new::<S>();
+    let method = BioMethod::new::<S>()?;
 
     let state = Box::new(StreamState {
         stream,
@@ -191,6 +191,7 @@ unsafe extern "C" fn destroy<S>(bio: *mut BIO) -> c_int {
 cfg_if! {
     if #[cfg(any(ossl110, libressl273))] {
         use ffi::{BIO_get_data, BIO_set_data, BIO_set_flags, BIO_set_init};
+        use cvt;
 
         #[allow(bad_style)]
         unsafe fn BIO_set_num(_bio: *mut ffi::BIO, _num: c_int) {}
@@ -199,18 +200,17 @@ cfg_if! {
         struct BIO_METHOD(*mut ffi::BIO_METHOD);
 
         impl BIO_METHOD {
-            fn new<S: Read + Write>() -> BIO_METHOD {
+            fn new<S: Read + Write>() -> Result<BIO_METHOD, ErrorStack> {
                 unsafe {
-                    let ptr = ffi::BIO_meth_new(ffi::BIO_TYPE_NONE, b"rust\0".as_ptr() as *const _);
-                    assert!(!ptr.is_null());
-                    let ret = BIO_METHOD(ptr);
-                    assert!(ffi::BIO_meth_set_write(ptr, bwrite::<S>) != 0);
-                    assert!(ffi::BIO_meth_set_read(ptr, bread::<S>) != 0);
-                    assert!(ffi::BIO_meth_set_puts(ptr, bputs::<S>) != 0);
-                    assert!(ffi::BIO_meth_set_ctrl(ptr, ctrl::<S>) != 0);
-                    assert!(ffi::BIO_meth_set_create(ptr, create) != 0);
-                    assert!(ffi::BIO_meth_set_destroy(ptr, destroy::<S>) != 0);
-                    ret
+                    let ptr = cvt_p(ffi::BIO_meth_new(ffi::BIO_TYPE_NONE, b"rust\0".as_ptr() as *const _))?;
+                    let method = BIO_METHOD(ptr);
+                    cvt(ffi::BIO_meth_set_write(method.0, bwrite::<S>))?;
+                    cvt(ffi::BIO_meth_set_read(method.0, bread::<S>))?;
+                    cvt(ffi::BIO_meth_set_puts(method.0, bputs::<S>))?;
+                    cvt(ffi::BIO_meth_set_ctrl(method.0, ctrl::<S>))?;
+                    cvt(ffi::BIO_meth_set_create(method.0, create))?;
+                    cvt(ffi::BIO_meth_set_destroy(method.0, destroy::<S>))?;
+                    Ok(method)
                 }
             }
 
@@ -231,7 +231,7 @@ cfg_if! {
         struct BIO_METHOD(*mut ffi::BIO_METHOD);
 
         impl BIO_METHOD {
-            fn new<S: Read + Write>() -> BIO_METHOD {
+            fn new<S: Read + Write>() -> Result<BIO_METHOD, ErrorStack> {
                 let ptr = Box::new(ffi::BIO_METHOD {
                     type_: ffi::BIO_TYPE_NONE,
                     name: b"rust\0".as_ptr() as *const _,
@@ -245,7 +245,7 @@ cfg_if! {
                     callback_ctrl: None,
                 });
 
-                BIO_METHOD(Box::into_raw(ptr))
+                Ok(BIO_METHOD(Box::into_raw(ptr)))
             }
 
             fn get(&self) -> *mut ffi::BIO_METHOD {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1823,6 +1823,14 @@ foreign_type_and_impl_send_sync! {
 
 impl Clone for SslContext {
     fn clone(&self) -> Self {
+        (**self).to_owned()
+    }
+}
+
+impl ToOwned for SslContextRef {
+    type Owned = SslContext;
+
+    fn to_owned(&self) -> Self::Owned {
         unsafe {
             SSL_CTX_up_ref(self.as_ptr());
             SslContext::from_ptr(self.as_ptr())
@@ -2381,11 +2389,11 @@ impl Ssl {
     ///
     /// [`SSL_new`]: https://www.openssl.org/docs/man1.0.2/ssl/SSL_new.html
     // FIXME should take &SslContextRef
-    pub fn new(ctx: &SslContext) -> Result<Ssl, ErrorStack> {
+    pub fn new(ctx: &SslContextRef) -> Result<Ssl, ErrorStack> {
         unsafe {
             let ptr = cvt_p(ffi::SSL_new(ctx.as_ptr()))?;
             let mut ssl = Ssl::from_ptr(ptr);
-            ssl.set_ex_data(*SESSION_CTX_INDEX, ctx.clone());
+            ssl.set_ex_data(*SESSION_CTX_INDEX, ctx.to_owned());
 
             Ok(ssl)
         }


### PR DESCRIPTION
This significantly simplifies working with them especially in async contexts since the whole HandshakeError/MidHandshakeSslStream mess is avoided.