### PR TITLE
Support the rest of LibreSSL 3.3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
             - target: x86_64-unknown-linux-gnu
               library:
                 name: libressl
-                version: 3.3.2
+                version: 3.3.3
       name: ${{ matrix.target }}-${{ matrix.library.name }}-${{ matrix.library.version }}
       runs-on: ubuntu-latest
       env:

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -232,7 +232,7 @@ See rust-openssl README for more information:
             (3, 2, _) => ('3', '2', 'x'),
             (3, 3, 0) => ('3', '3', '0'),
             (3, 3, 1) => ('3', '3', '1'),
-            (3, 3, 2) => ('3', '3', '2'),
+            (3, 3, _) => ('3', '3', 'x'),
             _ => version_error(),
         };
 
@@ -273,7 +273,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 3.3.2, but a different version of OpenSSL was found. The build is now aborting
+through 3.3.x, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -1,7 +1,7 @@
 //! Bindings to OpenSSL
 //!
 //! This crate provides a safe interface to the popular OpenSSL cryptography library. OpenSSL versions 1.0.1 through
-//! 1.1.1 and LibreSSL versions 2.5 through 3.3.2 are supported.
+//! 1.1.1 and LibreSSL versions 2.5 through 3.3.x are supported.
 //!
 //! # Building
 //!


### PR DESCRIPTION
"Other than the version number, it is identical to LibreSSL 3.3.2."

https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.3.3-relnotes.txt