### PR TITLE
Switch to Rust edition 2018

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -1,4 +1,3 @@
-#[allow(clippy::inconsistent_digit_grouping)]
 pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&'static str> {
     let mut cfgs = vec![];
 

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::inconsistent_digit_grouping)]
+#![allow(clippy::inconsistent_digit_grouping, clippy::unusual_byte_groupings)]
 
 extern crate autocfg;
 extern crate cc;

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/sfackler/rust-openssl"
 readme = "README.md"
 keywords = ["crypto", "tls", "ssl", "dtls"]
 categories = ["cryptography", "api-bindings"]
+edition = "2018"
 
 # these are deprecated and don't do anything anymore
 [features]

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -17,7 +17,7 @@ v102 = []
 v110 = []
 v111 = []
 
-vendored = ['openssl-sys/vendored']
+vendored = ['ffi/vendored']
 
 [dependencies]
 bitflags = "1.0"
@@ -26,7 +26,7 @@ foreign-types = "0.3.1"
 libc = "0.2"
 once_cell = "1.5.2"
 
-openssl-sys = { version = "0.9.60", path = "../openssl-sys" }
+ffi = { package = "openssl-sys", version = "0.9.60", path = "../openssl-sys" }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::inconsistent_digit_grouping)]
+#![allow(clippy::inconsistent_digit_grouping, clippy::unusual_byte_groupings)]
 
 use std::env;
 

--- a/openssl/examples/mk_certs.rs
+++ b/openssl/examples/mk_certs.rs
@@ -1,8 +1,6 @@
 //! A program that generates ca certs, certs verified by the ca, and public
 //! and private keys.
 
-extern crate openssl;
-
 use openssl::asn1::Asn1Time;
 use openssl::bn::{BigNum, MsbOption};
 use openssl::error::ErrorStack;

--- a/openssl/src/aes.rs
+++ b/openssl/src/aes.rs
@@ -59,7 +59,7 @@ use ffi;
 use libc::{c_int, c_uint};
 use std::{mem, ptr};
 
-use symm::Mode;
+use crate::symm::Mode;
 
 /// Provides Error handling for parsing keys.
 #[derive(Debug)]
@@ -240,7 +240,7 @@ mod test {
     use hex::FromHex;
 
     use super::*;
-    use symm::Mode;
+    use crate::symm::Mode;
 
     // From https://www.mgp25.com/AESIGE/
     #[test]

--- a/openssl/src/aes.rs
+++ b/openssl/src/aes.rs
@@ -55,7 +55,6 @@
 //! assert_eq!(&orig_key[..], &key_to_wrap[..]);
 //! ```
 //!
-use ffi;
 use libc::{c_int, c_uint};
 use std::{mem, ptr};
 

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -24,6 +24,7 @@
 //! use openssl::asn1::Asn1Time;
 //! let tomorrow = Asn1Time::days_from_now(1);
 //! ```
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_char, c_int, c_long, time_t};
 #[cfg(ossl102)]

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -35,12 +35,12 @@ use std::ptr;
 use std::slice;
 use std::str;
 
