### PR TITLE
Add support for MacPorts + fix scanning other directories on arm64

### DIFF
--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -25,27 +25,14 @@ fn resolve_with_wellknown_homebrew_location(dir: &str) -> Option<PathBuf> {
     // Check up default aarch 64 Homebrew installation location first
     // for quick resolution if possible.
     //  `pkg-config` on brew doesn't necessarily contain settings for openssl apparently.
-    let mut version_dir = dir.to_owned();
-    version_dir.push_str("@1.1");
-    let homebrew = Path::new(&version_dir);
+    let homebrew = Path::new(dir).join("opt/openssl@1.1");
     if homebrew.exists() {
         return Some(homebrew.to_path_buf());
     }
-    let homebrew = Path::new(dir);
-    if homebrew.exists() {
-        return Some(homebrew.to_path_buf());
-    }
+
     // Calling `brew --prefix <package>` command usually slow and
     // takes seconds, and will be used only as a last resort.
     let output = execute_command_and_get_output("brew", &["--prefix", "openssl@1.1"]);
-    if let Some(ref output) = output {
-        let homebrew = Path::new(&output);
-        if homebrew.exists() {
-            return Some(homebrew.to_path_buf());
-        }
-    }
-
-    let output = execute_command_and_get_output("brew", &["--prefix", "openssl"]);
     if let Some(ref output) = output {
         let homebrew = Path::new(&output);
         if homebrew.exists() {
@@ -71,8 +58,8 @@ fn find_openssl_dir(target: &str) -> OsString {
 
     if host == target && target.ends_with("-apple-darwin") {
         let homebrew_dir = match target {
-            "aarch64-apple-darwin" => "/opt/homebrew/opt/openssl",
-            _ => "/usr/local/opt/openssl",
+            "aarch64-apple-darwin" => "/opt/homebrew",
+            _ => "/usr/local",
         };
 
         if let Some(dir) = resolve_with_wellknown_homebrew_location(homebrew_dir) {

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -27,7 +27,7 @@ fn resolve_with_wellknown_homebrew_location(dir: &str) -> Option<PathBuf> {
     //  `pkg-config` on brew doesn't necessarily contain settings for openssl apparently.
     let homebrew = Path::new(dir).join("opt/openssl@1.1");
     if homebrew.exists() {
-        return Some(homebrew.to_path_buf());
+        return Some(homebrew);
     }
 
     // Calling `brew --prefix <package>` command usually slow and

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -28,8 +28,14 @@
 //! Additionally, it will use `pkg-config` on Unix-like systems to find the system installation.
 //!
 //! ```not_rust
-//! # macOS
+//! # macOS (Homebrew)
 //! $ brew install openssl@1.1
+//!
+//! # macOS (MacPorts)
+//! $ sudo port install openssl
+//!
+//! # macOS (pkgsrc)
+//! $ sudo pkgin install openssl
 //!
 //! # Arch Linux
 //! $ sudo pacman -S pkg-config openssl


### PR DESCRIPTION
This PR makes the following changes:

- Scan `/opt/local` in addition to `/opt/pkg`, a well-known location where MacPorts installs packages
- Refactor `resolve_with_wellknown_pkgsrc_location` into generic `resolve_with_wellknown_location`
- Fix not scanning other directories on `aarch64-apple-darwin`: previously, only the Homebrew directory was scanned
- Remove unnecessary Homebrew path checks: [`openssl` is an alias of `openssl@1.1`](https://github.com/Homebrew/homebrew-core/blob/master/Aliases/openssl) so the package will always be installed to `<prefix>/opt/openssl@1.1` rather than the unversioned path
- Add docs for installing `openssl` in different ways on macOS