### PR TITLE
Set the maximum libressl version to 3.x.x

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -226,17 +226,7 @@ See rust-openssl README for more information:
             (2, 8, _) => ('2', '8', 'x'),
             (2, 9, 0) => ('2', '9', '0'),
             (2, 9, _) => ('2', '9', 'x'),
-            (3, 0, 0) => ('3', '0', '0'),
-            (3, 0, 1) => ('3', '0', '1'),
-            (3, 0, _) => ('3', '0', 'x'),
-            (3, 1, 0) => ('3', '1', '0'),
-            (3, 1, _) => ('3', '1', 'x'),
-            (3, 2, 0) => ('3', '2', '0'),
-            (3, 2, 1) => ('3', '2', '1'),
-            (3, 2, _) => ('3', '2', 'x'),
-            (3, 3, 0) => ('3', '3', '0'),
-            (3, 3, 1) => ('3', '3', '1'),
-            (3, 3, _) => ('3', '3', 'x'),
+            (3, _, _) => ('3', 'x', 'x'),
             _ => version_error(),
         };
 
@@ -279,7 +269,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
-through 3.3.x, but a different version of OpenSSL was found. The build is now aborting
+through 3.x.x, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "


### PR DESCRIPTION
This set the maximum libressl version to `3.x.x`.

This would be very helpful as it is constantly tedious to have to patch rust to use the latest libressl version which to my knowledge has always worked for the `3.x` series. In the event a future version does cause problems I suggest reexamining this issue then if necessary.