### PR TITLE
Add conan artifact resolution

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -13,6 +13,7 @@ build = "build/main.rs"
 
 [features]
 vendored = ['openssl-src']
+try_conan = [ 'conan' ]
 
 [dependencies]
 libc = "0.2"
@@ -22,6 +23,7 @@ cc = "1.0"
 openssl-src = { version = "111.0.1", optional = true }
 pkg-config = "0.3.9"
 autocfg = "1.0"
+conan = { version = "0.2", optional = true }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2.8"

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -13,7 +13,6 @@ build = "build/main.rs"
 
 [features]
 vendored = ['openssl-src']
-try_conan = [ 'conan' ]
 
 [dependencies]
 libc = "0.2"
@@ -23,7 +22,7 @@ cc = "1.0"
 openssl-src = { version = "111.0.1", optional = true }
 pkg-config = "0.3.9"
 autocfg = "1.0"
-conan = { version = "0.2", optional = true }
+conan = "0.2"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2.8"

--- a/openssl-sys/build/build_with_conan.rs
+++ b/openssl-sys/build/build_with_conan.rs
@@ -13,24 +13,12 @@ use conan::*;
 ///    preferably with openssl and its options
 ///
 /// Return pair of (Lib dir, Include dir)
-pub fn try_build_with_conan() -> Option<(PathBuf, PathBuf)> {
+pub fn try_build_with_conan(conanfile_path: &PathBuf) -> Option<(PathBuf, PathBuf)> {
     println!("cargo:rerun-if-changed=build/build_with_conan.rs");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let conan_profile = format!("{}-{}", target_os, target_arch);
-
-    // Let the user have a chance at configuring where the conanfile.txt file is
-    // else assume it's in the local directory, which may not be where they want.
-    let conanfile_path = match option_env!("CONANFILE_ROOT") {
-        Some(p) => {
-            Path::new(p)
-            .join("conanfile.txt")
-            .as_path()
-            .to_owned()
-        },
-        None => Path::new("conanfile.txt").to_owned()
-    };
 
     // emit changes to the conanfile.txt as a directive to cargo to rerun this
     // build script in case conanfile.txt changes.
@@ -63,4 +51,24 @@ pub fn try_build_with_conan() -> Option<(PathBuf, PathBuf)> {
 
     // Else, return no value
     None
+}
+
+// Let the user have a chance at configuring where the conanfile.txt file is
+// else assume it's in the local directory, which may not be where they want.
+// Return a value if the file exists, or None
+pub fn get_conanfile_path() -> Option<PathBuf> {
+    let conanfile_path = match option_env!("CONANFILE_ROOT") {
+        Some(p) => {
+            Path::new(p)
+            .join("conanfile.txt")
+            .as_path()
+            .to_owned()
+        },
+        None => Path::new("conanfile.txt").to_owned()
+    };
+
+    match conanfile_path.exists() {
+        true => Some(conanfile_path),
+        false => None
+    }
 }

--- a/openssl-sys/build/build_with_conan.rs
+++ b/openssl-sys/build/build_with_conan.rs
@@ -1,0 +1,60 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use conan::*;
+
+///
+/// Assumes the user provides:
+/// 1. (optional) define the conan command with CONAN environment variable
+/// 2. the conan command is on the PATH environment
+/// 3. Already defined the expected conan profile, which looks like:
+///    windows-x86_64, linux-x86_64, etc...
+/// 4. pre-written out a conanfile.txt to read and use
+///    preferably with openssl and its options
+///
+/// Return pair of (Lib dir, Include dir)
+pub fn build_with_conan() -> Option<(PathBuf, PathBuf)> {
+    println!("cargo:rerun-if-changed=build/build_with_conan.rs");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let conan_profile = format!("{}-{}", target_os, target_arch);
+
+    // Let the user have a chance at configuring where the conanfile.txt file is
+    // else assume it's in the local directory, which may not be where they want.
+    let conanfile_path = match option_env!("CONANFILE_ROOT") {
+        Some(p) => {
+            Path::new(p)
+            .join("conanfile.txt")
+            .as_path()
+            .to_owned()
+        },
+        None => Path::new("conanfile.txt").to_owned()
+    };
+
+    // emit the conanfile.txt as a directive to cargo to rerun this
+    // in case conanfile.txt changes.
+    if let Some(s) = conanfile_path.to_str() {
+        println!("cargo:rerun-if-changed={}", s);
+    }
+
+    let command = InstallCommandBuilder::new()
+        .with_profile(&conan_profile)
+        .build_policy(BuildPolicy::Missing)
+        .recipe_path(&conanfile_path)
+        .build();
+        
+    if let Some(build_info) = command.generate() {
+        println!("using conan build info");
+        match build_info.get_dependency("openssl") {
+            Some(build_deps) => {
+                if let (Some(lib_dir), Some(include_dir)) = (build_deps.get_library_dir(), build_deps.get_include_dir()) {
+                    return Some((PathBuf::from(lib_dir), PathBuf::from(include_dir)))
+                }
+            }
+            None => return None
+        }
+    }
+
+
+    None
+}

--- a/openssl-sys/build/build_with_conan.rs
+++ b/openssl-sys/build/build_with_conan.rs
@@ -39,8 +39,8 @@ pub fn try_build_with_conan(conanfile_path: &PathBuf) -> Option<(PathBuf, PathBu
     if let Some(build_info) = command.generate() {
         println!("using conan build info");
         match build_info.get_dependency("openssl") {
-            Some(build_deps) => {
-                if let (Some(lib_dir), Some(include_dir)) = (build_deps.get_library_dir(), build_deps.get_include_dir()) {
+            Some(openssl_build_dep) => {
+                if let (Some(lib_dir), Some(include_dir)) = (openssl_build_dep.get_library_dir(), openssl_build_dep.get_include_dir()) {
                     return Some((PathBuf::from(lib_dir), PathBuf::from(include_dir)))
                 }
             }

--- a/openssl-sys/build/example_conanfile.txt
+++ b/openssl-sys/build/example_conanfile.txt
@@ -1,0 +1,6 @@
+[requires]
+openssl/1.1.1i@
+
+[options]
+openssl:shared=True
+# add any additional openssl options as needed

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -4,6 +4,10 @@ extern crate autocfg;
 extern crate cc;
 #[cfg(feature = "vendored")]
 extern crate openssl_src;
+
+#[cfg(feature = "try_conan")]
+extern crate conan;
+
 extern crate pkg_config;
 #[cfg(target_env = "msvc")]
 extern crate vcpkg;
@@ -18,6 +22,8 @@ mod cfgs;
 mod find_normal;
 #[cfg(feature = "vendored")]
 mod find_vendored;
+#[cfg(feature = "try_conan")]
+mod build_with_conan;
 
 enum Version {
     Openssl11x,
@@ -44,6 +50,12 @@ fn env(name: &str) -> Option<OsString> {
 }
 
 fn find_openssl(target: &str) -> (PathBuf, PathBuf) {
+    #[cfg(feature = "try_conan")]
+    {
+        if let Some(t) = build_with_conan::build_with_conan() {
+            return t;
+        }
+    }
     #[cfg(feature = "vendored")]
     {
         // vendor if the feature is present, unless

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -46,9 +46,11 @@ fn env(name: &str) -> Option<OsString> {
 }
 
 fn find_openssl(target: &str) -> (PathBuf, PathBuf) {
-    // try to build with conan but continue if it was not successful
-    if let Some(t) = build_with_conan::try_build_with_conan() {
-        return t;
+    // if the conanfile.txt exists, try and use it, else continue
+    if let Some(f) = build_with_conan::get_conanfile_path() {
+        if let Some(t) = build_with_conan::try_build_with_conan(&f) {
+            return t;
+        }
     }
     #[cfg(feature = "vendored")]
     {

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -4,10 +4,7 @@ extern crate autocfg;
 extern crate cc;
 #[cfg(feature = "vendored")]
 extern crate openssl_src;
-
-#[cfg(feature = "try_conan")]
 extern crate conan;
-
 extern crate pkg_config;
 #[cfg(target_env = "msvc")]
 extern crate vcpkg;
@@ -22,7 +19,6 @@ mod cfgs;
 mod find_normal;
 #[cfg(feature = "vendored")]
 mod find_vendored;
-#[cfg(feature = "try_conan")]
 mod build_with_conan;
 
 enum Version {
@@ -50,11 +46,9 @@ fn env(name: &str) -> Option<OsString> {
 }
 
 fn find_openssl(target: &str) -> (PathBuf, PathBuf) {
-    #[cfg(feature = "try_conan")]
-    {
-        if let Some(t) = build_with_conan::build_with_conan() {
-            return t;
-        }
+    // try to build with conan but continue if it was not successful
+    if let Some(t) = build_with_conan::try_build_with_conan() {
+        return t;
     }
     #[cfg(feature = "vendored")]
     {


### PR DESCRIPTION
Adds another option to build the sys crate using a conan-built/provided include and library paths.  conan is a C/C++ package manager.

Requires the user to specify the dependency on their own, along with options for conan to build. Skips quickly if the user is not attempting to use it.  Any questions, comments, or criticisms welcome :)

Adds use of the conan cargo crate to build and read conan paths info.