### PR TITLE
CI: speed up windows-vcpkg build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,15 @@ jobs:
       - uses: sfackler/actions/rustup@master
       - run: echo "::set-output name=version::$(rustc --version)"
         id: rust-version
-      - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-      - run: vcpkg install openssl:x64-windows
+      - name: Prepare vcpkg
+        uses: lukka/run-vcpkg@v7
+        id: runvcpkg
+        with:
+          vcpkgArguments: openssl:x64-windows
+          vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
+          vcpkgTriplet: x64-windows
+          # 2021.05.12 release
+          vcpkgGitCommitId: 5568f110b509a9fd90711978a7cb76bae75bb092
       - uses: actions/cache@v1
         with:
           path: ~/.cargo/registry/index


### PR DESCRIPTION
Based on my daily experience, windows-vcpkg installs `vcpkg` each time when the github action runs, switch to `lukka/run-vcpkg` to benefit from the `vcpkg` cache.

To test it truly makes sense, I added several commits to test CI behavior, if you want to merge this PR, I will rebase them into a single commit.

Testing result:

Current:  10m 36s
https://github.com/wongsyrone/rust-openssl/runs/2994266452?check_suite_focus=true
First time using this PR: 11m 37s
https://github.com/wongsyrone/rust-openssl/runs/2994422238?check_suite_focus=true
Second time using this PR: 2m 39s
https://github.com/wongsyrone/rust-openssl/runs/2994476156?check_suite_focus=true