### PR TITLE
Add support for retrieving SignerInfo structures from PKCS7 signatures

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -28,6 +28,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x2_09_01_00_0 {
             cfgs.push("libressl291");
         }
+        if libressl_version >= 0x3_01_00_00_0 {
+            cfgs.push("libressl310");
+        }
         if libressl_version >= 0x3_02_01_00_0 {
             cfgs.push("libressl321");
         }

--- a/openssl-sys/src/pkcs7.rs
+++ b/openssl-sys/src/pkcs7.rs
@@ -9,6 +9,26 @@ pub enum PKCS7_DIGEST {}
 pub enum PKCS7_ENCRYPT {}
 pub enum PKCS7 {}
 
+#[repr(C)]
+pub struct PKCS7_ISSUER_AND_SERIAL {
+    pub issuer: *mut X509_NAME,
+    pub serial: *mut ASN1_INTEGER,
+}
+
+#[repr(C)]
+pub struct PKCS7_SIGNER_INFO {
+    pub version: *mut ASN1_INTEGER,
+    pub issuer_and_serial: *mut PKCS7_ISSUER_AND_SERIAL,
+    pub digest_alg: *mut X509_ALGOR,
+    pub auth_attr: *mut stack_st_X509_ATTRIBUTE,
+    pub digest_enc_alg: *mut X509_ALGOR,
+    pub enc_digest: *mut ASN1_OCTET_STRING,
+    pub unauth_attr: *mut stack_st_X509_ATTRIBUTE,
+    pub pkey: *mut EVP_PKEY,
+}
+
+stack!(stack_st_PKCS7_SIGNER_INFO);
+
 pub const PKCS7_TEXT: c_int = 0x1;
 pub const PKCS7_NOCERTS: c_int = 0x2;
 pub const PKCS7_NOSIGS: c_int = 0x4;
@@ -54,6 +74,18 @@ extern "C" {
         certs: *mut stack_st_X509,
         flags: c_int,
     ) -> *mut stack_st_X509;
