### PR TITLE
Use DH_generate_parameters_ex()

### DIFF
--- a/openssl-sys/src/dh.rs
+++ b/openssl-sys/src/dh.rs
@@ -11,6 +11,13 @@ extern "C" {
         cb_arg: *mut c_void,
     ) -> *mut DH;
 
+    pub fn DH_generate_parameters_ex(
+        dh: *mut DH,
+        prime_len: c_int,
+        generator: c_int,
+        cb: *mut BN_GENCB,
+    ) -> c_int;
+
     pub fn DH_generate_key(dh: *mut DH) -> c_int;
     pub fn DH_compute_key(key: *mut c_uchar, pub_key: *const BIGNUM, dh: *mut DH) -> c_int;
     pub fn DH_size(dh: *const DH) -> c_int;

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -77,7 +77,6 @@ impl Dh<Params> {
     ///
     /// This corresponds to [`DH_generate_parameters_ex`].
     ///
-    /// [`DH_new`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_new.html
     /// [`DH_generate_parameters_ex`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_generate_parameters.html
     pub fn generate_params(prime_len: u32, generator: u32) -> Result<Dh<Params>, ErrorStack> {
         unsafe {

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -75,17 +75,20 @@ impl Dh<Params> {
 
     /// Generates DH params based on the given `prime_len` and a fixed `generator` value.
     ///
-    /// This corresponds to [`DH_generate_parameters`].
+    /// This corresponds to [`DH_generate_parameters_ex`].
     ///
-    /// [`DH_generate_parameters`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_generate_parameters.html
+    /// [`DH_new`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_new.html
+    /// [`DH_generate_parameters_ex`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_generate_parameters.html
     pub fn generate_params(prime_len: u32, generator: u32) -> Result<Dh<Params>, ErrorStack> {
         unsafe {
-            Ok(Dh::from_ptr(cvt_p(ffi::DH_generate_parameters(
+            let dh = Dh::from_ptr(cvt_p(ffi::DH_new())?);
+            cvt(ffi::DH_generate_parameters_ex(
+                dh.0,
                 prime_len as i32,
                 generator as i32,
-                None,
                 ptr::null_mut(),
-            ))?))
+            ))?;
+            Ok(dh)
         }
     }
 


### PR DESCRIPTION
https://www.openssl.org/docs/man1.1.0/man3/DH_generate_parameters.html
states that DH_generate_parameters() is deprecated. It has been so since
OpenSSL 0.9.8 was released in 2005.