### PR TITLE
Export SSL_get_extms_support

### DIFF
--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -482,6 +482,11 @@ pub unsafe fn SSL_set_mtu(ssl: *mut SSL, mtu: c_long) -> c_long {
     SSL_ctrl(ssl, SSL_CTRL_SET_MTU, mtu, ptr::null_mut())
 }
 
+#[cfg(ossl110)]
+pub unsafe fn SSL_get_extms_support(ssl: *mut SSL) -> c_long {
+    SSL_ctrl(ssl, SSL_CTRL_GET_EXTMS_SUPPORT, 0, ptr::null_mut())
+}
+
 pub type GEN_SESSION_CB =
     Option<unsafe extern "C" fn(*const SSL, *mut c_uchar, *mut c_uint) -> c_int>;
 
@@ -767,6 +772,8 @@ pub const SSL_CTRL_SET_ECDH_AUTO: c_int = 94;
 pub const SSL_CTRL_SET_SIGALGS_LIST: c_int = 98;
 #[cfg(ossl102)]
 pub const SSL_CTRL_SET_VERIFY_CERT_STORE: c_int = 106;
+#[cfg(ossl110)]
+pub const SSL_CTRL_GET_EXTMS_SUPPORT: c_int = 122;
 #[cfg(ossl110)]
 pub const SSL_CTRL_SET_MIN_PROTO_VERSION: c_int = 123;
 #[cfg(ossl110)]

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3110,6 +3110,16 @@ impl SslRef {
         }
     }
 
+    /// Determines if current session used Extended Master Secret
+    ///
+    /// This corresponds to [`SSL_get_extms_support`].
+    ///
+    /// [`SSL_get_extms_support`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_get_extms_support.html
+    #[cfg(ossl110)]
+    pub fn extms_support(&self) -> bool {
+        unsafe { ffi::SSL_get_extms_support(self.as_ptr()) != 0 }
+    }
+
     /// Returns the server's OCSP response, if present.
     ///
     /// This corresponds to [`SSL_get_tlsext_status_ocsp_resp`].

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3112,12 +3112,19 @@ impl SslRef {
 
     /// Determines if current session used Extended Master Secret
     ///
+    /// Returns `None` if the handshake is still in-progress.
+    ///
     /// This corresponds to [`SSL_get_extms_support`].
     ///
     /// [`SSL_get_extms_support`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_get_extms_support.html
     #[cfg(ossl110)]
-    pub fn extms_support(&self) -> bool {
-        unsafe { ffi::SSL_get_extms_support(self.as_ptr()) != 0 }
+    pub fn extms_support(&self) -> Option<bool> {
+        unsafe {
+            match ffi::SSL_get_extms_support(self.as_ptr()) {
+                -1 => None,
+                ret => Some(ret != 0),
+            }
+        }
     }
 
     /// Returns the server's OCSP response, if present.


### PR DESCRIPTION
As per https://github.com/openssl/openssl/commit/c536461499a3e93166921181847b3ed9b2d85c7d `SSL_get_extms_support` is available since `1.1.0`. Scoped it accordingly.