### PR TITLE
Add wrapper for X509_STORE_set_flags()

### DIFF
--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -183,6 +183,7 @@ extern "C" {
     ) -> *mut X509_LOOKUP;
 
     pub fn X509_STORE_set_default_paths(store: *mut X509_STORE) -> c_int;
+    pub fn X509_STORE_set_flags(store: *mut X509_STORE, flags: c_ulong) -> c_int;
 
     pub fn X509_STORE_CTX_get_ex_data(ctx: *mut X509_STORE_CTX, idx: c_int) -> *mut c_void;
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> c_int;

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -41,6 +41,8 @@ use std::mem;
 
 use crate::error::ErrorStack;
 use crate::stack::StackRef;
+#[cfg(any(ossl102, libressl261))]
+use crate::x509::verify::X509VerifyFlags;
 use crate::x509::{X509Object, X509};
 use crate::{cvt, cvt_p};
 
@@ -101,6 +103,16 @@ impl X509StoreBuilderRef {
     ) -> Result<&mut X509LookupRef<T>, ErrorStack> {
         let lookup = unsafe { ffi::X509_STORE_add_lookup(self.as_ptr(), method.as_ptr()) };
         cvt_p(lookup).map(|ptr| unsafe { X509LookupRef::from_ptr_mut(ptr) })
+    }
+
+    /// Sets certificate chain validation related flags.
+    ///
+    /// This corresponds to [`X509_STORE_set_flags`].
+    ///
+    /// [`X509_STORE_set_flags`]: https://www.openssl.org/docs/man1.1.1/man3/X509_STORE_set_flags.html
+    #[cfg(any(ossl102, libressl261))]
+    pub fn set_flags(&mut self, flags: X509VerifyFlags) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::X509_STORE_set_flags(self.as_ptr(), flags.bits())).map(|_| ()) }
     }
 }
 


### PR DESCRIPTION
This makes it possible to properly set verification flags (like CRL check) for the store.
