### PR TITLE
Keep LibreSSL 3.4.0 up-to-date for OpenBSD -current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
             - target: x86_64-unknown-linux-gnu
               library:
                 name: libressl
-                version: 3.3.3
+                version: 3.4.0
       name: ${{ matrix.target }}-${{ matrix.library.name }}-${{ matrix.library.version }}
       runs-on: ubuntu-latest
       env:

--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -34,6 +34,12 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x3_03_02_00_0 {
             cfgs.push("libressl332");
         }
+	if libressl_version >= 0x3_03_03_00_0 {
+	    cfgs.push("libressl333");
+	}
+	if libressl_version >= 0x3_04_00_00_0 {
+	    cfgs.push("libressl340");
+	}
     } else {
         let openssl_version = openssl_version.unwrap();
 

--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -34,7 +34,7 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x3_03_02_00_0 {
             cfgs.push("libressl332");
         }
-	if libressl_version >= 0x3_03_03_00_0 {
+        if libressl_version >= 0x3_03_03_00_0 {
             cfgs.push("libressl333");
         }
         if libressl_version >= 0x3_04_00_00_0 {

--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -35,11 +35,11 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
             cfgs.push("libressl332");
         }
 	if libressl_version >= 0x3_03_03_00_0 {
-	    cfgs.push("libressl333");
-	}
-	if libressl_version >= 0x3_04_00_00_0 {
-	    cfgs.push("libressl340");
-	}
+            cfgs.push("libressl333");
+        }
+        if libressl_version >= 0x3_04_00_00_0 {
+            cfgs.push("libressl340");
+        }
     } else {
         let openssl_version = openssl_version.unwrap();
 

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -233,6 +233,8 @@ See rust-openssl README for more information:
             (3, 3, 0) => ('3', '3', '0'),
             (3, 3, 1) => ('3', '3', '1'),
             (3, 3, _) => ('3', '3', 'x'),
+            (3, 4, 0) => ('3', '4', '0'),
+            (3, 4, _) => ('3', '4', 'x'),
             _ => version_error(),
         };
 
@@ -273,7 +275,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 3.3.x, but a different version of OpenSSL was found. The build is now aborting
+through 3.4.x, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -315,7 +315,7 @@ cfg_if! {
     if #[cfg(ossl102)] {
         pub const SSL_OP_NO_DTLSv1: c_ulong = 0x04000000;
         pub const SSL_OP_NO_DTLSv1_2: c_ulong = 0x08000000;
-    } else if #[cfg(libressl332)] {
+    } else if #[cfg(libressl340)] {
         pub const SSL_OP_NO_DTLSv1: c_ulong = 0x40000000;
         pub const SSL_OP_NO_DTLSv1_2: c_ulong = 0x80000000;
     }

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -71,5 +71,9 @@ fn main() {
         if version >= 0x3_03_02_00_0 {
             println!("cargo:rustc-cfg=libressl332");
         }
+
+        if version >= 0x3_04_00_00_0 {
+            println!("cargo:rustc-cfg=libressl340");
+        }
     }
 }

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -1,7 +1,7 @@
 //! Bindings to OpenSSL
 //!
 //! This crate provides a safe interface to the popular OpenSSL cryptography library. OpenSSL versions 1.0.1 through
-//! 1.1.1 and LibreSSL versions 2.5 through 3.3.x are supported.
+//! 1.1.1 and LibreSSL versions 2.5 through 3.4.x are supported.
 //!
 //! # Building
 //!

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -211,14 +211,14 @@ bitflags! {
 
         /// Disables the use of DTLSv1.0
         ///
-        /// Requires OpenSSL 1.0.2 or LibreSSL 3.3.2 or newer.
-        #[cfg(any(ossl102, ossl110, libressl332))]
+        /// Requires OpenSSL 1.0.2 or LibreSSL 3.4.0 or newer.
+        #[cfg(any(ossl102, ossl110, libressl340))]
         const NO_DTLSV1 = ffi::SSL_OP_NO_DTLSv1;
 
         /// Disables the use of DTLSv1.2.
         ///
-        /// Requires OpenSSL 1.0.2 or LibreSSL 3.3.2 or newer.
-        #[cfg(any(ossl102, ossl110, libressl332))]
+        /// Requires OpenSSL 1.0.2 or LibreSSL 3.4.0 or newer.
+        #[cfg(any(ossl102, ossl110, libressl340))]
         const NO_DTLSV1_2 = ffi::SSL_OP_NO_DTLSv1_2;
 
         /// Disables the use of all (D)TLS protocol versions.


### PR DESCRIPTION
I hope this is enough:

```
test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.95s

   Doc-tests openssl-sys

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Cheers.-
