### PR TITLE
Make openssl-sys no_std

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -16,6 +16,7 @@ vendored = ['openssl-src']
 
 [dependencies]
 libc = "0.2"
+conquer-once = { version = "0.3.2", use-default-features = false }
 
 [build-dependencies]
 cc = "1.0"

--- a/openssl-sys/src/rsa.rs
+++ b/openssl-sys/src/rsa.rs
@@ -1,5 +1,5 @@
+use core::ptr;
 use libc::*;
-use std::ptr;
 
 use *;
 

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -1,5 +1,5 @@
+use core::ptr;
 use libc::*;
-use std::ptr;
 
 use *;
 

--- a/openssl-sys/src/tls1.rs
+++ b/openssl-sys/src/tls1.rs
@@ -1,6 +1,6 @@
+use core::mem;
+use core::ptr;
 use libc::*;
-use std::mem;
-use std::ptr;
 
 use *;
 

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -156,7 +156,7 @@ pub unsafe fn X509_LOOKUP_add_dir(
         X509_L_ADD_DIR,
         name,
         _type as c_long,
-        std::ptr::null_mut(),
+        core::ptr::null_mut(),
     )
 }
 


### PR DESCRIPTION
I have been writing some embedded Rust that makes heavy use of openssl and I'd like to use the good wrappers instead of writing or generating my own but can't because openssl-sys requires std.

Turns out there's very little reason to.

openssl-sys's only use of std is `std::sync::Once` to run `OPENSSL_init_ssl` a single time.
Replacing the standard implementation by conquer_once's spinlock, the
wrappers can now be used in no_std context with no compatibility loss.

I didn't think it pertinent to modify the feature-set of the crate for something so slight, but if the small extra dependency is a pain, putting no_std behind a flag is always a possibility.