### PR TITLE
Only check OPENSSL_BUILT_ON if it is not ""

### DIFF
--- a/openssl/src/version.rs
+++ b/openssl/src/version.rs
@@ -127,6 +127,9 @@ fn test_versions() {
     assert!(number() > 0);
     assert!(version().starts_with(expected_name()));
     assert!(c_flags().starts_with("compiler:"));
-    assert!(built_on().starts_with("built on:"));
+    // some distributions patch out dates out of openssl so that the builds are reproducible
+    if !built_on().is_empty() {
+        assert!(built_on().starts_with("built on:"));
+    }
     assert!(dir().starts_with("OPENSSLDIR:"));
 }


### PR DESCRIPTION
Some distributions (e.g. openSUSE) patch out `OPENSSL_BUILT_ON` to be "" as this breaks reproducibility of the build.
With this commit, we only check that this value starts with "built on" if it is not "", thereby not loosing any test coverage.