### PR TITLE
Add PKCS7_get0_signers as pkcs7::Pkcs7::signers.

### DIFF
--- a/openssl-sys/src/pkcs7.rs
+++ b/openssl-sys/src/pkcs7.rs
@@ -49,6 +49,12 @@ extern "C" {
         flags: c_int,
     ) -> c_int;
 
+    pub fn PKCS7_get0_signers(
+        pkcs7: *mut PKCS7,
+        certs: *mut stack_st_X509,
+        flags: c_int,
+    ) -> *mut stack_st_X509;
+
     pub fn PKCS7_sign(
         signcert: *mut X509,
         pkey: *mut EVP_PKEY,


### PR DESCRIPTION
I need to be able to extract the signing certificates from a PKCS7, in order to fetch their intermediate issuers, in order to build and verify a signature chain up to a global root.

Full disclosure: I'm new to the Rust FFI and the last thing I'd want is to introduce a leak. One thing that was not clear to me from looking at code and searching around was when to `ffi:init()`.