### PR TITLE
Add PKeyMethod

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -25,6 +25,8 @@ pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
 pub const EVP_CTRL_GCM_GET_TAG: c_int = 0x10;
 pub const EVP_CTRL_GCM_SET_TAG: c_int = 0x11;
 
+pub const EVP_PKEY_FLAG_AUTOARGLEN: c_int = 2;
+
 pub unsafe fn EVP_get_digestbynid(type_: c_int) -> *const EVP_MD {
     EVP_get_digestbyname(OBJ_nid2sn(type_))
 }
@@ -302,6 +304,7 @@ extern "C" {
     pub fn EVP_get_digestbyname(name: *const c_char) -> *const EVP_MD;
     pub fn EVP_get_cipherbyname(name: *const c_char) -> *const EVP_CIPHER;
 
+    pub fn EVP_PKEY_type(typ: c_int) -> c_int;
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> c_int;
 }
 const_ptr_api! {
@@ -475,4 +478,25 @@ cfg_if! {
 extern "C" {
     pub fn EVP_EncodeBlock(dst: *mut c_uchar, src: *const c_uchar, src_len: c_int) -> c_int;
     pub fn EVP_DecodeBlock(dst: *mut c_uchar, src: *const c_uchar, src_len: c_int) -> c_int;
+}
+
+extern "C" {
+    pub fn EVP_PKEY_meth_new(id: c_int, flags: c_int) -> *mut EVP_PKEY_METHOD;
+    pub fn EVP_PKEY_meth_free(pmeth: *mut EVP_PKEY_METHOD);
+    pub fn EVP_PKEY_meth_copy(dst: *mut EVP_PKEY_METHOD, src: *const EVP_PKEY_METHOD);
+    pub fn EVP_PKEY_meth_find(typ: c_int) -> *const EVP_PKEY_METHOD;
+    pub fn EVP_PKEY_meth_add0(pmeth: *const EVP_PKEY_METHOD) -> c_int;
+
+    pub fn EVP_PKEY_meth_set_sign(
+        pmeth: *mut EVP_PKEY_METHOD,
+        sign_init: extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> c_int,
+        sign: extern "C" fn(
+            ctx: *mut EVP_PKEY_CTX,
+            sig: *mut c_uchar,
+            siglen: *mut size_t,
+            tbs: *const c_uchar,
+            tbslen: size_t,
+        ) -> c_int,
+    );
+
 }

--- a/openssl-sys/src/ossl_typ.rs
+++ b/openssl-sys/src/ossl_typ.rs
@@ -123,6 +123,8 @@ cfg_if! {
     }
 }
 
+pub enum EVP_PKEY_METHOD {}
+
 pub enum PKCS8_PRIV_KEY_INFO {}
 
 pub enum EVP_PKEY_ASN1_METHOD {}

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -177,6 +177,14 @@ fn cvt_p<T>(r: *mut T) -> Result<*mut T, ErrorStack> {
     }
 }
 
+fn cvt_const_p<T>(r: *const T) -> Result<*const T, ErrorStack> {
+    if r.is_null() {
+        Err(ErrorStack::get())
+    } else {
+        Ok(r)
+    }
+}
+
 fn cvt(r: c_int) -> Result<c_int, ErrorStack> {
     if r <= 0 {
         Err(ErrorStack::get())


### PR DESCRIPTION
Seeking an initial review, as I'm not sure how to best idiomatically wrap `EVP_PKEY_METHOD` in the existing style of this crate.

Typical usage is either going to be calling `EVP_PKEY_meth_new` and setting all applicable function for a given algorithm or calling `EVP_PKEY_meth_new` + `EVP_PKEY_meth_find` + `EVP_PKEY_meth_copy` to make a mutable copy of the default struct and setting a subset of the functions. Then `EVP_PKEY_meth_add0` is called to replace the existing struct with ours.

Some observations:
- `EVP_PKEY_meth_find` returns `*const EVP_PKEY_METHOD` and does not have an `up_ref` function, so I don't believe it is possible to implement `ToOwned`.
- `EVP_PKEY_meth_add0` replaces the existing struct for a given algorithm globally. 
- I couldn't figure out a way to adapt the callbacks to Rust closures in the style of openssl/src/ssl/callbacks.rs.

https://www.openssl.org/docs/man1.1.1/man3/EVP_PKEY_meth_new.html