### PR TITLE
Add private key to pkcs8 passphrase

### DIFF
--- a/openssl-sys/src/pem.rs
+++ b/openssl-sys/src/pem.rs
@@ -66,6 +66,15 @@ const_ptr_api! {
         ) -> c_int;
         pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: #[const_ptr_if(ossl300)] PKCS7) -> c_int;
         pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, ec: #[const_ptr_if(ossl300)] EC_KEY) -> c_int;
+        pub fn i2d_PKCS8PrivateKey_bio(
+            bp: *mut BIO,
+            x: #[const_ptr_if(ossl300)] EVP_PKEY,
+            enc: *const EVP_CIPHER,
+            kstr: #[const_ptr_if(ossl300)] c_char,
+            klen: c_int,
+            cb: pem_password_cb,
+            u: *mut c_void,
+        ) -> c_int;
     }
 }
 

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -109,6 +109,7 @@ fn main() {
             s.starts_with("PEM_read_bio_") ||
             (s.starts_with("PEM_write_bio_") && s.ends_with("PrivateKey")) ||
             s == "d2i_PKCS8PrivateKey_bio" ||
+            s == "i2d_PKCS8PrivateKey_bio" ||
             s == "SSL_get_ex_new_index" ||
             s == "SSL_CTX_get_ex_new_index" ||
             s == "CRYPTO_get_ex_new_index"


### PR DESCRIPTION
This PR adds the counterparts of `d2i_PKCS8PrivateKey_bio` and `private_key_from_pkcs8_passphrase`.