### PR TITLE
Updated CMS (PKCS#7) to match OpenSSL spec

### DIFF
--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -289,12 +289,12 @@ mod test {
             let encrypted_der = encrypt.to_der().expect("failed to create der from cms");
             let decrypt =
                 CmsContentInfo::from_der(&encrypted_der).expect("failed read cms from der");
-            
+
             let decrypt_with_cert_check = decrypt
                 .decrypt(&priv_cert.pkey, &priv_cert.cert)
                 .expect("failed to decrypt cms");
-            let decrypt_with_cert_check =
-                String::from_utf8(decrypt_with_cert_check).expect("failed to create string from cms content");
+            let decrypt_with_cert_check = String::from_utf8(decrypt_with_cert_check)
+                .expect("failed to create string from cms content");
 
             let decrypt_without_cert_check = decrypt
                 .decrypt_without_cert_check(&priv_cert.pkey)
@@ -311,13 +311,13 @@ mod test {
             let encrypted_pem = encrypt.to_pem().expect("failed to create pem from cms");
             let decrypt =
                 CmsContentInfo::from_pem(&encrypted_pem).expect("failed read cms from pem");
-            
+
             let decrypt_with_cert_check = decrypt
                 .decrypt(&priv_cert.pkey, &priv_cert.cert)
                 .expect("failed to decrypt cms");
             let decrypt_with_cert_check = String::from_utf8(decrypt_with_cert_check)
                 .expect("failed to create string from cms content");
-            
+
             let decrypt_without_cert_check = decrypt
                 .decrypt_without_cert_check(&priv_cert.pkey)
                 .expect("failed to decrypt cms");

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -289,12 +289,21 @@ mod test {
             let encrypted_der = encrypt.to_der().expect("failed to create der from cms");
             let decrypt =
                 CmsContentInfo::from_der(&encrypted_der).expect("failed read cms from der");
-            let decrypt = decrypt
-                .decrypt(&priv_cert.pkey, Some(&priv_cert.cert))
+            
+            let decrypt_with_cert_check = decrypt
+                .decrypt(&priv_cert.pkey, &priv_cert.cert)
                 .expect("failed to decrypt cms");
-            let decrypt =
-                String::from_utf8(decrypt).expect("failed to create string from cms content");
-            assert_eq!(input, decrypt);
+            let decrypt_with_cert_check =
+                String::from_utf8(decrypt_with_cert_check).expect("failed to create string from cms content");
+
+            let decrypt_without_cert_check = decrypt
+                .decrypt_without_cert_check(&priv_cert.pkey)
+                .expect("failed to decrypt cms");
+            let decrypt_without_cert_check = String::from_utf8(decrypt_without_cert_check)
+                .expect("failed to create string from cms content");
+
+            assert_eq!(input, decrypt_with_cert_check);
+            assert_eq!(input, decrypt_without_cert_check);
         }
 
         // decrypt cms message using private key cert (PEM)
@@ -302,11 +311,13 @@ mod test {
             let encrypted_pem = encrypt.to_pem().expect("failed to create pem from cms");
             let decrypt =
                 CmsContentInfo::from_pem(&encrypted_pem).expect("failed read cms from pem");
+            
             let decrypt_with_cert_check = decrypt
                 .decrypt(&priv_cert.pkey, &priv_cert.cert)
                 .expect("failed to decrypt cms");
             let decrypt_with_cert_check = String::from_utf8(decrypt_with_cert_check)
                 .expect("failed to create string from cms content");
+            
             let decrypt_without_cert_check = decrypt
                 .decrypt_without_cert_check(&priv_cert.pkey)
                 .expect("failed to decrypt cms");

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -323,6 +323,7 @@ mod test {
                 .expect("failed to decrypt cms");
             let decrypt_without_cert_check = String::from_utf8(decrypt_without_cert_check)
                 .expect("failed to create string from cms content");
+
             assert_eq!(input, decrypt_with_cert_check);
             assert_eq!(input, decrypt_without_cert_check);
         }

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -66,7 +66,7 @@ foreign_type_and_impl_send_sync! {
     pub struct CmsContentInfoRef;
 }
 
-impl CmsContentInfoRef {    
+impl CmsContentInfoRef {
     /// Given the sender's private key, `pkey` and the recipient's certificiate, `cert`,
     /// decrypt the data in `self`.
     ///
@@ -94,7 +94,7 @@ impl CmsContentInfoRef {
             Ok(out.get_buf().to_owned())
         }
     }
-    
+
     /// Given the sender's private key, `pkey`,
     /// decrypt the data in `self` without validating the recipient certificate.
     ///


### PR DESCRIPTION
The [OpenSSL spec for CMS (PKCS#7)](https://www.openssl.org/docs/man1.0.2/man3/CMS_decrypt.html) allows for NULL to be provided as the `cert` value to try all possible recipients. This is useful in scenarios where a recipient certificate is not available, like in the [AWS Nitro Enclaves KMS flow](https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html).

It does, however, potentially leave the implementation vulnerable to Bleichenbacher's attack on PKCS#1 v1.5 RSA padding as outlined in the OpenSSL specs. Included documentation to outline this.
