### PR TITLE
ec: Add EcKey affine_coordinates

### DIFF
--- a/openssl-sys/src/ec.rs
+++ b/openssl-sys/src/ec.rs
@@ -95,6 +95,15 @@ extern "C" {
 
     pub fn EC_POINT_dup(p: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 
+    #[cfg(ossl111)]
+    pub fn EC_POINT_get_affine_coordinates(
+        group: *const EC_GROUP,
+        p: *const EC_POINT,
+        x: *mut BIGNUM,
+        y: *mut BIGNUM,
+        ctx: *mut BN_CTX,
+    ) -> c_int;
+
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         p: *const EC_POINT,


### PR DESCRIPTION
In OpenSSL, new functions were introduced[1] to get/set the affine
coordinates of a point, where OpenSSL itself determines what version of
the _GFp or _GF2m underlying function to call.
This makes that function available.

[1]: https://github.com/openssl/openssl/commit/8e3cced75fb5fee5da59ebef9605d403a999391b

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>