### PR TITLE
Print out a version directive for OpenSSL 3.0.0

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -266,6 +266,7 @@ See rust-openssl README for more information:
         if openssl_version >= 0x4_00_00_00_0 {
             version_error()
         } else if openssl_version >= 0x3_00_00_00_0 {
+            println!("cargo:version=300");
             Version::Openssl3xx
         } else if openssl_version >= 0x1_01_01_00_0 {
             println!("cargo:version=111");


### PR DESCRIPTION
This was printed out for previous OpenSSL versions for downstream
consumers but it looks like this was accidentally omitted for the 3.0.0
branch.