### PR TITLE
Support LibreSSL 3.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
             - target: x86_64-unknown-linux-gnu
               library:
                 name: libressl
-                version: 3.3.1
+                version: 3.3.2
       name: ${{ matrix.target }}-${{ matrix.library.name }}-${{ matrix.library.version }}
       runs-on: ubuntu-latest
       env:

--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -31,6 +31,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x3_02_01_00_0 {
             cfgs.push("libressl321");
         }
+        if libressl_version >= 0x3_03_02_00_0 {
+            cfgs.push("libressl332");
+        }
     } else {
         let openssl_version = openssl_version.unwrap();
 

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -232,6 +232,7 @@ See rust-openssl README for more information:
             (3, 2, _) => ('3', '2', 'x'),
             (3, 3, 0) => ('3', '3', '0'),
             (3, 3, 1) => ('3', '3', '1'),
+            (3, 3, 2) => ('3', '3', '2'),
             _ => version_error(),
         };
 
@@ -272,7 +273,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 3.3.1, but a different version of OpenSSL was found. The build is now aborting
+through 3.3.2, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -311,9 +311,9 @@ pub const SSL_OP_NO_TLSv1_1: c_ulong = 0x10000000;
 pub const SSL_OP_NO_TLSv1_2: c_ulong = 0x08000000;
 
 pub const SSL_OP_NO_TLSv1: c_ulong = 0x04000000;
-#[cfg(ossl102)]
+#[cfg(any(ossl102, libressl332))]
 pub const SSL_OP_NO_DTLSv1: c_ulong = 0x04000000;
-#[cfg(ossl102)]
+#[cfg(any(ossl102, libressl332))]
 pub const SSL_OP_NO_DTLSv1_2: c_ulong = 0x08000000;
 #[cfg(ossl111)]
 pub const SSL_OP_NO_TLSv1_3: c_ulong = 0x20000000;

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -311,10 +311,15 @@ pub const SSL_OP_NO_TLSv1_1: c_ulong = 0x10000000;
 pub const SSL_OP_NO_TLSv1_2: c_ulong = 0x08000000;
 
 pub const SSL_OP_NO_TLSv1: c_ulong = 0x04000000;
-#[cfg(any(ossl102, libressl332))]
-pub const SSL_OP_NO_DTLSv1: c_ulong = 0x04000000;
-#[cfg(any(ossl102, libressl332))]
-pub const SSL_OP_NO_DTLSv1_2: c_ulong = 0x08000000;
+cfg_if! {
+    if #[cfg(ossl102)] {
+        pub const SSL_OP_NO_DTLSv1: c_ulong = 0x04000000;
+        pub const SSL_OP_NO_DTLSv1_2: c_ulong = 0x08000000;
+    } else if #[cfg(libressl332)] {
+        pub const SSL_OP_NO_DTLSv1: c_ulong = 0x40000000;
+        pub const SSL_OP_NO_DTLSv1_2: c_ulong = 0x80000000;
+    }
+}
 #[cfg(ossl111)]
 pub const SSL_OP_NO_TLSv1_3: c_ulong = 0x20000000;
 

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -67,5 +67,9 @@ fn main() {
         if version >= 0x3_02_01_00_0 {
             println!("cargo:rustc-cfg=libressl321");
         }
+
+        if version >= 0x3_03_02_00_0 {
+            println!("cargo:rustc-cfg=libressl332");
+        }
     }
 }

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -1,7 +1,7 @@
 //! Bindings to OpenSSL
 //!
 //! This crate provides a safe interface to the popular OpenSSL cryptography library. OpenSSL versions 1.0.1 through
-//! 1.1.1 and LibreSSL versions 2.5 through 3.3.1 are supported.
+//! 1.1.1 and LibreSSL versions 2.5 through 3.3.2 are supported.
 //!
 //! # Building
 //!

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -211,14 +211,14 @@ bitflags! {
 
         /// Disables the use of DTLSv1.0
         ///
-        /// Requires OpenSSL 1.0.2 or newer.
-        #[cfg(any(ossl102, ossl110))]
+        /// Requires OpenSSL 1.0.2 or LibreSSL 3.3.2 or newer.
+        #[cfg(any(ossl102, ossl110, libressl332))]
         const NO_DTLSV1 = ffi::SSL_OP_NO_DTLSv1;
 
         /// Disables the use of DTLSv1.2.
         ///
-        /// Requires OpenSSL 1.0.2, or newer.
-        #[cfg(any(ossl102, ossl110))]
+        /// Requires OpenSSL 1.0.2 or LibreSSL 3.3.2 or newer.
+        #[cfg(any(ossl102, ossl110, libressl332))]
         const NO_DTLSV1_2 = ffi::SSL_OP_NO_DTLSv1_2;
 
         /// Disables the use of all (D)TLS protocol versions.

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -306,7 +306,6 @@ fn state() {
 /// lists of supported protocols have an overlap -- with only ONE protocol
 /// being valid for both.
 #[test]
-#[cfg_attr(libressl291, ignore)]
 fn test_connect_with_srtp_ctx() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -365,7 +364,6 @@ fn test_connect_with_srtp_ctx() {
 /// lists of supported protocols have an overlap -- with only ONE protocol
 /// being valid for both.
 #[test]
-#[cfg_attr(libressl291, ignore)]
 fn test_connect_with_srtp_ssl() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
DTLS support is now exposed. Opcode values are different from OpenSSL.
While here, re-enable SRTP tests that should have been done during the 2.9.2 cycle.

Supersedes #1452 