### PR TITLE
Add LibreSSL version 3.4.1 to the supported version list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
             - target: x86_64-unknown-linux-gnu
               library:
                 name: libressl
-                version: 3.4.0
+                version: 3.4.1
       name: ${{ matrix.target }}-${{ matrix.library.name }}-${{ matrix.library.version }}
       runs-on: ubuntu-latest
       env:

--- a/openssl-sys/CHANGELOG.md
+++ b/openssl-sys/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* Added support for LibreSSL 3.4.1
+
 ## [v0.9.70] - 2021-10-31
 
 ### Fixed

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -253,6 +253,7 @@ See rust-openssl README for more information:
             (3, 3, 1) => ('3', '3', '1'),
             (3, 3, _) => ('3', '3', 'x'),
             (3, 4, 0) => ('3', '4', '0'),
+            (3, 4, 1) => ('3', '4', '1'),
             _ => version_error(),
         };
 
@@ -295,7 +296,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3.0.0), or LibreSSL 2.5
-through 3.4.0, but a different version of OpenSSL was found. The build is now aborting
+through 3.4.1, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -1,7 +1,7 @@
 //! Bindings to OpenSSL
 //!
 //! This crate provides a safe interface to the popular OpenSSL cryptography library. OpenSSL versions 1.0.1 through
-//! 1.1.1 and LibreSSL versions 2.5 through 3.4.0 are supported.
+//! 1.1.1 and LibreSSL versions 2.5 through 3.4.1 are supported.
 //!
 //! # Building
 //!


### PR DESCRIPTION
OpenBSD 7.0 ships with LibreSSL version 3.4.1. This PR adds this version to the "supported versions" list. Fixes issue #1559.