### PR TITLE
Add d2i_X509_bio to openssl-sys

### DIFF
--- a/openssl-sys/src/err.rs
+++ b/openssl-sys/src/err.rs
@@ -4,6 +4,7 @@ pub const ERR_TXT_MALLOCED: c_int = 0x01;
 pub const ERR_TXT_STRING: c_int = 0x02;
 
 pub const ERR_LIB_PEM: c_int = 9;
+pub const ERR_LIB_ASN1: c_int = 13;
 
 const_fn! {
     pub const fn ERR_PACK(l: c_int, f: c_int, r: c_int) -> c_ulong {

--- a/openssl-sys/src/object.rs
+++ b/openssl-sys/src/object.rs
@@ -5,6 +5,7 @@ use *;
 extern "C" {
     pub fn OBJ_nid2ln(nid: c_int) -> *const c_char;
     pub fn OBJ_nid2sn(nid: c_int) -> *const c_char;
+    pub fn OBJ_nid2obj(n: c_int) -> *mut ASN1_OBJECT;
     pub fn OBJ_obj2nid(o: *const ASN1_OBJECT) -> c_int;
     pub fn OBJ_obj2txt(
         buf: *mut c_char,

--- a/openssl-sys/src/ossl_typ.rs
+++ b/openssl-sys/src/ossl_typ.rs
@@ -1010,7 +1010,41 @@ cfg_if! {
     }
 }
 
-pub enum COMP_METHOD {}
+pub enum COMP_CTX {}
+
+cfg_if! {
+    if #[cfg(ossl110)] {
+        pub enum COMP_METHOD {}
+    } else {
+        #[repr(C)]
+        pub struct COMP_METHOD {
+            pub type_: c_int,
+            pub name: *const c_char,
+            init: Option<unsafe extern "C" fn(*mut COMP_CTX) -> c_int>,
+            finish: Option<unsafe extern "C" fn(*mut COMP_CTX)>,
+            compress: Option<
+                unsafe extern "C" fn(
+                    *mut COMP_CTX,
+                    *mut c_uchar,
+                    c_uint,
+                    *mut c_uchar,
+                    c_uint,
+                ) -> c_int,
+            >,
+            expand: Option<
+                unsafe extern "C" fn(
+                    *mut COMP_CTX,
+                    *mut c_uchar,
+                    c_uint,
+                    *mut c_uchar,
+                    c_uint,
+                ) -> c_int,
+            >,
+            ctrl: Option<unsafe extern "C" fn() -> c_long>,
+            callback_ctrl: Option<unsafe extern "C" fn() -> c_long>,
+        }
+    }
+}
 
 cfg_if! {
     if #[cfg(any(ossl110, libressl280))] {

--- a/openssl-sys/src/rand.rs
+++ b/openssl-sys/src/rand.rs
@@ -7,4 +7,6 @@ extern "C" {
     pub fn RAND_keep_random_devices_open(keep: c_int);
 
     pub fn RAND_status() -> c_int;
+
+    pub fn RAND_add(buf: *const c_void, num: c_int, randomness: c_double);
 }

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -1348,7 +1348,9 @@ cfg_if! {
     }
 }
 
+#[cfg(not(osslconf = "OPENSSL_NO_COMP"))]
 extern "C" {
+    #[cfg(ossl110)]
     pub fn COMP_get_type(meth: *const COMP_METHOD) -> i32;
 }
 

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -998,6 +998,9 @@ extern "C" {
     );
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: c_int);
 
+    #[cfg(ossl111)]
+    pub fn SSL_CTX_set_post_handshake_auth(ctx: *mut SSL_CTX, val: c_int);
+
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> c_int;
 
     pub fn SSL_CTX_set_session_id_context(
@@ -1343,6 +1346,10 @@ cfg_if! {
             pub fn SSL_COMP_get_name(comp: *const COMP_METHOD) -> *const c_char;
         }
     }
+}
+
+extern "C" {
+    pub fn COMP_get_type(meth: *const COMP_METHOD) -> i32;
 }
 
 extern "C" {

--- a/openssl-sys/src/x509.rs
+++ b/openssl-sys/src/x509.rs
@@ -6,6 +6,8 @@ pub const X509_FILETYPE_PEM: c_int = 1;
 pub const X509_FILETYPE_ASN1: c_int = 2;
 pub const X509_FILETYPE_DEFAULT: c_int = 3;
 
+pub const ASN1_R_HEADER_TOO_LONG: c_int = 123;
+
 #[repr(C)]
 pub struct X509_VAL {
     pub notBefore: *mut ASN1_TIME,
@@ -284,6 +286,7 @@ extern "C" {
     pub fn X509_free(x: *mut X509);
     pub fn i2d_X509(x: *mut X509, buf: *mut *mut u8) -> c_int;
     pub fn d2i_X509(a: *mut *mut X509, pp: *mut *const c_uchar, length: c_long) -> *mut X509;
+    pub fn d2i_X509_bio(b: *mut BIO, a: *mut *mut X509) -> *mut X509;
 
     pub fn X509_get_pubkey(x: *mut X509) -> *mut EVP_PKEY;
 

--- a/openssl-sys/src/x509.rs
+++ b/openssl-sys/src/x509.rs
@@ -581,3 +581,10 @@ cfg_if! {
         }
     }
 }
+
+extern "C" {
+    pub fn X509_get_default_cert_file_env() -> *const c_char;
+    pub fn X509_get_default_cert_file() -> *const c_char;
+    pub fn X509_get_default_cert_dir_env() -> *const c_char;
+    pub fn X509_get_default_cert_dir() -> *const c_char;
+}


### PR DESCRIPTION
I wasn't sure where to find `der` keys to use to test, so I just concatenated `cms_pubkey.der` with itself to test it.