### PR TITLE
Switch from lazy_static to once_cell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
         default: false
       image:
         type: string
-        default: 1.34.0
+        default: 1.36.0
       minimal_build:
         type: boolean
         default: false
@@ -175,7 +175,7 @@ jobs:
         default: false
       image:
         type: string
-        default: 1.34.0
+        default: 1.36.0
     macos:
       xcode: "12.2.0"
     environment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup update --no-self-update 1.34.0 && rustup default 1.34.0
+        run: rustup update --no-self-update 1.36.0 && rustup default 1.36.0
       - name: Get rust version
         id: rust-version
         run: echo "::set-output name=version::$(rustc --version)"

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -22,8 +22,8 @@ vendored = ['openssl-sys/vendored']
 bitflags = "1.0"
 cfg-if = "1.0"
 foreign-types = "0.3.1"
-lazy_static = "1"
 libc = "0.2"
+once_cell = "1.5.2"
 
 openssl-sys = { version = "0.9.60", path = "../openssl-sys" }
 

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -116,9 +116,8 @@ extern crate bitflags;
 extern crate cfg_if;
 #[macro_use]
 extern crate foreign_types;
-#[macro_use]
-extern crate lazy_static;
 extern crate libc;
+extern crate once_cell;
 extern crate openssl_sys as ffi;
 
 #[cfg(test)]

--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -414,10 +414,10 @@ cfg_if! {
                 GeneralName, X509NameRef, X509Ref, X509StoreContext, X509StoreContextRef,
                 X509VerifyResult,
             };
+            use once_cell::sync::Lazy;
 
-            lazy_static! {
-                pub static ref HOSTNAME_IDX: Index<Ssl, String> = Ssl::new_ex_index().unwrap();
-            }
+            pub static HOSTNAME_IDX: Lazy<Index<Ssl, String>> =
+                Lazy::new(|| Ssl::new_ex_index().unwrap());
 
             pub fn verify_callback(preverify_ok: bool, x509_ctx: &mut X509StoreContextRef) -> bool {
                 if !preverify_ok || x509_ctx.error_depth() != 0 {

--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -430,7 +430,7 @@ cfg_if! {
                 }
 
                 let hostname_idx =
-                    try_get_hostname_idx.expect("failed to initialize hostname index");
+                    try_get_hostname_idx().expect("failed to initialize hostname index");
                 let ok = match (
                     x509_ctx.current_cert(),
                     X509StoreContext::ssl_idx()

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -87,7 +87,7 @@ use ex_data::Index;
 use hash::MessageDigest;
 #[cfg(ossl110)]
 use nid::Nid;
-use once_cell::sync::Lazy;
+use once_cell::sync::{Lazy, OnceCell};
 use pkey::{HasPrivate, PKeyRef, Params, Private};
 use srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
 use ssl::bio::BioMethod;
@@ -515,7 +515,11 @@ impl NameType {
 
 static INDEXES: Lazy<Mutex<HashMap<TypeId, c_int>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 static SSL_INDEXES: Lazy<Mutex<HashMap<TypeId, c_int>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-static SESSION_CTX_INDEX: Lazy<Index<Ssl, SslContext>> = Lazy::new(|| Ssl::new_ex_index().unwrap());
+static SESSION_CTX_INDEX: OnceCell<Index<Ssl, SslContext>> = OnceCell::new();
+
+fn try_get_session_ctx_index() -> Result<&'static Index<Ssl, SslContext>, ErrorStack> {
+    SESSION_CTX_INDEX.get_or_try_init(Ssl::new_ex_index)
+}
 
 unsafe extern "C" fn free_data_box<T>(
     _parent: *mut c_void,
@@ -2389,10 +2393,11 @@ impl Ssl {
     /// [`SSL_new`]: https://www.openssl.org/docs/man1.0.2/ssl/SSL_new.html
     // FIXME should take &SslContextRef
     pub fn new(ctx: &SslContextRef) -> Result<Ssl, ErrorStack> {
+        let session_ctx_index = try_get_session_ctx_index()?;
         unsafe {
             let ptr = cvt_p(ffi::SSL_new(ctx.as_ptr()))?;
             let mut ssl = Ssl::from_ptr(ptr);
-            ssl.set_ex_data(*SESSION_CTX_INDEX, ctx.to_owned());
+            ssl.set_ex_data(*session_ctx_index, ctx.to_owned());
 
             Ok(ssl)
         }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -87,6 +87,7 @@ use ex_data::Index;
 use hash::MessageDigest;
 #[cfg(ossl110)]
 use nid::Nid;
+use once_cell::sync::Lazy;
 use pkey::{HasPrivate, PKeyRef, Params, Private};
 use srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
 use ssl::bio::BioMethod;
@@ -512,11 +513,9 @@ impl NameType {
     }
 }
 
-lazy_static! {
-    static ref INDEXES: Mutex<HashMap<TypeId, c_int>> = Mutex::new(HashMap::new());
-    static ref SSL_INDEXES: Mutex<HashMap<TypeId, c_int>> = Mutex::new(HashMap::new());
-    static ref SESSION_CTX_INDEX: Index<Ssl, SslContext> = Ssl::new_ex_index().unwrap();
-}
+static INDEXES: Lazy<Mutex<HashMap<TypeId, c_int>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static SSL_INDEXES: Lazy<Mutex<HashMap<TypeId, c_int>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static SESSION_CTX_INDEX: Lazy<Index<Ssl, SslContext>> = Lazy::new(|| Ssl::new_ex_index().unwrap());
 
 unsafe extern "C" fn free_data_box<T>(
     _parent: *mut c_void,


### PR DESCRIPTION
This also changes the MSRV from 1.34.0 to 1.36.0.

Closes #1399.

Looks like with both the old and new MSRV, the crate could also switch to edition 2018. Would you like another PR for that?