### PR TITLE
Add X509Name to/from DER methods

### DIFF
--- a/openssl-sys/src/x509.rs
+++ b/openssl-sys/src/x509.rs
@@ -478,6 +478,7 @@ const_ptr_api! {
             loc: c_int,
             set: c_int,
         ) -> c_int;
+        pub fn i2d_X509_NAME(n: #[const_ptr_if(ossl300)] X509_NAME, buf: *mut *mut u8) -> c_int;
         pub fn X509_NAME_ENTRY_get_object(ne: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
         pub fn X509_NAME_ENTRY_get_data(ne: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME_ENTRY) -> *mut ASN1_STRING;
     }
@@ -492,6 +493,11 @@ extern "C" {
         loc: c_int,
         set: c_int,
     ) -> c_int;
+    pub fn d2i_X509_NAME(
+        n: *mut *mut X509_NAME,
+        pp: *mut *const c_uchar,
+        length: c_long,
+    ) -> *mut X509_NAME;
 }
 
 // "raw" X509_EXTENSION related functions

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -947,6 +947,17 @@ impl X509Name {
         let file = CString::new(file.as_ref().as_os_str().to_str().unwrap()).unwrap();
         unsafe { cvt_p(ffi::SSL_load_client_CA_file(file.as_ptr())).map(|p| Stack::from_ptr(p)) }
     }
+
+    from_der! {
+        /// Deserializes a DER-encoded X509 name structure.
+        ///
+        /// This corresponds to [`d2i_X509_NAME`].
+        ///
+        /// [`d2i_X509_NAME`]: https://www.openssl.org/docs/manmaster/man3/d2i_X509_NAME.html
+        from_der,
+        X509Name,
+        ffi::d2i_X509_NAME
+    }
 }
 
 impl Stackable for X509Name {
@@ -970,6 +981,16 @@ impl X509NameRef {
             nid: None,
             loc: -1,
         }
+    }
+
+    to_der! {
+        /// Serializes the certificate into a DER-encoded X509 name structure.
+        ///
+        /// This corresponds to [`i2d_X509_NAME`].
+        ///
+        /// [`i2d_X509_NAME`]: https://www.openssl.org/docs/man1.1.0/crypto/i2d_X509_NAME.html
+        to_der,
+        ffi::i2d_X509_NAME
     }
 }
 

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -453,3 +453,26 @@ fn x509_ref_version_no_version_set() {
         "Default certificate version is incorrect",
     );
 }
+
+#[test]
+fn test_save_subject_der() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+
+    let der = cert.subject_name().to_der().unwrap();
+    println!("der: {:?}", der);
+    assert!(!der.is_empty());
+}
+
+#[test]
+fn test_load_subject_der() {
+    // The subject from ../../test/cert.pem
+    const SUBJECT_DER: &[u8] = &[
+        48, 90, 49, 11, 48, 9, 6, 3, 85, 4, 6, 19, 2, 65, 85, 49, 19, 48, 17, 6, 3, 85, 4, 8, 12,
+        10, 83, 111, 109, 101, 45, 83, 116, 97, 116, 101, 49, 33, 48, 31, 6, 3, 85, 4, 10, 12, 24,
+        73, 110, 116, 101, 114, 110, 101, 116, 32, 87, 105, 100, 103, 105, 116, 115, 32, 80, 116,
+        121, 32, 76, 116, 100, 49, 19, 48, 17, 6, 3, 85, 4, 3, 12, 10, 102, 111, 111, 98, 97, 114,
+        46, 99, 111, 109,
+    ];
+    X509Name::from_der(SUBJECT_DER).unwrap();
+}


### PR DESCRIPTION
Since X509Name is more complex than a single value (it's a a sequence
of entries) it's useful to be able to serialise/deserialise to/from
flat data, and DER is a natural form for this.

So add a {i2d,d2i}_X509_NAME -sys functions, and to_der/from_der
wrappers in X509NameRef and X509Name respectively.