-use bio::MemBio;
-use bn::{BigNum, BigNumRef};
-use error::ErrorStack;
-use nid::Nid;
-use string::OpensslString;
-use {cvt, cvt_p};
+use crate::bio::MemBio;
+use crate::bn::{BigNum, BigNumRef};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::string::OpensslString;
+use crate::{cvt, cvt_p};
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_GENERALIZEDTIME;
@@ -526,7 +526,7 @@ impl Asn1IntegerRef {
     #[allow(missing_docs)]
     #[deprecated(since = "0.10.6", note = "use to_bn instead")]
     pub fn get(&self) -> i64 {
-        unsafe { ::ffi::ASN1_INTEGER_get(self.as_ptr()) as i64 }
+        unsafe { ffi::ASN1_INTEGER_get(self.as_ptr()) as i64 }
     }
 
     /// Converts the integer to a `BigNum`.
@@ -536,7 +536,7 @@ impl Asn1IntegerRef {
     /// [`ASN1_INTEGER_to_BN`]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_INTEGER_get.html
     pub fn to_bn(&self) -> Result<BigNum, ErrorStack> {
         unsafe {
-            cvt_p(::ffi::ASN1_INTEGER_to_BN(self.as_ptr(), ptr::null_mut()))
+            cvt_p(ffi::ASN1_INTEGER_to_BN(self.as_ptr(), ptr::null_mut()))
                 .map(|p| BigNum::from_ptr(p))
         }
     }
@@ -549,7 +549,7 @@ impl Asn1IntegerRef {
     /// [`bn`]: ../bn/struct.BigNumRef.html#method.to_asn1_integer
     /// [`ASN1_INTEGER_set`]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_INTEGER_set.html
     pub fn set(&mut self, value: i32) -> Result<(), ErrorStack> {
-        unsafe { cvt(::ffi::ASN1_INTEGER_set(self.as_ptr(), value as c_long)).map(|_| ()) }
+        unsafe { cvt(ffi::ASN1_INTEGER_set(self.as_ptr(), value as c_long)).map(|_| ()) }
     }
 }
 
@@ -674,8 +674,8 @@ cfg_if! {
 mod tests {
     use super::*;
 
-    use bn::BigNum;
-    use nid::Nid;
+    use crate::bn::BigNum;
+    use crate::nid::Nid;
 
     /// Tests conversion between BigNum and Asn1Integer.
     #[test]

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -65,7 +65,7 @@ foreign_type_and_impl_send_sync! {
 }
 
 impl fmt::Display for Asn1GeneralizedTimeRef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         unsafe {
             let mem_bio = match MemBio::new() {
                 Err(_) => return f.write_str("error"),
@@ -284,7 +284,7 @@ impl<'a> PartialOrd<Asn1Time> for &'a Asn1TimeRef {
 }
 
 impl fmt::Display for Asn1TimeRef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         unsafe {
             let mem_bio = match MemBio::new() {
                 Err(_) => return f.write_str("error"),
@@ -300,7 +300,7 @@ impl fmt::Display for Asn1TimeRef {
 }
 
 impl fmt::Debug for Asn1TimeRef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.to_string())
     }
 }
@@ -481,7 +481,7 @@ impl Asn1StringRef {
 }
 
 impl fmt::Debug for Asn1StringRef {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.as_utf8() {
             Ok(openssl_string) => openssl_string.fmt(fmt),
             Err(_) => fmt.write_str("error"),
@@ -636,7 +636,7 @@ impl Asn1ObjectRef {
 }
 
 impl fmt::Display for Asn1ObjectRef {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         unsafe {
             let mut buf = [0; 80];
             let len = ffi::OBJ_obj2txt(
@@ -654,7 +654,7 @@ impl fmt::Display for Asn1ObjectRef {
 }
 
 impl fmt::Debug for Asn1ObjectRef {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str(self.to_string().as_str())
     }
 }

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -24,7 +24,6 @@
 //! use openssl::asn1::Asn1Time;
 //! let tomorrow = Asn1Time::days_from_now(1);
 //! ```
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_char, c_int, c_long, time_t};
 #[cfg(ossl102)]

--- a/openssl/src/base64.rs
+++ b/openssl/src/base64.rs
@@ -1,6 +1,6 @@
 //! Base64 encoding support.
-use cvt_n;
-use error::ErrorStack;
+use crate::cvt_n;
+use crate::error::ErrorStack;
 use ffi;
 use libc::c_int;
 

--- a/openssl/src/base64.rs
+++ b/openssl/src/base64.rs
@@ -1,7 +1,6 @@
 //! Base64 encoding support.
 use crate::cvt_n;
 use crate::error::ErrorStack;
-use ffi;
 use libc::c_int;
 
 /// Encodes a slice of bytes to a base64 string.

--- a/openssl/src/bio.rs
+++ b/openssl/src/bio.rs
@@ -1,4 +1,3 @@
-use ffi;
 use libc::c_int;
 use std::marker::PhantomData;
 use std::ptr;

--- a/openssl/src/bio.rs
+++ b/openssl/src/bio.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use libc::c_int;
 use std::marker::PhantomData;
 use std::ptr;

--- a/openssl/src/bio.rs
+++ b/openssl/src/bio.rs
@@ -4,8 +4,8 @@ use std::marker::PhantomData;
 use std::ptr;
 use std::slice;
 
-use cvt_p;
-use error::ErrorStack;
+use crate::cvt_p;
+use crate::error::ErrorStack;
 
 pub struct MemBioSlice<'a>(*mut ffi::BIO, PhantomData<&'a [u8]>);
 

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -22,7 +22,6 @@
 //! ```
 //!
 //! [`BIGNUM`]: https://wiki.openssl.org/index.php/Manual:Bn_internal(3)
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::cmp::Ordering;

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -22,6 +22,7 @@
 //! ```
 //!
 //! [`BIGNUM`]: https://wiki.openssl.org/index.php/Manual:Bn_internal(3)
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::cmp::Ordering;

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -30,10 +30,10 @@ use std::ffi::CString;
 use std::ops::{Add, Deref, Div, Mul, Neg, Rem, Shl, Shr, Sub};
 use std::{fmt, ptr};
 
-use asn1::Asn1Integer;
-use error::ErrorStack;
-use string::OpensslString;
-use {cvt, cvt_n, cvt_p};
+use crate::asn1::Asn1Integer;
+use crate::error::ErrorStack;
+use crate::string::OpensslString;
+use crate::{cvt, cvt_n, cvt_p};
 
 cfg_if! {
     if #[cfg(ossl110)] {
@@ -1376,7 +1376,7 @@ impl Neg for BigNum {
 
 #[cfg(test)]
 mod tests {
-    use bn::{BigNum, BigNumContext};
+    use crate::bn::{BigNum, BigNumContext};
 
     #[test]
     fn test_to_from_slice() {

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -1122,7 +1122,7 @@ impl BigNum {
 }
 
 impl fmt::Debug for BigNumRef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.to_dec_str() {
             Ok(s) => f.write_str(&s),
             Err(e) => Err(e.into()),
@@ -1131,7 +1131,7 @@ impl fmt::Debug for BigNumRef {
 }
 
 impl fmt::Debug for BigNum {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.to_dec_str() {
             Ok(s) => f.write_str(&s),
             Err(e) => Err(e.into()),
@@ -1140,7 +1140,7 @@ impl fmt::Debug for BigNum {
 }
 
 impl fmt::Display for BigNumRef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.to_dec_str() {
             Ok(s) => f.write_str(&s),
             Err(e) => Err(e.into()),
@@ -1149,7 +1149,7 @@ impl fmt::Display for BigNumRef {
 }
 
 impl fmt::Display for BigNum {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.to_dec_str() {
             Ok(s) => f.write_str(&s),
             Err(e) => Err(e.into()),

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -6,6 +6,7 @@
 //! Data accepted by this module will be smime type `enveloped-data`.
 
 use foreign_types::{ForeignType, ForeignTypeRef};
+use libc::c_uint;
 use std::ptr;
 
 use crate::bio::{MemBio, MemBioSlice};
@@ -15,7 +16,6 @@ use crate::stack::StackRef;
 use crate::symm::Cipher;
 use crate::x509::{X509Ref, X509};
 use crate::{cvt, cvt_p};
-use libc::c_uint;
 
 bitflags! {
     pub struct CMSOptions : c_uint {

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -5,7 +5,6 @@
 //! generated from a `Vec` of bytes.  This `Vec` follows the smime protocol standards.
 //! Data accepted by this module will be smime type `enveloped-data`.
 
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use std::ptr;
 

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -9,14 +9,14 @@ use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use std::ptr;
 
-use bio::{MemBio, MemBioSlice};
-use error::ErrorStack;
+use crate::bio::{MemBio, MemBioSlice};
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, PKeyRef};
+use crate::stack::StackRef;
+use crate::symm::Cipher;
+use crate::x509::{X509Ref, X509};
+use crate::{cvt, cvt_p};
 use libc::c_uint;
-use pkey::{HasPrivate, PKeyRef};
-use stack::StackRef;
-use symm::Cipher;
-use x509::{X509Ref, X509};
-use {cvt, cvt_p};
 
 bitflags! {
     pub struct CMSOptions : c_uint {
@@ -224,9 +224,9 @@ impl CmsContentInfo {
 #[cfg(test)]
 mod test {
     use super::*;
-    use pkcs12::Pkcs12;
-    use stack::Stack;
-    use x509::X509;
+    use crate::pkcs12::Pkcs12;
+    use crate::stack::Stack;
+    use crate::x509::X509;
 
     #[test]
     fn cms_encrypt_decrypt() {

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -5,6 +5,7 @@
 //! generated from a `Vec` of bytes.  This `Vec` follows the smime protocol standards.
 //! Data accepted by this module will be smime type `enveloped-data`.
 
+use bitflags::bitflags;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_uint;
 use std::ptr;

--- a/openssl/src/conf.rs
+++ b/openssl/src/conf.rs
@@ -1,8 +1,8 @@
 //! Interface for processing OpenSSL configuration files.
 use ffi;
 
-use cvt_p;
-use error::ErrorStack;
+use crate::cvt_p;
+use crate::error::ErrorStack;
 
 pub struct ConfMethod(*mut ffi::CONF_METHOD);
 

--- a/openssl/src/conf.rs
+++ b/openssl/src/conf.rs
@@ -1,5 +1,4 @@
 //! Interface for processing OpenSSL configuration files.
-use ffi;
 
 use crate::cvt_p;
 use crate::error::ErrorStack;

--- a/openssl/src/derive.rs
+++ b/openssl/src/derive.rs
@@ -4,9 +4,9 @@ use foreign_types::ForeignTypeRef;
 use std::marker::PhantomData;
 use std::ptr;
 
-use error::ErrorStack;
-use pkey::{HasPrivate, HasPublic, PKeyRef};
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, HasPublic, PKeyRef};
+use crate::{cvt, cvt_p};
 
 /// A type used to derive a shared secret between two keys.
 pub struct Deriver<'a>(*mut ffi::EVP_PKEY_CTX, PhantomData<&'a ()>);
@@ -97,9 +97,9 @@ impl<'a> Deriver<'a> {
 mod test {
     use super::*;
 
-    use ec::{EcGroup, EcKey};
-    use nid::Nid;
-    use pkey::PKey;
+    use crate::ec::{EcGroup, EcKey};
+    use crate::nid::Nid;
+    use crate::pkey::PKey;
 
     #[test]
     fn derive_without_peer() {

--- a/openssl/src/derive.rs
+++ b/openssl/src/derive.rs
@@ -1,5 +1,4 @@
 //! Shared secret derivation.
-use ffi;
 use foreign_types::ForeignTypeRef;
 use std::marker::PhantomData;
 use std::ptr;

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -1,12 +1,12 @@
-use error::ErrorStack;
+use crate::error::ErrorStack;
 use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use std::mem;
 use std::ptr;
 
-use bn::{BigNum, BigNumRef};
-use pkey::{HasParams, HasPrivate, HasPublic, Params, Private};
-use {cvt, cvt_p};
+use crate::bn::{BigNum, BigNumRef};
+use crate::pkey::{HasParams, HasPrivate, HasPublic, Params, Private};
+use crate::{cvt, cvt_p};
 
 generic_foreign_type_and_impl_send_sync! {
     type CType = ffi::DH;
@@ -297,9 +297,9 @@ cfg_if! {
 
 #[cfg(test)]
 mod tests {
-    use bn::BigNum;
-    use dh::Dh;
-    use ssl::{SslContext, SslMethod};
+    use crate::bn::BigNum;
+    use crate::dh::Dh;
+    use crate::ssl::{SslContext, SslMethod};
 
     #[test]
     #[cfg(ossl102)]

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -1,5 +1,4 @@
 use crate::error::ErrorStack;
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use std::mem;
 use std::ptr;

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -1,9 +1,9 @@
-use crate::error::ErrorStack;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use std::mem;
 use std::ptr;
 
 use crate::bn::{BigNum, BigNumRef};
+use crate::error::ErrorStack;
 use crate::pkey::{HasParams, HasPrivate, HasPublic, Params, Private};
 use crate::{cvt, cvt_p};
 

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use std::mem;
 use std::ptr;

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -5,7 +5,6 @@
 //! using the private key that can be validated with the public key but not be generated
 //! without the private key.
 
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::fmt;

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -288,7 +288,7 @@ impl Dsa<Public> {
 }
 
 impl<T> fmt::Debug for Dsa<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DSA")
     }
 }

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -12,11 +12,11 @@ use std::fmt;
 use std::mem;
 use std::ptr;
 
-use bn::{BigNum, BigNumRef};
-use error::ErrorStack;
-use pkey::{HasParams, HasPrivate, HasPublic, Private, Public};
-use util::ForeignTypeRefExt;
-use {cvt, cvt_p};
+use crate::bn::{BigNum, BigNumRef};
+use crate::error::ErrorStack;
+use crate::pkey::{HasParams, HasPrivate, HasPublic, Private, Public};
+use crate::util::ForeignTypeRefExt;
+use crate::{cvt, cvt_p};
 
 generic_foreign_type_and_impl_send_sync! {
     type CType = ffi::DSA;
@@ -358,10 +358,10 @@ cfg_if! {
 #[cfg(test)]
 mod test {
     use super::*;
-    use bn::BigNumContext;
-    use hash::MessageDigest;
-    use pkey::PKey;
-    use sign::{Signer, Verifier};
+    use crate::bn::BigNumContext;
+    use crate::hash::MessageDigest;
+    use crate::pkey::PKey;
+    use crate::sign::{Signer, Verifier};
 
     #[test]
     pub fn test_generate() {

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -5,6 +5,7 @@
 //! using the private key that can be validated with the public key but not be generated
 //! without the private key.
 
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::fmt;

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -915,7 +915,7 @@ impl<T> Clone for EcKey<T> {
 }
 
 impl<T> fmt::Debug for EcKey<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "EcKey")
     }
 }

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -21,12 +21,12 @@ use libc::c_int;
 use std::fmt;
 use std::ptr;
 
-use bn::{BigNumContextRef, BigNumRef};
-use error::ErrorStack;
-use nid::Nid;
-use pkey::{HasParams, HasPrivate, HasPublic, Params, Private, Public};
-use util::ForeignTypeRefExt;
-use {cvt, cvt_n, cvt_p, init};
+use crate::bn::{BigNumContextRef, BigNumRef};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::pkey::{HasParams, HasPrivate, HasPublic, Params, Private, Public};
+use crate::util::ForeignTypeRefExt;
+use crate::{cvt, cvt_n, cvt_p, init};
 
 /// Compressed or Uncompressed conversion
 ///
@@ -925,8 +925,8 @@ mod test {
     use hex::FromHex;
 
     use super::*;
-    use bn::{BigNum, BigNumContext};
-    use nid::Nid;
+    use crate::bn::{BigNum, BigNumContext};
+    use crate::nid::Nid;
 
     #[test]
     fn key_new_by_curve_name() {

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -15,7 +15,6 @@
 //! [`EcGroup`]: struct.EcGroup.html
 //! [`Nid`]: ../nid/struct.Nid.html
 //! [Eliptic Curve Cryptography]: https://wiki.openssl.org/index.php/Elliptic_Curve_Cryptography
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::fmt;

--- a/openssl/src/ecdsa.rs
+++ b/openssl/src/ecdsa.rs
@@ -1,6 +1,5 @@
 //! Low level Elliptic Curve Digital Signature Algorithm (ECDSA) functions.
 
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::mem;

--- a/openssl/src/ecdsa.rs
+++ b/openssl/src/ecdsa.rs
@@ -1,5 +1,6 @@
 //! Low level Elliptic Curve Digital Signature Algorithm (ECDSA) functions.
 
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::mem;

--- a/openssl/src/ecdsa.rs
+++ b/openssl/src/ecdsa.rs
@@ -6,12 +6,12 @@ use libc::c_int;
 use std::mem;
 use std::ptr;
 
-use bn::{BigNum, BigNumRef};
-use ec::EcKeyRef;
-use error::ErrorStack;
-use pkey::{HasPrivate, HasPublic};
-use util::ForeignTypeRefExt;
-use {cvt_n, cvt_p};
+use crate::bn::{BigNum, BigNumRef};
+use crate::ec::EcKeyRef;
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, HasPublic};
+use crate::util::ForeignTypeRefExt;
+use crate::{cvt_n, cvt_p};
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::ECDSA_SIG;
@@ -175,10 +175,10 @@ cfg_if! {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ec::EcGroup;
-    use ec::EcKey;
-    use nid::Nid;
-    use pkey::{Private, Public};
+    use crate::ec::EcGroup;
+    use crate::ec::EcKey;
+    use crate::nid::Nid;
+    use crate::pkey::{Private, Public};
 
     fn get_public_key(group: &EcGroup, x: &EcKey<Private>) -> Result<EcKey<Public>, ErrorStack> {
         let public_key_point = x.public_key();

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -41,12 +41,12 @@
 //! ```
 use std::{marker::PhantomData, ptr};
 
-use error::ErrorStack;
+use crate::error::ErrorStack;
+use crate::hash::MessageDigest;
+use crate::pkey::{HasPrivate, HasPublic, PKeyRef};
+use crate::rsa::Padding;
+use crate::{cvt, cvt_p};
 use foreign_types::ForeignTypeRef;
-use hash::MessageDigest;
-use pkey::{HasPrivate, HasPublic, PKeyRef};
-use rsa::Padding;
-use {cvt, cvt_p};
 
 /// A type which encrypts data.
 pub struct Encrypter<'a> {
@@ -423,10 +423,10 @@ impl<'a> Decrypter<'a> {
 mod test {
     use hex::FromHex;
 
-    use encrypt::{Decrypter, Encrypter};
-    use hash::MessageDigest;
-    use pkey::PKey;
-    use rsa::{Padding, Rsa};
+    use crate::encrypt::{Decrypter, Encrypter};
+    use crate::hash::MessageDigest;
+    use crate::pkey::PKey;
+    use crate::rsa::{Padding, Rsa};
 
     const INPUT: &str =
         "65794a68624763694f694a53557a49314e694a392e65794a7063334d694f694a71623255694c41304b49434a6c\

--- a/openssl/src/envelope.rs
+++ b/openssl/src/envelope.rs
@@ -3,9 +3,6 @@
 //! # Example
 //!
 //! ```rust
-//!
-//! extern crate openssl;
-//!
 //! use openssl::rsa::Rsa;
 //! use openssl::envelope::Seal;
 //! use openssl::pkey::PKey;

--- a/openssl/src/envelope.rs
+++ b/openssl/src/envelope.rs
@@ -8,20 +8,18 @@
 //! use openssl::pkey::PKey;
 //! use openssl::symm::Cipher;
 //!
-//! fn main() {
-//!     let rsa = Rsa::generate(2048).unwrap();
-//!     let key = PKey::from_rsa(rsa).unwrap();
+//! let rsa = Rsa::generate(2048).unwrap();
+//! let key = PKey::from_rsa(rsa).unwrap();
 //!
-//!     let cipher = Cipher::aes_256_cbc();
-//!     let mut seal = Seal::new(cipher, &[key]).unwrap();
+//! let cipher = Cipher::aes_256_cbc();
+//! let mut seal = Seal::new(cipher, &[key]).unwrap();
 //!
-//!     let secret = b"My secret message";
-//!     let mut encrypted = vec![0; secret.len() + cipher.block_size()];
+//! let secret = b"My secret message";
+//! let mut encrypted = vec![0; secret.len() + cipher.block_size()];
 //!
-//!     let mut enc_len = seal.update(secret, &mut encrypted).unwrap();
-//!     enc_len += seal.finalize(&mut encrypted[enc_len..]).unwrap();
-//!     encrypted.truncate(enc_len);
-//! }
+//! let mut enc_len = seal.update(secret, &mut encrypted).unwrap();
+//! enc_len += seal.finalize(&mut encrypted[enc_len..]).unwrap();
+//! encrypted.truncate(enc_len);
 //! ```
 use crate::error::ErrorStack;
 use crate::pkey::{HasPrivate, HasPublic, PKey, PKeyRef};

--- a/openssl/src/envelope.rs
+++ b/openssl/src/envelope.rs
@@ -26,15 +26,15 @@
 //!     encrypted.truncate(enc_len);
 //! }
 //! ```
-use error::ErrorStack;
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, HasPublic, PKey, PKeyRef};
+use crate::symm::Cipher;
+use crate::{cvt, cvt_p};
 use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
-use pkey::{HasPrivate, HasPublic, PKey, PKeyRef};
 use std::cmp;
 use std::ptr;
-use symm::Cipher;
-use {cvt, cvt_p};
 
 /// Represents an EVP_Seal context.
 pub struct Seal {
@@ -259,8 +259,8 @@ impl Drop for Open {
 #[cfg(test)]
 mod test {
     use super::*;
-    use pkey::PKey;
-    use symm::Cipher;
+    use crate::pkey::PKey;
+    use crate::symm::Cipher;
 
     #[test]
     fn public_encrypt_private_decrypt() {

--- a/openssl/src/envelope.rs
+++ b/openssl/src/envelope.rs
@@ -30,7 +30,6 @@ use crate::error::ErrorStack;
 use crate::pkey::{HasPrivate, HasPublic, PKey, PKeyRef};
 use crate::symm::Cipher;
 use crate::{cvt, cvt_p};
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::cmp;

--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -24,8 +24,6 @@ use std::io;
 use std::ptr;
 use std::str;
 
-use ffi;
-
 /// Collection of [`Error`]s from OpenSSL.
 ///
 /// [`Error`]: struct.Error.html

--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -58,7 +58,7 @@ impl ErrorStack {
 }
 
 impl fmt::Display for ErrorStack {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.0.is_empty() {
             return fmt.write_str("OpenSSL error");
         }
@@ -236,7 +236,7 @@ impl Error {
 }
 
 impl fmt::Debug for Error {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = fmt.debug_struct("Error");
         builder.field("code", &self.code());
         if let Some(library) = self.library() {
@@ -258,7 +258,7 @@ impl fmt::Debug for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "error:{:08X}", self.code())?;
         match self.library() {
             Some(l) => write!(fmt, ":{}", l)?,

--- a/openssl/src/fips.rs
+++ b/openssl/src/fips.rs
@@ -5,7 +5,6 @@
 //! [OpenSSL's documentation]: https://www.openssl.org/docs/fips/UserGuide-2.0.pdf
 use crate::cvt;
 use crate::error::ErrorStack;
-use ffi;
 
 /// Moves the library into or out of the FIPS 140-2 mode of operation.
 ///

--- a/openssl/src/fips.rs
+++ b/openssl/src/fips.rs
@@ -3,8 +3,8 @@
 //! See [OpenSSL's documentation] for details.
 //!
 //! [OpenSSL's documentation]: https://www.openssl.org/docs/fips/UserGuide-2.0.pdf
-use cvt;
-use error::ErrorStack;
+use crate::cvt;
+use crate::error::ErrorStack;
 use ffi;
 
 /// Moves the library into or out of the FIPS 140-2 mode of operation.

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use std::ffi::CString;
 use std::fmt;
 use std::io;

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -390,7 +390,7 @@ impl AsRef<[u8]> for DigestBytes {
 }
 
 impl fmt::Debug for DigestBytes {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, fmt)
     }
 }

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -1,4 +1,3 @@
-use ffi;
 use std::ffi::CString;
 use std::fmt;
 use std::io;

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -6,9 +6,9 @@ use std::io::prelude::*;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
-use error::ErrorStack;
-use nid::Nid;
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::{cvt, cvt_p};
 
 cfg_if! {
     if #[cfg(ossl110)] {

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -111,16 +111,6 @@
 #![doc(html_root_url = "https://docs.rs/openssl/0.10")]
 #![warn(rust_2018_idioms)]
 
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate cfg_if;
-#[macro_use]
-extern crate foreign_types;
-
-#[cfg(test)]
-extern crate hex;
-
 #[doc(inline)]
 pub use ffi::init;
 

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -130,7 +130,7 @@ pub use ffi::init;
 
 use libc::c_int;
 
-use error::ErrorStack;
+use crate::error::ErrorStack;
 
 #[macro_use]
 mod macros;

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -118,8 +118,6 @@ extern crate cfg_if;
 #[macro_use]
 extern crate foreign_types;
 
-extern crate openssl_sys as ffi;
-
 #[cfg(test)]
 extern crate hex;
 

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -109,6 +109,7 @@
 //! ctx.set_ciphersuites("TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256").unwrap();
 //! ```
 #![doc(html_root_url = "https://docs.rs/openssl/0.10")]
+#![warn(rust_2018_idioms)]
 
 #[macro_use]
 extern crate bitflags;
@@ -116,14 +117,11 @@ extern crate bitflags;
 extern crate cfg_if;
 #[macro_use]
 extern crate foreign_types;
-extern crate libc;
-extern crate once_cell;
+
 extern crate openssl_sys as ffi;
 
 #[cfg(test)]
 extern crate hex;
-#[cfg(test)]
-extern crate tempdir;
 
 #[doc(inline)]
 pub use ffi::init;

--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -3,10 +3,10 @@ macro_rules! private_key_from_pem {
         from_pem!($(#[$m])* $n, $t, $f);
 
         $(#[$m2])*
-        pub fn $n2(pem: &[u8], passphrase: &[u8]) -> Result<$t, ::error::ErrorStack> {
+        pub fn $n2(pem: &[u8], passphrase: &[u8]) -> Result<$t, crate::error::ErrorStack> {
             unsafe {
                 ffi::init();
-                let bio = ::bio::MemBioSlice::new(pem)?;
+                let bio = crate::bio::MemBioSlice::new(pem)?;
                 let passphrase = ::std::ffi::CString::new(passphrase).unwrap();
                 cvt_p($f(bio.as_ptr(),
                          ptr::null_mut(),
@@ -17,16 +17,16 @@ macro_rules! private_key_from_pem {
         }
 
         $(#[$m3])*
-        pub fn $n3<F>(pem: &[u8], callback: F) -> Result<$t, ::error::ErrorStack>
-            where F: FnOnce(&mut [u8]) -> Result<usize, ::error::ErrorStack>
+        pub fn $n3<F>(pem: &[u8], callback: F) -> Result<$t, crate::error::ErrorStack>
+            where F: FnOnce(&mut [u8]) -> Result<usize, crate::error::ErrorStack>
         {
             unsafe {
                 ffi::init();
-                let mut cb = ::util::CallbackState::new(callback);
-                let bio = ::bio::MemBioSlice::new(pem)?;
+                let mut cb = crate::util::CallbackState::new(callback);
+                let bio = crate::bio::MemBioSlice::new(pem)?;
                 cvt_p($f(bio.as_ptr(),
                          ptr::null_mut(),
-                         Some(::util::invoke_passwd_cb::<F>),
+                         Some(crate::util::invoke_passwd_cb::<F>),
                          &mut cb as *mut _ as *mut _))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
             }
@@ -37,9 +37,9 @@ macro_rules! private_key_from_pem {
 macro_rules! private_key_to_pem {
     ($(#[$m:meta])* $n:ident, $(#[$m2:meta])* $n2:ident, $f:path) => {
         $(#[$m])*
-        pub fn $n(&self) -> Result<Vec<u8>, ::error::ErrorStack> {
+        pub fn $n(&self) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
-                let bio = ::bio::MemBio::new()?;
+                let bio = crate::bio::MemBio::new()?;
                 cvt($f(bio.as_ptr(),
                         self.as_ptr(),
                         ptr::null(),
@@ -54,11 +54,11 @@ macro_rules! private_key_to_pem {
         $(#[$m2])*
         pub fn $n2(
             &self,
-            cipher: ::symm::Cipher,
+            cipher: crate::symm::Cipher,
             passphrase: &[u8]
-        ) -> Result<Vec<u8>, ::error::ErrorStack> {
+        ) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
-                let bio = ::bio::MemBio::new()?;
+                let bio = crate::bio::MemBio::new()?;
                 assert!(passphrase.len() <= ::libc::c_int::max_value() as usize);
                 cvt($f(bio.as_ptr(),
                         self.as_ptr(),
@@ -76,9 +76,9 @@ macro_rules! private_key_to_pem {
 macro_rules! to_pem {
     ($(#[$m:meta])* $n:ident, $f:path) => {
         $(#[$m])*
-        pub fn $n(&self) -> Result<Vec<u8>, ::error::ErrorStack> {
+        pub fn $n(&self) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
-                let bio = ::bio::MemBio::new()?;
+                let bio = crate::bio::MemBio::new()?;
                 cvt($f(bio.as_ptr(), self.as_ptr()))?;
                 Ok(bio.get_buf().to_owned())
             }
@@ -89,12 +89,12 @@ macro_rules! to_pem {
 macro_rules! to_der {
     ($(#[$m:meta])* $n:ident, $f:path) => {
         $(#[$m])*
-        pub fn $n(&self) -> Result<Vec<u8>, ::error::ErrorStack> {
+        pub fn $n(&self) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
-                let len = ::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
+                let len = crate::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
                                         ptr::null_mut()))?;
                 let mut buf = vec![0; len as usize];
-                ::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
+                crate::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
                               &mut buf.as_mut_ptr()))?;
                 Ok(buf)
             }
@@ -105,11 +105,11 @@ macro_rules! to_der {
 macro_rules! from_der {
     ($(#[$m:meta])* $n:ident, $t:ty, $f:path) => {
         $(#[$m])*
-        pub fn $n(der: &[u8]) -> Result<$t, ::error::ErrorStack> {
+        pub fn $n(der: &[u8]) -> Result<$t, crate::error::ErrorStack> {
             unsafe {
-                ::ffi::init();
+                ffi::init();
                 let len = ::std::cmp::min(der.len(), ::libc::c_long::max_value() as usize) as ::libc::c_long;
-                ::cvt_p($f(::std::ptr::null_mut(), &mut der.as_ptr(), len))
+                crate::cvt_p($f(::std::ptr::null_mut(), &mut der.as_ptr(), len))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
             }
         }
@@ -119,10 +119,10 @@ macro_rules! from_der {
 macro_rules! from_pem {
     ($(#[$m:meta])* $n:ident, $t:ty, $f:path) => {
         $(#[$m])*
-        pub fn $n(pem: &[u8]) -> Result<$t, ::error::ErrorStack> {
+        pub fn $n(pem: &[u8]) -> Result<$t, crate::error::ErrorStack> {
             unsafe {
-                ::init();
-                let bio = ::bio::MemBioSlice::new(pem)?;
+                crate::init();
+                let bio = crate::bio::MemBioSlice::new(pem)?;
                 cvt_p($f(bio.as_ptr(), ::std::ptr::null_mut(), None, ::std::ptr::null_mut()))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
             }

--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -143,7 +143,7 @@ macro_rules! foreign_type_and_impl_send_sync {
         pub struct $borrowed:ident;
     )
         => {
-            foreign_type! {
+            ::foreign_types::foreign_type! {
                 $(#[$impl_attr])*
                 type CType = $ctype;
                 fn drop = $drop;

--- a/openssl/src/memcmp.rs
+++ b/openssl/src/memcmp.rs
@@ -29,7 +29,6 @@
 //! assert!(!eq(&a, &b));
 //! assert!(!eq(&a, &c));
 //! ```
-use ffi;
 use libc::size_t;
 
 /// Returns `true` iff `a` and `b` contain the same bytes.

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -1,5 +1,4 @@
 //! A collection of numerical identifiers for OpenSSL objects.
-use ffi;
 use libc::{c_char, c_int};
 
 use std::ffi::CStr;

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -5,8 +5,8 @@ use libc::{c_char, c_int};
 use std::ffi::CStr;
 use std::str;
 
-use cvt_p;
-use error::ErrorStack;
+use crate::cvt_p;
+use crate::error::ErrorStack;
 
 /// The digest and public-key algorithms associated with a signature.
 pub struct SignatureAlgorithms {

--- a/openssl/src/ocsp.rs
+++ b/openssl/src/ocsp.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use foreign_types::ForeignTypeRef;
 use libc::{c_int, c_long, c_ulong};
 use std::mem;

--- a/openssl/src/ocsp.rs
+++ b/openssl/src/ocsp.rs
@@ -4,14 +4,14 @@ use libc::{c_int, c_long, c_ulong};
 use std::mem;
 use std::ptr;
 
-use asn1::Asn1GeneralizedTimeRef;
-use error::ErrorStack;
-use hash::MessageDigest;
-use stack::StackRef;
-use util::ForeignTypeRefExt;
-use x509::store::X509StoreRef;
-use x509::{X509Ref, X509};
-use {cvt, cvt_p};
+use crate::asn1::Asn1GeneralizedTimeRef;
+use crate::error::ErrorStack;
+use crate::hash::MessageDigest;
+use crate::stack::StackRef;
+use crate::util::ForeignTypeRefExt;
+use crate::x509::store::X509StoreRef;
+use crate::x509::{X509Ref, X509};
+use crate::{cvt, cvt_p};
 
 bitflags! {
     pub struct OcspFlag: c_ulong {

--- a/openssl/src/ocsp.rs
+++ b/openssl/src/ocsp.rs
@@ -1,4 +1,3 @@
-use ffi;
 use foreign_types::ForeignTypeRef;
 use libc::{c_int, c_long, c_ulong};
 use std::mem;

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -1,6 +1,5 @@
 //! PKCS #12 archives.
 
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::ffi::CString;

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -6,13 +6,13 @@ use libc::c_int;
 use std::ffi::CString;
 use std::ptr;
 
-use error::ErrorStack;
-use nid::Nid;
-use pkey::{HasPrivate, PKey, PKeyRef, Private};
-use stack::Stack;
-use util::ForeignTypeExt;
-use x509::{X509Ref, X509};
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::pkey::{HasPrivate, PKey, PKeyRef, Private};
+use crate::stack::Stack;
+use crate::util::ForeignTypeExt;
+use crate::x509::{X509Ref, X509};
+use crate::{cvt, cvt_p};
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::PKCS12;
@@ -197,15 +197,15 @@ impl Pkcs12Builder {
 
 #[cfg(test)]
 mod test {
-    use hash::MessageDigest;
+    use crate::hash::MessageDigest;
     use hex;
 
-    use asn1::Asn1Time;
-    use nid::Nid;
-    use pkey::PKey;
-    use rsa::Rsa;
-    use x509::extension::KeyUsage;
-    use x509::{X509Name, X509};
+    use crate::asn1::Asn1Time;
+    use crate::nid::Nid;
+    use crate::pkey::PKey;
+    use crate::rsa::Rsa;
+    use crate::x509::extension::KeyUsage;
+    use crate::x509::{X509Name, X509};
 
     use super::*;
 

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -197,10 +197,8 @@ impl Pkcs12Builder {
 
 #[cfg(test)]
 mod test {
-    use crate::hash::MessageDigest;
-    use hex;
-
     use crate::asn1::Asn1Time;
+    use crate::hash::MessageDigest;
     use crate::nid::Nid;
     use crate::pkey::PKey;
     use crate::rsa::Rsa;

--- a/openssl/src/pkcs5.rs
+++ b/openssl/src/pkcs5.rs
@@ -2,10 +2,10 @@ use ffi;
 use libc::c_int;
 use std::ptr;
 
-use cvt;
-use error::ErrorStack;
-use hash::MessageDigest;
-use symm::Cipher;
+use crate::cvt;
+use crate::error::ErrorStack;
+use crate::hash::MessageDigest;
+use crate::symm::Cipher;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct KeyIvPair {
@@ -141,8 +141,8 @@ pub fn scrypt(
 
 #[cfg(test)]
 mod tests {
-    use hash::MessageDigest;
-    use symm::Cipher;
+    use crate::hash::MessageDigest;
+    use crate::symm::Cipher;
 
     // Test vectors from
     // https://git.lysator.liu.se/nettle/nettle/blob/nettle_3.1.1_release_20150424/testsuite/pbkdf2-test.c

--- a/openssl/src/pkcs5.rs
+++ b/openssl/src/pkcs5.rs
@@ -1,4 +1,3 @@
-use ffi;
 use libc::c_int;
 use std::ptr;
 

--- a/openssl/src/pkcs5.rs
+++ b/openssl/src/pkcs5.rs
@@ -281,8 +281,6 @@ mod tests {
     #[test]
     #[cfg(any(ossl110))]
     fn scrypt() {
-        use hex;
-
         let pass = "pleaseletmein";
         let salt = "SodiumChloride";
         let expected =

--- a/openssl/src/pkcs7.rs
+++ b/openssl/src/pkcs7.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use foreign_types::ForeignTypeRef;
 use libc::c_int;
 use std::ptr;

--- a/openssl/src/pkcs7.rs
+++ b/openssl/src/pkcs7.rs
@@ -1,15 +1,15 @@
-use bio::{MemBio, MemBioSlice};
-use error::ErrorStack;
+use crate::bio::{MemBio, MemBioSlice};
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, PKeyRef};
+use crate::stack::StackRef;
+use crate::symm::Cipher;
+use crate::x509::store::X509StoreRef;
+use crate::x509::{X509Ref, X509};
+use crate::{cvt, cvt_p};
 use ffi;
 use foreign_types::ForeignTypeRef;
 use libc::c_int;
-use pkey::{HasPrivate, PKeyRef};
-use stack::StackRef;
 use std::ptr;
-use symm::Cipher;
-use x509::store::X509StoreRef;
-use x509::{X509Ref, X509};
-use {cvt, cvt_p};
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::PKCS7;
@@ -284,12 +284,12 @@ impl Pkcs7Ref {
 
 #[cfg(test)]
 mod tests {
-    use pkcs7::{Pkcs7, Pkcs7Flags};
-    use pkey::PKey;
-    use stack::Stack;
-    use symm::Cipher;
-    use x509::store::X509StoreBuilder;
-    use x509::X509;
+    use crate::pkcs7::{Pkcs7, Pkcs7Flags};
+    use crate::pkey::PKey;
+    use crate::stack::Stack;
+    use crate::symm::Cipher;
+    use crate::x509::store::X509StoreBuilder;
+    use crate::x509::X509;
 
     #[test]
     fn encrypt_decrypt_test() {

--- a/openssl/src/pkcs7.rs
+++ b/openssl/src/pkcs7.rs
@@ -1,3 +1,7 @@
+use foreign_types::ForeignTypeRef;
+use libc::c_int;
+use std::ptr;
+
 use crate::bio::{MemBio, MemBioSlice};
 use crate::error::ErrorStack;
 use crate::pkey::{HasPrivate, PKeyRef};
@@ -6,9 +10,6 @@ use crate::symm::Cipher;
 use crate::x509::store::X509StoreRef;
 use crate::x509::{X509Ref, X509};
 use crate::{cvt, cvt_p};
-use foreign_types::ForeignTypeRef;
-use libc::c_int;
-use std::ptr;
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::PKCS7;

--- a/openssl/src/pkcs7.rs
+++ b/openssl/src/pkcs7.rs
@@ -6,7 +6,6 @@ use crate::symm::Cipher;
 use crate::x509::store::X509StoreRef;
 use crate::x509::{X509Ref, X509};
 use crate::{cvt, cvt_p};
-use ffi;
 use foreign_types::ForeignTypeRef;
 use libc::c_int;
 use std::ptr;

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -45,7 +45,6 @@
 //! }
 //! ```
 
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_long};
 use std::ffi::CString;

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -40,6 +40,7 @@
 //! println!("{:?}", str::from_utf8(pub_key.as_slice()).unwrap());
 //! ```
 
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_long};
 use std::ffi::CString;

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -33,13 +33,11 @@
 //! use openssl::pkey::PKey;
 //! use std::str;
 //!
-//! fn main() {
-//!     let rsa = Rsa::generate(2048).unwrap();
-//!     let pkey = PKey::from_rsa(rsa).unwrap();
+//! let rsa = Rsa::generate(2048).unwrap();
+//! let pkey = PKey::from_rsa(rsa).unwrap();
 //!
-//!     let pub_key: Vec<u8> = pkey.public_key_to_pem().unwrap();
-//!     println!("{:?}", str::from_utf8(pub_key.as_slice()).unwrap());
-//! }
+//! let pub_key: Vec<u8> = pkey.public_key_to_pem().unwrap();
+//! println!("{:?}", str::from_utf8(pub_key.as_slice()).unwrap());
 //! ```
 
 use foreign_types::{ForeignType, ForeignTypeRef};

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -53,16 +53,16 @@ use std::fmt;
 use std::mem;
 use std::ptr;
 
-use bio::MemBioSlice;
-use dh::Dh;
-use dsa::Dsa;
-use ec::EcKey;
-use error::ErrorStack;
-use rsa::Rsa;
+use crate::bio::MemBioSlice;
+use crate::dh::Dh;
+use crate::dsa::Dsa;
+use crate::ec::EcKey;
+use crate::error::ErrorStack;
+use crate::rsa::Rsa;
 #[cfg(ossl110)]
-use symm::Cipher;
-use util::{invoke_passwd_cb, CallbackState};
-use {cvt, cvt_p};
+use crate::symm::Cipher;
+use crate::util::{invoke_passwd_cb, CallbackState};
+use crate::{cvt, cvt_p};
 
 /// A tag type indicating that a key only has parameters.
 pub enum Params {}
@@ -678,12 +678,12 @@ cfg_if! {
 
 #[cfg(test)]
 mod tests {
-    use dh::Dh;
-    use dsa::Dsa;
-    use ec::EcKey;
-    use nid::Nid;
-    use rsa::Rsa;
-    use symm::Cipher;
+    use crate::dh::Dh;
+    use crate::dsa::Dsa;
+    use crate::ec::EcKey;
+    use crate::nid::Nid;
+    use crate::rsa::Rsa;
+    use crate::symm::Cipher;
 
     use super::*;
 

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -292,7 +292,7 @@ where
 }
 
 impl<T> fmt::Debug for PKey<T> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let alg = match self.id() {
             Id::RSA => "RSA",
             Id::HMAC => "HMAC",

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -29,9 +29,6 @@
 //! Generate a 2048-bit RSA public/private key pair and print the public key.
 //!
 //! ```rust
-//!
-//! extern crate openssl;
-//!
 //! use openssl::rsa::Rsa;
 //! use openssl::pkey::PKey;
 //! use std::str;

--- a/openssl/src/rand.rs
+++ b/openssl/src/rand.rs
@@ -13,8 +13,8 @@
 use ffi;
 use libc::c_int;
 
-use cvt;
-use error::ErrorStack;
+use crate::cvt;
+use crate::error::ErrorStack;
 
 /// Fill buffer with cryptographically strong pseudo-random bytes.
 ///

--- a/openssl/src/rand.rs
+++ b/openssl/src/rand.rs
@@ -10,7 +10,6 @@
 //! let mut buf = [0; 256];
 //! rand_bytes(&mut buf).unwrap();
 //! ```
-use ffi;
 use libc::c_int;
 
 use crate::cvt;

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -18,12 +18,10 @@
 //! ```rust
 //! use openssl::rsa::{Rsa, Padding};
 //!
-//! fn main() {
-//!     let rsa = Rsa::generate(2048).unwrap();
-//!     let data = b"foobar";
-//!     let mut buf = vec![0; rsa.size() as usize];
-//!     let encrypted_len = rsa.public_encrypt(data, &mut buf, Padding::PKCS1).unwrap();
-//! }
+//! let rsa = Rsa::generate(2048).unwrap();
+//! let data = b"foobar";
+//! let mut buf = vec![0; rsa.size() as usize];
+//! let encrypted_len = rsa.public_encrypt(data, &mut buf, Padding::PKCS1).unwrap();
 //! ```
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -651,7 +651,7 @@ impl Rsa<Private> {
 }
 
 impl<T> fmt::Debug for Rsa<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Rsa")
     }
 }

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -28,7 +28,6 @@
 //!     let encrypted_len = rsa.public_encrypt(data, &mut buf, Padding::PKCS1).unwrap();
 //! }
 //! ```
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::fmt;

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -35,11 +35,11 @@ use std::fmt;
 use std::mem;
 use std::ptr;
 
-use bn::{BigNum, BigNumRef};
-use error::ErrorStack;
-use pkey::{HasPrivate, HasPublic, Private, Public};
-use util::ForeignTypeRefExt;
-use {cvt, cvt_n, cvt_p};
+use crate::bn::{BigNum, BigNumRef};
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, HasPublic, Private, Public};
+use crate::util::ForeignTypeRefExt;
+use crate::{cvt, cvt_n, cvt_p};
 
 /// Type of encryption padding to use.
 ///
@@ -754,7 +754,7 @@ cfg_if! {
 
 #[cfg(test)]
 mod test {
-    use symm::Cipher;
+    use crate::symm::Cipher;
 
     use super::*;
 

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -16,9 +16,6 @@
 //! Generate a 2048-bit RSA key pair and use the public key to encrypt some data.
 //!
 //! ```rust
-//!
-//! extern crate openssl;
-//!
 //! use openssl::rsa::{Rsa, Padding};
 //!
 //! fn main() {

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -23,6 +23,7 @@
 //! let mut buf = vec![0; rsa.size() as usize];
 //! let encrypted_len = rsa.public_encrypt(data, &mut buf, Padding::PKCS1).unwrap();
 //! ```
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::fmt;

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -341,8 +341,6 @@ impl Sha512 {
 
 #[cfg(test)]
 mod test {
-    use hex;
-
     use super::*;
 
     #[test]

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -45,7 +45,6 @@
 //!     println!("Hash = {}", hex::encode(hash));
 //! }
 //! ```
-use ffi;
 use libc::c_void;
 use std::mem;
 

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -16,15 +16,13 @@
 //! ```rust
 //! use openssl::sha;
 //!
-//! fn main() {
-//!     let mut hasher = sha::Sha256::new();
+//! let mut hasher = sha::Sha256::new();
 //!
-//!     hasher.update(b"Hello, ");
-//!     hasher.update(b"world");
+//! hasher.update(b"Hello, ");
+//! hasher.update(b"world");
 //!
-//!     let hash = hasher.finish();
-//!     println!("Hashed \"Hello, world\" to {}", hex::encode(hash));
-//! }
+//! let hash = hasher.finish();
+//! println!("Hashed \"Hello, world\" to {}", hex::encode(hash));
 //! ```
 //!
 //! On the other hand, if you already have access to all of the data you woud like to hash, you
@@ -34,10 +32,8 @@
 //! ```rust
 //! use openssl::sha::sha256;
 //!
-//! fn main() {
-//!     let hash = sha256(b"your data or message");
-//!     println!("Hash = {}", hex::encode(hash));
-//! }
+//! let hash = sha256(b"your data or message");
+//! println!("Hash = {}", hex::encode(hash));
 //! ```
 use libc::c_void;
 use std::mem;

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -14,9 +14,6 @@
 //! you can create a hasher that you can repeatedly update to add bytes to.
 //!
 //! ```rust
-//! extern crate openssl;
-//! extern crate hex;
-//!
 //! use openssl::sha;
 //!
 //! fn main() {
@@ -35,9 +32,6 @@
 //! to the algorithm you want to use.
 //!
 //! ```rust
-//! extern crate openssl;
-//! extern crate hex;
-//!
 //! use openssl::sha::sha256;
 //!
 //! fn main() {

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -61,6 +61,7 @@
 //! # let target = hmac.clone();
 //! assert!(memcmp::eq(&hmac, &target));
 //! ```
+use cfg_if::cfg_if;
 use foreign_types::ForeignTypeRef;
 use libc::c_int;
 use std::io::{self, Write};

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -68,11 +68,11 @@ use std::io::{self, Write};
 use std::marker::PhantomData;
 use std::ptr;
 
-use error::ErrorStack;
-use hash::MessageDigest;
-use pkey::{HasPrivate, HasPublic, PKeyRef};
-use rsa::Padding;
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::hash::MessageDigest;
+use crate::pkey::{HasPrivate, HasPublic, PKeyRef};
+use crate::rsa::Padding;
+use crate::{cvt, cvt_p};
 
 cfg_if! {
     if #[cfg(ossl110)] {
@@ -639,12 +639,12 @@ mod test {
     use hex::{self, FromHex};
     use std::iter;
 
-    use ec::{EcGroup, EcKey};
-    use hash::MessageDigest;
-    use nid::Nid;
-    use pkey::PKey;
-    use rsa::{Padding, Rsa};
-    use sign::{RsaPssSaltlen, Signer, Verifier};
+    use crate::ec::{EcGroup, EcKey};
+    use crate::hash::MessageDigest;
+    use crate::nid::Nid;
+    use crate::pkey::PKey;
+    use crate::rsa::{Padding, Rsa};
+    use crate::sign::{RsaPssSaltlen, Signer, Verifier};
 
     const INPUT: &str =
         "65794a68624763694f694a53557a49314e694a392e65794a7063334d694f694a71623255694c41304b49434a6c\
@@ -802,7 +802,7 @@ mod test {
     #[test]
     #[cfg(ossl110)]
     fn test_cmac() {
-        let cipher = ::symm::Cipher::aes_128_cbc();
+        let cipher = crate::symm::Cipher::aes_128_cbc();
         let key = Vec::from_hex("9294727a3638bb1c13f48ef8158bfc9d").unwrap();
         let pkey = PKey::cmac(&cipher, &key).unwrap();
         let mut signer = Signer::new_without_digest(&pkey).unwrap();

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -61,7 +61,6 @@
 //! # let target = hmac.clone();
 //! assert!(memcmp::eq(&hmac, &target));
 //! ```
-use ffi;
 use foreign_types::ForeignTypeRef;
 use libc::c_int;
 use std::io::{self, Write};

--- a/openssl/src/srtp.rs
+++ b/openssl/src/srtp.rs
@@ -1,7 +1,7 @@
+use crate::stack::Stackable;
 use ffi;
 use foreign_types::ForeignTypeRef;
 use libc::c_ulong;
-use stack::Stackable;
 use std::ffi::CStr;
 use std::str;
 

--- a/openssl/src/srtp.rs
+++ b/openssl/src/srtp.rs
@@ -1,5 +1,4 @@
 use crate::stack::Stackable;
-use ffi;
 use foreign_types::ForeignTypeRef;
 use libc::c_ulong;
 use std::ffi::CStr;

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -10,8 +10,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 use std::slice;
 
-use cvt_p;
-use error::ErrorStack;
+use crate::cvt_p;
+use crate::error::ErrorStack;
 
 pub struct StreamState<S> {
     pub stream: S,
@@ -191,7 +191,7 @@ unsafe extern "C" fn destroy<S>(bio: *mut BIO) -> c_int {
 cfg_if! {
     if #[cfg(any(ossl110, libressl273))] {
         use ffi::{BIO_get_data, BIO_set_data, BIO_set_flags, BIO_set_init};
-        use cvt;
+        use crate::cvt;
 
         #[allow(bad_style)]
         unsafe fn BIO_set_num(_bio: *mut ffi::BIO, _num: c_int) {}

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use ffi::{
     self, BIO_clear_retry_flags, BIO_new, BIO_set_retry_read, BIO_set_retry_write, BIO,
     BIO_CTRL_DGRAM_QUERY_MTU, BIO_CTRL_FLUSH,

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -1,4 +1,3 @@
-use ffi;
 use foreign_types::ForeignType;
 use foreign_types::ForeignTypeRef;
 #[cfg(any(ossl111, not(osslconf = "OPENSSL_NO_PSK")))]

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use foreign_types::ForeignType;
 use foreign_types::ForeignTypeRef;
 #[cfg(any(ossl111, not(osslconf = "OPENSSL_NO_PSK")))]

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -15,23 +15,23 @@ use std::slice;
 use std::str;
 use std::sync::Arc;
 
-use dh::Dh;
+use crate::dh::Dh;
 #[cfg(all(ossl101, not(ossl110)))]
-use ec::EcKey;
-use error::ErrorStack;
-use pkey::Params;
+use crate::ec::EcKey;
+use crate::error::ErrorStack;
+use crate::pkey::Params;
 #[cfg(any(ossl102, libressl261))]
-use ssl::AlpnError;
-use ssl::{
+use crate::ssl::AlpnError;
+use crate::ssl::{
     try_get_session_ctx_index, SniError, Ssl, SslAlert, SslContext, SslContextRef, SslRef,
     SslSession, SslSessionRef,
 };
 #[cfg(ossl111)]
-use ssl::{ClientHelloResponse, ExtensionContext};
-use util::ForeignTypeRefExt;
+use crate::ssl::{ClientHelloResponse, ExtensionContext};
+use crate::util::ForeignTypeRefExt;
 #[cfg(ossl111)]
-use x509::X509Ref;
-use x509::{X509StoreContext, X509StoreContextRef};
+use crate::x509::X509Ref;
+use crate::x509::{X509StoreContext, X509StoreContextRef};
 
 pub extern "C" fn raw_verify<F>(preverify_ok: c_int, x509_ctx: *mut ffi::X509_STORE_CTX) -> c_int
 where

--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -21,7 +21,7 @@ ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
 -----END DH PARAMETERS-----
 ";
 
-#[allow(clippy::inconsistent_digit_grouping)]
+#[allow(clippy::inconsistent_digit_grouping, clippy::unusual_byte_groupings)]
 fn ctx(method: SslMethod) -> Result<SslContextBuilder, ErrorStack> {
     let mut ctx = SslContextBuilder::new(method)?;
 

--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -1,13 +1,13 @@
 use std::io::{Read, Write};
 use std::ops::{Deref, DerefMut};
 
-use dh::Dh;
-use error::ErrorStack;
-use ssl::{
+use crate::dh::Dh;
+use crate::error::ErrorStack;
+use crate::ssl::{
     HandshakeError, Ssl, SslContext, SslContextBuilder, SslContextRef, SslMethod, SslMode,
     SslOptions, SslRef, SslStream, SslVerifyMode,
 };
-use version;
+use crate::version;
 
 const FFDHE_2048: &str = "
 -----BEGIN DH PARAMETERS-----
@@ -366,8 +366,8 @@ cfg_if! {
         }
     } else {
         fn setup_curves(ctx: &mut SslContextBuilder) -> Result<(), ErrorStack> {
-            use ec::EcKey;
-            use nid::Nid;
+            use crate::ec::EcKey;
+            use crate::nid::Nid;
 
             let curve = EcKey::from_curve_name(Nid::X9_62_PRIME256V1)?;
             ctx.set_tmp_ecdh(&curve)
@@ -382,7 +382,7 @@ cfg_if! {
         }
 
         fn setup_verify_hostname(ssl: &mut SslRef, domain: &str) -> Result<(), ErrorStack> {
-            use x509::verify::X509CheckFlags;
+            use crate::x509::verify::X509CheckFlags;
 
             let param = ssl.param_mut();
             param.set_hostflags(X509CheckFlags::NO_PARTIAL_WILDCARDS);
@@ -406,17 +406,17 @@ cfg_if! {
         mod verify {
             use std::net::IpAddr;
             use std::str;
+            use once_cell::sync::OnceCell;
 
-            use error::ErrorStack;
-            use ex_data::Index;
-            use nid::Nid;
-            use ssl::Ssl;
-            use stack::Stack;
-            use x509::{
+            use crate::error::ErrorStack;
+            use crate::ex_data::Index;
+            use crate::nid::Nid;
+            use crate::ssl::Ssl;
+            use crate::stack::Stack;
+            use crate::x509::{
                 GeneralName, X509NameRef, X509Ref, X509StoreContext, X509StoreContextRef,
                 X509VerifyResult,
             };
-            use once_cell::sync::OnceCell;
 
             static HOSTNAME_IDX: OnceCell<Index<Ssl, String>> = OnceCell::new();
 
@@ -565,7 +565,7 @@ cfg_if! {
 
             #[test]
             fn test_dns_match() {
-                use ssl::connector::verify::matches_dns;
+                use crate::ssl::connector::verify::matches_dns;
                 assert!(matches_dns("website.tld", "website.tld")); // A name should match itself.
                 assert!(matches_dns("website.tld", "wEbSiTe.tLd")); // DNS name matching ignores case of hostname.
                 assert!(matches_dns("wEbSiTe.TlD", "website.tld")); // DNS name matching ignores case of subject.

--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use std::io::{Read, Write};
 use std::ops::{Deref, DerefMut};
 

--- a/openssl/src/ssl/error.rs
+++ b/openssl/src/ssl/error.rs
@@ -5,9 +5,9 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::io;
 
-use error::ErrorStack;
-use ssl::MidHandshakeSslStream;
-use x509::X509VerifyResult;
+use crate::error::ErrorStack;
+use crate::ssl::MidHandshakeSslStream;
+use crate::x509::X509VerifyResult;
 
 /// An error code returned from SSL functions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/openssl/src/ssl/error.rs
+++ b/openssl/src/ssl/error.rs
@@ -99,7 +99,7 @@ impl From<ErrorStack> for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.code {
             ErrorCode::ZERO_RETURN => fmt.write_str("the SSL session has been shut down"),
             ErrorCode::WANT_READ => match self.io_error() {
@@ -157,7 +157,7 @@ impl<S: fmt::Debug> StdError for HandshakeError<S> {
 }
 
 impl<S: fmt::Debug> fmt::Display for HandshakeError<S> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             HandshakeError::SetupFailure(ref e) => write!(f, "stream setup failed: {}", e)?,
             HandshakeError::Failure(ref s) => {

--- a/openssl/src/ssl/error.rs
+++ b/openssl/src/ssl/error.rs
@@ -1,4 +1,3 @@
-use ffi;
 use libc::c_int;
 use std::error;
 use std::error::Error as StdError;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -57,7 +57,6 @@
 //!     }
 //! }
 //! ```
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 use once_cell::sync::{Lazy, OnceCell};

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -57,6 +57,8 @@
 //!     }
 //! }
 //! ```
+use bitflags::bitflags;
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 use once_cell::sync::{Lazy, OnceCell};

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1843,7 +1843,7 @@ impl ToOwned for SslContextRef {
 
 // TODO: add useful info here
 impl fmt::Debug for SslContext {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "SslContext")
     }
 }
@@ -2346,7 +2346,7 @@ foreign_type_and_impl_send_sync! {
 }
 
 impl fmt::Debug for Ssl {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, fmt)
     }
 }
@@ -2441,7 +2441,7 @@ impl Ssl {
 }
 
 impl fmt::Debug for SslRef {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Ssl")
             .field("state", &self.state_string_long())
             .field("verify_result", &self.verify_result())
@@ -3469,7 +3469,7 @@ impl<S> fmt::Debug for SslStream<S>
 where
     S: fmt::Debug,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("SslStream")
             .field("stream", &self.get_ref())
             .field("ssl", &self.ssl())

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -60,6 +60,7 @@
 use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
+use once_cell::sync::{Lazy, OnceCell};
 use std::any::TypeId;
 use std::cmp;
 use std::collections::HashMap;
@@ -77,34 +78,33 @@ use std::slice;
 use std::str;
 use std::sync::{Arc, Mutex};
 
-use dh::{Dh, DhRef};
+use crate::dh::{Dh, DhRef};
 #[cfg(all(ossl101, not(ossl110)))]
-use ec::EcKey;
-use ec::EcKeyRef;
-use error::ErrorStack;
-use ex_data::Index;
+use crate::ec::EcKey;
+use crate::ec::EcKeyRef;
+use crate::error::ErrorStack;
+use crate::ex_data::Index;
 #[cfg(ossl111)]
-use hash::MessageDigest;
+use crate::hash::MessageDigest;
 #[cfg(ossl110)]
-use nid::Nid;
-use once_cell::sync::{Lazy, OnceCell};
-use pkey::{HasPrivate, PKeyRef, Params, Private};
-use srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
-use ssl::bio::BioMethod;
-use ssl::callbacks::*;
-use ssl::error::InnerError;
-use stack::{Stack, StackRef};
-use util::{ForeignTypeExt, ForeignTypeRefExt};
-use x509::store::{X509Store, X509StoreBuilderRef, X509StoreRef};
+use crate::nid::Nid;
+use crate::pkey::{HasPrivate, PKeyRef, Params, Private};
+use crate::srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
+use crate::ssl::bio::BioMethod;
+use crate::ssl::callbacks::*;
+use crate::ssl::error::InnerError;
+use crate::stack::{Stack, StackRef};
+use crate::util::{ForeignTypeExt, ForeignTypeRefExt};
+use crate::x509::store::{X509Store, X509StoreBuilderRef, X509StoreRef};
 #[cfg(any(ossl102, libressl261))]
-use x509::verify::X509VerifyParamRef;
-use x509::{X509Name, X509Ref, X509StoreContextRef, X509VerifyResult, X509};
-use {cvt, cvt_n, cvt_p, init};
+use crate::x509::verify::X509VerifyParamRef;
+use crate::x509::{X509Name, X509Ref, X509StoreContextRef, X509VerifyResult, X509};
+use crate::{cvt, cvt_n, cvt_p, init};
 
-pub use ssl::connector::{
+pub use crate::ssl::connector::{
     ConnectConfiguration, SslAcceptor, SslAcceptorBuilder, SslConnector, SslConnectorBuilder,
 };
-pub use ssl::error::{Error, ErrorCode, HandshakeError};
+pub use crate::ssl::error::{Error, ErrorCode, HandshakeError};
 
 mod bio;
 mod callbacks;

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1,6 +1,5 @@
 #![allow(unused_imports)]
 
-use hex;
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
@@ -1196,7 +1195,7 @@ fn stateless() {
             self.incoming.get_mut().extend_from_slice(data);
         }
 
-        pub fn take_outgoing(&mut self) -> Outgoing {
+        pub fn take_outgoing(&mut self) -> Outgoing<'_> {
             Outgoing(&mut self.outgoing)
         }
     }

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -16,28 +16,28 @@ use std::thread;
 use std::time::Duration;
 use tempdir::TempDir;
 
-use dh::Dh;
-use error::ErrorStack;
-use hash::MessageDigest;
-use ocsp::{OcspResponse, OcspResponseStatus};
-use pkey::PKey;
-use srtp::SrtpProfileId;
-use ssl;
-use ssl::test::server::Server;
+use crate::dh::Dh;
+use crate::error::ErrorStack;
+use crate::hash::MessageDigest;
+use crate::ocsp::{OcspResponse, OcspResponseStatus};
+use crate::pkey::PKey;
+use crate::srtp::SrtpProfileId;
+use crate::ssl;
+use crate::ssl::test::server::Server;
 #[cfg(any(ossl110, ossl111, libressl261))]
-use ssl::SslVersion;
+use crate::ssl::SslVersion;
 #[cfg(ossl111)]
-use ssl::{ClientHelloResponse, ExtensionContext};
-use ssl::{
+use crate::ssl::{ClientHelloResponse, ExtensionContext};
+use crate::ssl::{
     Error, HandshakeError, MidHandshakeSslStream, ShutdownResult, ShutdownState, Ssl, SslAcceptor,
     SslAcceptorBuilder, SslConnector, SslContext, SslContextBuilder, SslFiletype, SslMethod,
     SslOptions, SslSessionCacheMode, SslStream, SslVerifyMode, StatusType,
 };
 #[cfg(ossl102)]
-use x509::store::X509StoreBuilder;
+use crate::x509::store::X509StoreBuilder;
 #[cfg(ossl102)]
-use x509::verify::X509CheckFlags;
-use x509::{X509Name, X509StoreContext, X509VerifyResult, X509};
+use crate::x509::verify::X509CheckFlags;
+use crate::x509::{X509Name, X509StoreContext, X509VerifyResult, X509};
 
 mod server;
 
@@ -868,8 +868,8 @@ fn tmp_dh_callback() {
 #[test]
 #[cfg(all(ossl101, not(ossl110)))]
 fn tmp_ecdh_callback() {
-    use ec::EcKey;
-    use nid::Nid;
+    use crate::ec::EcKey;
+    use crate::nid::Nid;
 
     static CALLED_BACK: AtomicBool = AtomicBool::new(false);
 
@@ -917,8 +917,8 @@ fn tmp_dh_callback_ssl() {
 #[test]
 #[cfg(all(ossl101, not(ossl110)))]
 fn tmp_ecdh_callback_ssl() {
-    use ec::EcKey;
-    use nid::Nid;
+    use crate::ec::EcKey;
+    use crate::nid::Nid;
 
     static CALLED_BACK: AtomicBool = AtomicBool::new(false);
 

--- a/openssl/src/ssl/test/server.rs
+++ b/openssl/src/ssl/test/server.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::thread::{self, JoinHandle};
 
-use ssl::{Ssl, SslContext, SslContextBuilder, SslFiletype, SslMethod, SslRef, SslStream};
+use crate::ssl::{Ssl, SslContext, SslContextBuilder, SslFiletype, SslMethod, SslRef, SslStream};
 
 pub struct Server {
     handle: Option<JoinHandle<()>>,

--- a/openssl/src/stack.rs
+++ b/openssl/src/stack.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::c_int;
 use std::borrow::Borrow;

--- a/openssl/src/stack.rs
+++ b/openssl/src/stack.rs
@@ -50,7 +50,7 @@ where
     T: Stackable,
     T::Ref: fmt::Debug,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_list().entries(self).finish()
     }
 }
@@ -199,14 +199,14 @@ impl<T: Stackable> StackRef<T> {
         self.len() == 0
     }
 
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             stack: self,
             idxs: 0..self.len() as c_int,
         }
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<T> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         IterMut {
             idxs: 0..self.len() as c_int,
             stack: self,
@@ -310,10 +310,7 @@ impl<'a, T: Stackable> iter::IntoIterator for &'a mut Stack<T> {
 }
 
 /// An iterator over the stack's contents.
-pub struct Iter<'a, T: Stackable>
-where
-    T: 'a,
-{
+pub struct Iter<'a, T: Stackable> {
     stack: &'a StackRef<T>,
     idxs: Range<c_int>,
 }
@@ -347,7 +344,7 @@ impl<'a, T: Stackable> DoubleEndedIterator for Iter<'a, T> {
 impl<'a, T: Stackable> ExactSizeIterator for Iter<'a, T> {}
 
 /// A mutable iterator over the stack's contents.
-pub struct IterMut<'a, T: Stackable + 'a> {
+pub struct IterMut<'a, T: Stackable> {
     stack: &'a mut StackRef<T>,
     idxs: Range<c_int>,
 }

--- a/openssl/src/stack.rs
+++ b/openssl/src/stack.rs
@@ -9,9 +9,9 @@ use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 
-use error::ErrorStack;
-use util::ForeignTypeExt;
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::util::ForeignTypeExt;
+use crate::{cvt, cvt_p};
 
 cfg_if! {
     if #[cfg(ossl110)] {

--- a/openssl/src/stack.rs
+++ b/openssl/src/stack.rs
@@ -1,4 +1,3 @@
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::c_int;
 use std::borrow::Borrow;

--- a/openssl/src/string.rs
+++ b/openssl/src/string.rs
@@ -18,13 +18,13 @@ foreign_type_and_impl_send_sync! {
 }
 
 impl fmt::Display for OpensslString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 
 impl fmt::Debug for OpensslString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
@@ -69,13 +69,13 @@ impl AsRef<[u8]> for OpensslStringRef {
 }
 
 impl fmt::Display for OpensslStringRef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 
 impl fmt::Debug for OpensslStringRef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }

--- a/openssl/src/string.rs
+++ b/openssl/src/string.rs
@@ -1,4 +1,3 @@
-use ffi;
 use foreign_types::ForeignTypeRef;
 use libc::{c_char, c_void};
 use std::convert::AsRef;

--- a/openssl/src/string.rs
+++ b/openssl/src/string.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::ops::Deref;
 use std::str;
 
-use stack::Stackable;
+use crate::stack::Stackable;
 
 foreign_type_and_impl_send_sync! {
     type CType = c_char;
@@ -87,7 +87,7 @@ unsafe fn free(buf: *mut c_char) {
 
 #[cfg(ossl110)]
 unsafe fn free(buf: *mut c_char) {
-    ::ffi::CRYPTO_free(
+    ffi::CRYPTO_free(
         buf as *mut c_void,
         concat!(file!(), "\0").as_ptr() as *const c_char,
         line!() as ::libc::c_int,

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -52,7 +52,6 @@
 //! println!("Decrypted: '{}'", output_string);
 //! ```
 
-use ffi;
 use libc::c_int;
 use std::cmp;
 use std::ptr;

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -52,6 +52,7 @@
 //! println!("Decrypted: '{}'", output_string);
 //! ```
 
+use cfg_if::cfg_if;
 use libc::c_int;
 use std::cmp;
 use std::ptr;

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -57,9 +57,9 @@ use libc::c_int;
 use std::cmp;
 use std::ptr;
 
-use error::ErrorStack;
-use nid::Nid;
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::{cvt, cvt_p};
 
 #[derive(Copy, Clone)]
 pub enum Mode {

--- a/openssl/src/util.rs
+++ b/openssl/src/util.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 use std::panic::{self, AssertUnwindSafe};
 use std::slice;
 
-use error::ErrorStack;
+use crate::error::ErrorStack;
 
 /// Wraps a user-supplied callback and a slot for panics thrown inside the callback (while FFI
 /// frames are on the stack).

--- a/openssl/src/version.rs
+++ b/openssl/src/version.rs
@@ -11,6 +11,7 @@
 // limitations under the License.
 //
 
+use cfg_if::cfg_if;
 use std::ffi::CStr;
 
 cfg_if! {

--- a/openssl/src/x509/extension.rs
+++ b/openssl/src/x509/extension.rs
@@ -22,9 +22,9 @@
 //! ```
 use std::fmt::Write;
 
-use error::ErrorStack;
-use nid::Nid;
-use x509::{X509Extension, X509v3Context};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::x509::{X509Extension, X509v3Context};
 
 /// An extension which indicates whether a certificate is a CA certificate.
 pub struct BasicConstraints {

--- a/openssl/src/x509/extension.rs
+++ b/openssl/src/x509/extension.rs
@@ -8,8 +8,6 @@
 //! # Example
 //!
 //! ```rust
-//! extern crate openssl;
-//!
 //! use openssl::x509::extension::BasicConstraints;
 //! use openssl::x509::X509Extension;
 //!

--- a/openssl/src/x509/extension.rs
+++ b/openssl/src/x509/extension.rs
@@ -397,7 +397,7 @@ impl SubjectKeyIdentifier {
     }
 
     /// Return a `SubjectKeyIdentifier` extension as an `X509Extension`.
-    pub fn build(&self, ctx: &X509v3Context) -> Result<X509Extension, ErrorStack> {
+    pub fn build(&self, ctx: &X509v3Context<'_>) -> Result<X509Extension, ErrorStack> {
         let mut value = String::new();
         let mut first = true;
         append(&mut value, &mut first, self.critical, "critical");
@@ -449,7 +449,7 @@ impl AuthorityKeyIdentifier {
     }
 
     /// Return a `AuthorityKeyIdentifier` extension as an `X509Extension`.
-    pub fn build(&self, ctx: &X509v3Context) -> Result<X509Extension, ErrorStack> {
+    pub fn build(&self, ctx: &X509v3Context<'_>) -> Result<X509Extension, ErrorStack> {
         let mut value = String::new();
         let mut first = true;
         append(&mut value, &mut first, self.critical, "critical");
@@ -538,7 +538,7 @@ impl SubjectAlternativeName {
     }
 
     /// Return a `SubjectAlternativeName` extension as an `X509Extension`.
-    pub fn build(&self, ctx: &X509v3Context) -> Result<X509Extension, ErrorStack> {
+    pub fn build(&self, ctx: &X509v3Context<'_>) -> Result<X509Extension, ErrorStack> {
         let mut value = String::new();
         let mut first = true;
         append(&mut value, &mut first, self.critical, "critical");

--- a/openssl/src/x509/extension.rs
+++ b/openssl/src/x509/extension.rs
@@ -11,12 +11,10 @@
 //! use openssl::x509::extension::BasicConstraints;
 //! use openssl::x509::X509Extension;
 //!
-//! fn main() {
-//!     let mut bc = BasicConstraints::new();
-//!     let bc = bc.critical().ca().pathlen(1);
+//! let mut bc = BasicConstraints::new();
+//! let bc = bc.critical().ca().pathlen(1);
 //!
-//!     let extension: X509Extension = bc.build().unwrap();
-//! }
+//! let extension: X509Extension = bc.build().unwrap();
 //! ```
 use std::fmt::Write;
 

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -7,6 +7,7 @@
 //! Internet protocols, including SSL/TLS, which is the basis for HTTPS,
 //! the secure protocol for browsing the web.
 
+use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_long};
 use std::error::Error;

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -7,7 +7,6 @@
 //! Internet protocols, including SSL/TLS, which is the basis for HTTPS,
 //! the secure protocol for browsing the web.
 
-use ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_long};
 use std::error::Error;

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -20,19 +20,21 @@ use std::ptr;
 use std::slice;
 use std::str;
 
-use asn1::{Asn1BitStringRef, Asn1IntegerRef, Asn1ObjectRef, Asn1StringRef, Asn1TimeRef, Asn1Type};
-use bio::MemBioSlice;
-use conf::ConfRef;
-use error::ErrorStack;
-use ex_data::Index;
-use hash::{DigestBytes, MessageDigest};
-use nid::Nid;
-use pkey::{HasPrivate, HasPublic, PKey, PKeyRef, Public};
-use ssl::SslRef;
-use stack::{Stack, StackRef, Stackable};
-use string::OpensslString;
-use util::{ForeignTypeExt, ForeignTypeRefExt};
-use {cvt, cvt_n, cvt_p};
+use crate::asn1::{
+    Asn1BitStringRef, Asn1IntegerRef, Asn1ObjectRef, Asn1StringRef, Asn1TimeRef, Asn1Type,
+};
+use crate::bio::MemBioSlice;
+use crate::conf::ConfRef;
+use crate::error::ErrorStack;
+use crate::ex_data::Index;
+use crate::hash::{DigestBytes, MessageDigest};
+use crate::nid::Nid;
+use crate::pkey::{HasPrivate, HasPublic, PKey, PKeyRef, Public};
+use crate::ssl::SslRef;
+use crate::stack::{Stack, StackRef, Stackable};
+use crate::string::OpensslString;
+use crate::util::{ForeignTypeExt, ForeignTypeRefExt};
+use crate::{cvt, cvt_n, cvt_p};
 
 #[cfg(any(ossl102, libressl261))]
 pub mod verify;

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -678,7 +678,7 @@ impl Clone for X509 {
 }
 
 impl fmt::Debug for X509 {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let serial = match &self.serial_number().to_bn() {
             Ok(bn) => match bn.to_hex_str() {
                 Ok(hex) => hex.to_string(),
@@ -749,7 +749,7 @@ impl X509Extension {
     /// See the extension module for builder types which will construct certain common extensions.
     pub fn new(
         conf: Option<&ConfRef>,
-        context: Option<&X509v3Context>,
+        context: Option<&X509v3Context<'_>>,
         name: &str,
         value: &str,
     ) -> Result<X509Extension, ErrorStack> {
@@ -775,7 +775,7 @@ impl X509Extension {
     /// See the extension module for builder types which will construct certain common extensions.
     pub fn new_nid(
         conf: Option<&ConfRef>,
-        context: Option<&X509v3Context>,
+        context: Option<&X509v3Context<'_>>,
         name: Nid,
         value: &str,
     ) -> Result<X509Extension, ErrorStack> {
@@ -956,7 +956,7 @@ impl X509NameRef {
 }
 
 impl fmt::Debug for X509NameRef {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.debug_list().entries(self.entries()).finish()
     }
 }
@@ -1036,7 +1036,7 @@ impl X509NameEntryRef {
 }
 
 impl fmt::Debug for X509NameEntryRef {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_fmt(format_args!("{:?} = {:?}", self.object(), self.data()))
     }
 }
@@ -1283,7 +1283,7 @@ impl X509ReqRef {
 pub struct X509VerifyResult(c_int);
 
 impl fmt::Debug for X509VerifyResult {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("X509VerifyResult")
             .field("code", &self.0)
             .field("error", &self.error_string())
@@ -1292,7 +1292,7 @@ impl fmt::Debug for X509VerifyResult {
 }
 
 impl fmt::Display for X509VerifyResult {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str(self.error_string())
     }
 }
@@ -1397,7 +1397,7 @@ impl GeneralNameRef {
 }
 
 impl fmt::Debug for GeneralNameRef {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(email) = self.email() {
             formatter.write_str(email)
         } else if let Some(dnsname) = self.dnsname() {

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -35,6 +35,7 @@
 //! let store: X509Store = builder.build();
 //! ```
 
+use cfg_if::cfg_if;
 use foreign_types::ForeignTypeRef;
 use std::mem;
 

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -44,10 +44,10 @@ use ffi;
 use foreign_types::ForeignTypeRef;
 use std::mem;
 
-use error::ErrorStack;
-use stack::StackRef;
-use x509::{X509Object, X509};
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::stack::StackRef;
+use crate::x509::{X509Object, X509};
+use crate::{cvt, cvt_p};
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::X509_STORE;

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -13,28 +13,26 @@
 //! use openssl::rsa::Rsa;
 //! use openssl::nid::Nid;
 //!
-//! fn main() {
-//!     let rsa = Rsa::generate(2048).unwrap();
-//!     let pkey = PKey::from_rsa(rsa).unwrap();
+//! let rsa = Rsa::generate(2048).unwrap();
+//! let pkey = PKey::from_rsa(rsa).unwrap();
 //!
-//!     let mut name = X509Name::builder().unwrap();
-//!     name.append_entry_by_nid(Nid::COMMONNAME, "foobar.com").unwrap();
-//!     let name = name.build();
+//! let mut name = X509Name::builder().unwrap();
+//! name.append_entry_by_nid(Nid::COMMONNAME, "foobar.com").unwrap();
+//! let name = name.build();
 //!
-//!     let mut builder = X509::builder().unwrap();
-//!     builder.set_version(2).unwrap();
-//!     builder.set_subject_name(&name).unwrap();
-//!     builder.set_issuer_name(&name).unwrap();
-//!     builder.set_pubkey(&pkey).unwrap();
-//!     builder.sign(&pkey, MessageDigest::sha256()).unwrap();
+//! let mut builder = X509::builder().unwrap();
+//! builder.set_version(2).unwrap();
+//! builder.set_subject_name(&name).unwrap();
+//! builder.set_issuer_name(&name).unwrap();
+//! builder.set_pubkey(&pkey).unwrap();
+//! builder.sign(&pkey, MessageDigest::sha256()).unwrap();
 //!
-//!     let certificate: X509 = builder.build();
+//! let certificate: X509 = builder.build();
 //!
-//!     let mut builder = X509StoreBuilder::new().unwrap();
-//!     let _ = builder.add_cert(certificate);
+//! let mut builder = X509StoreBuilder::new().unwrap();
+//! let _ = builder.add_cert(certificate);
 //!
-//!     let store: X509Store = builder.build();
-//! }
+//! let store: X509Store = builder.build();
 //! ```
 
 use foreign_types::ForeignTypeRef;

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -6,9 +6,6 @@
 //! # Example
 //!
 //! ```rust
-//!
-//! extern crate openssl;
-//!
 //! use openssl::x509::store::{X509StoreBuilder, X509Store};
 //! use openssl::x509::{X509, X509Name};
 //! use openssl::pkey::PKey;

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -40,7 +40,6 @@
 //! }
 //! ```
 
-use ffi;
 use foreign_types::ForeignTypeRef;
 use std::mem;
 

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -1,19 +1,19 @@
-use asn1::Asn1Time;
-use bn::{BigNum, MsbOption};
-use hash::MessageDigest;
-use hex::{self, FromHex};
-use nid::Nid;
-use pkey::{PKey, Private};
-use rsa::Rsa;
-use stack::Stack;
-use x509::extension::{
+use crate::asn1::Asn1Time;
+use crate::bn::{BigNum, MsbOption};
+use crate::hash::MessageDigest;
+use crate::nid::Nid;
+use crate::pkey::{PKey, Private};
+use crate::rsa::Rsa;
+use crate::stack::Stack;
+use crate::x509::extension::{
     AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName,
     SubjectKeyIdentifier,
 };
-use x509::store::X509StoreBuilder;
+use crate::x509::store::X509StoreBuilder;
 #[cfg(ossl110)]
-use x509::X509Builder;
-use x509::{X509Name, X509Req, X509StoreContext, X509VerifyResult, X509};
+use crate::x509::X509Builder;
+use crate::x509::{X509Name, X509Req, X509StoreContext, X509VerifyResult, X509};
+use hex::{self, FromHex};
 
 fn pkey() -> PKey<Private> {
     let rsa = Rsa::generate(2048).unwrap();

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use foreign_types::ForeignTypeRef;
 use libc::{c_uint, c_ulong};
 use std::net::IpAddr;

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -1,4 +1,3 @@
-use ffi;
 use foreign_types::ForeignTypeRef;
 use libc::{c_uint, c_ulong};
 use std::net::IpAddr;

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -3,8 +3,8 @@ use foreign_types::ForeignTypeRef;
 use libc::{c_uint, c_ulong};
 use std::net::IpAddr;
 
-use cvt;
-use error::ErrorStack;
+use crate::cvt;
+use crate::error::ErrorStack;
 
 bitflags! {
     /// Flags used to check an `X509` certificate.

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -2,6 +2,7 @@
 name = "systest"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
 
 [dependencies]
 libc = "0.2"

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -1,5 +1,6 @@
 use std::env;
 
+#[allow(clippy::inconsistent_digit_grouping, clippy::unusual_byte_groupings)]
 #[path = "../openssl-sys/build/cfgs.rs"]
 mod cfgs;
 

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -1,5 +1,3 @@
-extern crate ctest;
-
 use std::env;
 
 #[path = "../openssl-sys/build/cfgs.rs"]

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,8 +1,5 @@
 #![allow(bad_style, clippy::all)]
 
-extern crate libc;
-extern crate openssl_sys;
-
 use libc::*;
 use openssl_sys::*;
 


### PR DESCRIPTION
The openssl-errors crate was already on the 2018 edition, and openssl-sys can't be updated without breaking the tests as [ctest doesn't support modern Rust features](https://github.com/gnzlbg/ctest/issues/70).