+
+    pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
+
+    pub fn PKCS7_SIGNER_INFO_get0_algs(
+        si: *mut PKCS7_SIGNER_INFO,
+        pk: *mut *mut EVP_PKEY,
+        pdig: *mut *mut X509_ALGOR,
+        psig: *mut *mut X509_ALGOR,
+    );
+
+    // Not declared in the header, but the symbol exists and is exported
+    pub fn PKCS7_SIGNER_INFO_free(x: *mut PKCS7_SIGNER_INFO);
 
     pub fn PKCS7_sign(
         signcert: *mut X509,

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -64,6 +64,10 @@ fn main() {
             println!("cargo:rustc-cfg=libressl291");
         }
 
+        if version >= 0x3_01_00_00_0 {
+            println!("cargo:rustc-cfg=libressl310");
+        }
+
         if version >= 0x3_02_01_00_0 {
             println!("cargo:rustc-cfg=libressl321");
         }

--- a/openssl/src/pkcs7.rs
+++ b/openssl/src/pkcs7.rs
@@ -4,14 +4,101 @@ use libc::c_int;
 use std::mem;
 use std::ptr;
 
+use crate::asn1::{Asn1IntegerRef, Asn1StringRef};
 use crate::bio::{MemBio, MemBioSlice};
 use crate::error::ErrorStack;
 use crate::pkey::{HasPrivate, PKeyRef};
-use crate::stack::{Stack, StackRef};
+use crate::stack::{Stack, StackRef, Stackable};
 use crate::symm::Cipher;
+use crate::util::ForeignTypeRefExt;
 use crate::x509::store::X509StoreRef;
-use crate::x509::{X509Ref, X509};
+use crate::x509::{X509AlgorithmRef, X509NameRef, X509Ref, X509};
 use crate::{cvt, cvt_p};
+
+foreign_type_and_impl_send_sync! {
+    type CType = ffi::PKCS7_SIGNER_INFO;
+    fn drop = ffi::PKCS7_SIGNER_INFO_free;
+
+    /// A PKCS#7 SignerInfo structure.
+    pub struct Pkcs7SignerInfo;
+
+    /// Reference to `Pkcs7SignerInfo`
+    pub struct Pkcs7SignerInfoRef;
+}
+
+impl Pkcs7SignerInfoRef {
+    /// Returns the issuer's subject name.
+    ///
+    /// This corresponds to `PKCS7_SIGNER_INFO`'s `issuer_and_serial.issuer` field.`
+    pub fn subject_name(&self) -> &X509NameRef {
+        unsafe {
+            let ias = (*self.as_ptr()).issuer_and_serial;
+            assert!(!ias.is_null());
+
+            let issuer = (*ias).issuer;
+            X509NameRef::from_const_ptr_opt(issuer).expect("subject name must not be null")
+        }
+    }
+
+    /// Returns the issuer's serial number.
+    ///
+    /// This corresponds to `PKCS7_SIGNER_INFO`'s `issuer_and_serial.serial` field.
+    pub fn serial_number(&self) -> &Asn1IntegerRef {
+        unsafe {
+            let ias = (*self.as_ptr()).issuer_and_serial;
+            assert!(!ias.is_null());
+
+            let serial = (*ias).serial;
+            Asn1IntegerRef::from_const_ptr_opt(serial).expect("serial number must not be null")
+        }
+    }
+
+    /// Returns the signature's digest algorithm.
+    pub fn digest_algorithm(&self) -> &X509AlgorithmRef {
+        unsafe {
+            let mut algor = ptr::null_mut();
+            ffi::PKCS7_SIGNER_INFO_get0_algs(
+                self.as_ptr(),
+                ptr::null_mut(),
+                &mut algor,
+                ptr::null_mut(),
+            );
+
+            X509AlgorithmRef::from_const_ptr_opt(algor).expect("digest algorithm must not be null")
+        }
+    }
+
+    /// Returns the signature's digest encryption algorithm.
+    pub fn digest_encryption_algorithm(&self) -> &X509AlgorithmRef {
+        unsafe {
+            let mut algor = ptr::null_mut();
+            ffi::PKCS7_SIGNER_INFO_get0_algs(
+                self.as_ptr(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                &mut algor,
+            );
+
+            X509AlgorithmRef::from_const_ptr_opt(algor)
+                .expect("digest encryption algorithm must not be null")
+        }
+    }
+
+    /// Returns the raw signature.
+    ///
+    /// This corresponds to `PKCS7_SIGNER_INFO`'s `enc_digest` field.
+    pub fn signature(&self) -> &Asn1StringRef {
+        unsafe {
+            // ASN1_OCTET_STRING is a typedef of ASN1_STRING
+            let ptr = (*self.as_ptr()).enc_digest as *mut ffi::ASN1_STRING;
+            Asn1StringRef::from_const_ptr_opt(ptr).expect("signature must not be null")
+        }
+    }
+}
+
+impl Stackable for Pkcs7SignerInfo {
+    type StackType = ffi::stack_st_PKCS7_SIGNER_INFO;
+}
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::PKCS7;
@@ -311,11 +398,31 @@ impl Pkcs7Ref {
             Ok(stack)
         }
     }
+
+    /// Retrieve the SignerInfo entries from the PKCS#7 structure.
+    ///
+    /// This corresponds to [`PKCS7_get_signer_info`].
+    ///
+    /// [`PKCS7_get_signer_info`]: https://man.archlinux.org/man/community/libressl/libressl-PKCS7_get_signer_info.3.en
+    pub fn signer_infos(&self) -> Option<&StackRef<Pkcs7SignerInfo>> {
+        unsafe {
+            let ptr = ffi::PKCS7_get_signer_info(self.as_ptr());
+            if ptr.is_null() {
+                return None;
+            }
+
+            // The returned value is not owned by the caller.
+            Some(StackRef::<Pkcs7SignerInfo>::from_ptr(ptr))
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use cfg_if::cfg_if;
+
     use crate::hash::MessageDigest;
+    use crate::nid::Nid;
     use crate::pkcs7::{Pkcs7, Pkcs7Flags};
     use crate::pkey::PKey;
     use crate::stack::Stack;
@@ -462,6 +569,45 @@ mod tests {
         assert_eq!(signer_certs.len(), 1);
         let signer_digest = signer_certs[0].digest(MessageDigest::sha256()).unwrap();
         assert_eq!(*cert_digest, *signer_digest);
+
+        let signer_infos = pkcs7.signer_infos().unwrap();
+        assert_eq!(signer_infos.len(), 1);
+        assert_eq!(
+            signer_infos[0].serial_number().to_bn().unwrap(),
+            cert.serial_number().to_bn().unwrap()
+        );
+
+        let cert_subject = cert
+            .subject_name()
+            .entries()
+            .map(|e| (e.data().as_slice(), e.object().nid()))
+            .collect::<Vec<_>>();
+        let signer_subject = cert
+            .subject_name()
+            .entries()
+            .map(|e| (e.data().as_slice(), e.object().nid()))
+            .collect::<Vec<_>>();
+        assert_eq!(cert_subject, signer_subject);
+
+        cfg_if! {
+            if #[cfg(any(ossl102, libressl310))] {
+                assert_eq!(
+                    signer_infos[0].digest_algorithm().object().nid(),
+                    Nid::SHA256
+                );
+            } else {
+                assert_eq!(
+                    signer_infos[0].digest_algorithm().object().nid(),
+                    Nid::SHA1
+                );
+            }
+        }
+        assert_eq!(
+            signer_infos[0].digest_encryption_algorithm().object().nid(),
+            Nid::RSAENCRYPTION
+        );
+
+        assert!(!signer_infos[0].signature().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
This commit adds support for querying most fields from the SignerInfo structures contained within a PKCS7 signature:

* Subject name of signer
* Serial number of signer
* Digest algorithm
* Digest encryption algorithm
* Raw signature