### PR TITLE
Add CipherCtx

### DIFF
--- a/openssl-sys/src/crypto.rs
+++ b/openssl-sys/src/crypto.rs
@@ -127,4 +127,9 @@ extern "C" {
     pub fn FIPS_mode_set(onoff: c_int) -> c_int;
 
     pub fn CRYPTO_memcmp(a: *const c_void, b: *const c_void, len: size_t) -> c_int;
+
+    #[cfg(ossl300)]
+    pub fn OSSL_LIB_CTX_new() -> *mut OSSL_LIB_CTX;
+    #[cfg(ossl300)]
+    pub fn OSSL_LIB_CTX_free(libcts: *mut OSSL_LIB_CTX);
 }

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -92,11 +92,6 @@ cfg_if! {
         pub unsafe fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> c_int {
             EVP_CIPHER_CTX_get_iv_length(ctx)
         }
-
-        #[inline]
-        pub unsafe fn EVP_CIPHER_CTX_tag_length(ctx: *const EVP_CIPHER_CTX) -> c_int {
-            EVP_CIPHER_CTX_get_tag_length(ctx)
-        }
     } else {
         extern "C" {
             pub fn EVP_MD_size(md: *const EVP_MD) -> c_int;
@@ -111,7 +106,6 @@ cfg_if! {
             pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> c_int;
             pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> c_int;
             pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> c_int;
-            pub fn EVP_CIPHER_CTX_tag_length(ctx: *const EVP_CIPHER_CTX) -> c_int;
         }
     }
 }

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -39,6 +39,11 @@ cfg_if! {
             pub fn EVP_CIPHER_get_block_size(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_get_iv_length(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_get_nid(cipher: *const EVP_CIPHER) -> c_int;
+            pub fn EVP_CIPHER_fetch(
+                ctx: *mut OSSL_LIB_CTX,
+                algorithm: *const c_char,
+                properties: *const c_char,
+            ) -> *mut EVP_CIPHER;
             pub fn EVP_CIPHER_free(cipher: *mut EVP_CIPHER);
 
             pub fn EVP_CIPHER_CTX_get0_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -323,6 +323,7 @@ extern "C" {
         arg: c_int,
         ptr: *mut c_void,
     ) -> c_int;
+    pub fn EVP_CIPHER_CTX_rand_key(ctx: *mut EVP_CIPHER_CTX, key: *mut c_uchar) -> c_int;
 
     pub fn EVP_md_null() -> *const EVP_MD;
     pub fn EVP_md5() -> *const EVP_MD;

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -39,6 +39,7 @@ cfg_if! {
             pub fn EVP_CIPHER_get_block_size(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_get_iv_length(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_get_nid(cipher: *const EVP_CIPHER) -> c_int;
+            pub fn EVP_CIPHER_free(cipher: *mut EVP_CIPHER);
 
             pub fn EVP_CIPHER_CTX_get0_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
             pub fn EVP_CIPHER_CTX_get_block_size(ctx: *const EVP_CIPHER_CTX) -> c_int;

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -39,6 +39,12 @@ cfg_if! {
             pub fn EVP_CIPHER_get_block_size(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_get_iv_length(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_get_nid(cipher: *const EVP_CIPHER) -> c_int;
+
+            pub fn EVP_CIPHER_CTX_get0_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
+            pub fn EVP_CIPHER_CTX_get_block_size(ctx: *const EVP_CIPHER_CTX) -> c_int;
+            pub fn EVP_CIPHER_CTX_get_key_length(ctx: *const EVP_CIPHER_CTX) -> c_int;
+            pub fn EVP_CIPHER_CTX_get_iv_length(ctx: *const EVP_CIPHER_CTX) -> c_int;
+            pub fn EVP_CIPHER_CTX_get_tag_length(ctx: *const EVP_CIPHER_CTX) -> c_int;
         }
 
         #[inline]
@@ -70,6 +76,26 @@ cfg_if! {
         pub unsafe fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> c_int {
             EVP_CIPHER_get_nid(cipher)
         }
+
+        #[inline]
+        pub unsafe fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> c_int {
+            EVP_CIPHER_CTX_get_block_size(ctx)
+        }
+
+        #[inline]
+        pub unsafe fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> c_int {
+            EVP_CIPHER_CTX_get_key_length(ctx)
+        }
+
+        #[inline]
+        pub unsafe fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> c_int {
+            EVP_CIPHER_CTX_get_iv_length(ctx)
+        }
+
+        #[inline]
+        pub unsafe fn EVP_CIPHER_CTX_tag_length(ctx: *const EVP_CIPHER_CTX) -> c_int {
+            EVP_CIPHER_CTX_get_tag_length(ctx)
+        }
     } else {
         extern "C" {
             pub fn EVP_MD_size(md: *const EVP_MD) -> c_int;
@@ -79,10 +105,15 @@ cfg_if! {
             pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> c_int;
+
+            pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
+            pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> c_int;
+            pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> c_int;
+            pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> c_int;
+            pub fn EVP_CIPHER_CTX_tag_length(ctx: *const EVP_CIPHER_CTX) -> c_int;
         }
     }
 }
-extern "C" {}
 
 cfg_if! {
     if #[cfg(ossl110)] {

--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -2,8 +2,7 @@
 
 use crate::nid::Nid;
 use cfg_if::cfg_if;
-use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
-use std::ops::{Deref, DerefMut};
+use foreign_types::{ForeignTypeRef, Opaque};
 
 cfg_if! {
     if #[cfg(any(ossl110, libressl273))] {
@@ -28,6 +27,9 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(ossl300)] {
+        use foreign_types::ForeignType;
+        use std::ops::{Deref, DerefMut};
+
         type Inner = *mut ffi::EVP_CIPHER;
 
         impl Drop for Cipher {

--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -8,6 +8,8 @@ cfg_if! {
     if #[cfg(any(ossl110, libressl273))] {
         use ffi::{EVP_CIPHER_block_size, EVP_CIPHER_iv_length, EVP_CIPHER_key_length};
     } else {
+        use libc::c_int;
+
         #[allow(bad_style)]
         pub unsafe fn EVP_CIPHER_iv_length(ptr: *const ffi::EVP_CIPHER) -> c_int {
             (*ptr).iv_len

--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -1,0 +1,352 @@
+//! Symmetric ciphers.
+
+use crate::nid::Nid;
+use cfg_if::cfg_if;
+use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
+use std::ops::{Deref, DerefMut};
+
+cfg_if! {
+    if #[cfg(any(ossl110, libressl273))] {
+        use ffi::{EVP_CIPHER_block_size, EVP_CIPHER_iv_length, EVP_CIPHER_key_length};
+    } else {
+        #[allow(bad_style)]
+        pub unsafe fn EVP_CIPHER_iv_length(ptr: *const ffi::EVP_CIPHER) -> c_int {
+            (*ptr).iv_len
+        }
+
+        #[allow(bad_style)]
+        pub unsafe fn EVP_CIPHER_block_size(ptr: *const ffi::EVP_CIPHER) -> c_int {
+            (*ptr).block_size
+        }
+
+        #[allow(bad_style)]
+        pub unsafe fn EVP_CIPHER_key_length(ptr: *const ffi::EVP_CIPHER) -> c_int {
+            (*ptr).key_len
+        }
+    }
+}
+
+cfg_if! {
+    if #[cfg(ossl300)] {
+        type Inner = *mut ffi::EVP_CIPHER;
+
+        impl Drop for Cipher {
+            #[inline]
+            fn drop(&mut self) {
+                unsafe {
+                    ffi::EVP_CIPHER_free(self.as_ptr());
+                }
+            }
+        }
+
+        impl ForeignType for Cipher {
+            type CType = ffi::EVP_CIPHER;
+            type Ref = CipherRef;
+
+            #[inline]
+            unsafe fn from_ptr(ptr: *mut Self::CType) -> Self {
+                Cipher(ptr)
+            }
+
+            #[inline]
+            fn as_ptr(&self) -> *mut Self::CType {
+                self.0
+            }
+        }
+
+        impl Deref for Cipher {
+            type Target = CipherRef;
+
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                unsafe {
+                    CipherRef::from_ptr(self.as_ptr())
+                }
+            }
+        }
+
+        impl DerefMut for Cipher {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                unsafe {
+                    CipherRef::from_ptr_mut(self.as_ptr())
+                }
+            }
+        }
+    } else {
+        enum Inner {}
+    }
+}
+
+/// A symmetric cipher.
+pub struct Cipher(Inner);
+
+unsafe impl Sync for Cipher {}
+unsafe impl Send for Cipher {}
+
+impl Cipher {
+    /// Looks up the cipher for a certain nid.
+    ///
+    /// This corresponds to [`EVP_get_cipherbynid`]
+    ///
+    /// [`EVP_get_cipherbynid`]: https://www.openssl.org/docs/man1.0.2/crypto/EVP_get_cipherbyname.html
+    pub fn from_nid(nid: Nid) -> Option<&'static CipherRef> {
+        unsafe {
+            let ptr = ffi::EVP_get_cipherbyname(ffi::OBJ_nid2sn(nid.as_raw()));
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CipherRef::from_ptr(ptr as *mut _))
+            }
+        }
+    }
+
+    pub fn aes_128_ecb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_ecb() as *mut _) }
+    }
+
+    pub fn aes_128_cbc() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_cbc() as *mut _) }
+    }
+
+    pub fn aes_128_xts() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_xts() as *mut _) }
+    }
+
+    pub fn aes_128_ctr() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_ctr() as *mut _) }
+    }
+
+    pub fn aes_128_cfb1() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_cfb1() as *mut _) }
+    }
+
+    pub fn aes_128_cfb128() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_cfb128() as *mut _) }
+    }
+
+    pub fn aes_128_cfb8() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_cfb8() as *mut _) }
+    }
+
+    pub fn aes_128_gcm() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_gcm() as *mut _) }
+    }
+
+    pub fn aes_128_ccm() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_ccm() as *mut _) }
+    }
+
+    pub fn aes_128_ofb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_ofb() as *mut _) }
+    }
+
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[cfg(ossl110)]
+    pub fn aes_128_ocb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_ocb() as *mut _) }
+    }
+
+    pub fn aes_192_ecb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_ecb() as *mut _) }
+    }
+
+    pub fn aes_192_cbc() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cbc() as *mut _) }
+    }
+
+    pub fn aes_192_ctr() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_ctr() as *mut _) }
+    }
+
+    pub fn aes_192_cfb1() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb1() as *mut _) }
+    }
+
+    pub fn aes_192_cfb128() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb128() as *mut _) }
+    }
+
+    pub fn aes_192_cfb8() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb8() as *mut _) }
+    }
+
+    pub fn aes_192_gcm() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_gcm() as *mut _) }
+    }
+
+    pub fn aes_192_ccm() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_ccm() as *mut _) }
+    }
+
+    pub fn aes_192_ofb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_ofb() as *mut _) }
+    }
+
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[cfg(ossl110)]
+    pub fn aes_192_ocb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_ocb() as *mut _) }
+    }
+
+    pub fn aes_256_ecb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_ecb() as *mut _) }
+    }
+
+    pub fn aes_256_cbc() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cbc() as *mut _) }
+    }
+
+    pub fn aes_256_ctr() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_ctr() as *mut _) }
+    }
+
+    pub fn aes_256_cfb1() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb1() as *mut _) }
+    }
+
+    pub fn aes_256_cfb128() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb128() as *mut _) }
+    }
+
+    pub fn aes_256_cfb8() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb8() as *mut _) }
+    }
+
+    pub fn aes_256_gcm() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_gcm() as *mut _) }
+    }
+
+    pub fn aes_256_ccm() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_ccm() as *mut _) }
+    }
+
+    pub fn aes_256_ofb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_ofb() as *mut _) }
+    }
+
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[cfg(ossl110)]
+    pub fn aes_256_ocb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_ocb() as *mut _) }
+    }
+
+    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
+    pub fn bf_cbc() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_bf_cbc() as *mut _) }
+    }
+
+    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
+    pub fn bf_ecb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_bf_ecb() as *mut _) }
+    }
+
+    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
+    pub fn bf_cfb64() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_bf_cfb64() as *mut _) }
+    }
+
+    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
+    pub fn bf_ofb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_bf_ofb() as *mut _) }
+    }
+
+    pub fn des_cbc() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_des_cbc() as *mut _) }
+    }
+
+    pub fn des_ecb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_des_ecb() as *mut _) }
+    }
+
+    pub fn des_ede3() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_des_ede3() as *mut _) }
+    }
+
+    pub fn des_ede3_cbc() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_des_ede3_cbc() as *mut _) }
+    }
+
+    pub fn des_ede3_cfb64() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_des_ede3_cfb64() as *mut _) }
+    }
+
+    pub fn rc4() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_rc4() as *mut _) }
+    }
+
+    #[cfg(all(ossl110, not(osslconf = "OPENSSL_NO_CHACHA")))]
+    pub fn chacha20() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_chacha20() as *mut _) }
+    }
+
+    #[cfg(all(ossl110, not(osslconf = "OPENSSL_NO_CHACHA")))]
+    pub fn chacha20_poly1305() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_chacha20_poly1305() as *mut _) }
+    }
+
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    pub fn seed_cbc() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_seed_cbc() as *mut _) }
+    }
+
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    pub fn seed_cfb128() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_seed_cfb128() as *mut _) }
+    }
+
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    pub fn seed_ecb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_seed_ecb() as *mut _) }
+    }
+
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    pub fn seed_ofb() -> &'static CipherRef {
+        unsafe { CipherRef::from_ptr(ffi::EVP_seed_ofb() as *mut _) }
+    }
+}
+
+/// A reference to a [`Cipher`].
+pub struct CipherRef(Opaque);
+
+impl ForeignTypeRef for CipherRef {
+    type CType = ffi::EVP_CIPHER;
+}
+
+unsafe impl Sync for CipherRef {}
+unsafe impl Send for CipherRef {}
+
+impl CipherRef {
+    /// Returns the cipher's Nid.
+    ///
+    /// This corresponds to [`EVP_CIPHER_nid`]
+    ///
+    /// [`EVP_CIPHER_nid`]: https://www.openssl.org/docs/man1.0.2/crypto/EVP_CIPHER_nid.html
+    pub fn nid(&self) -> Nid {
+        let nid = unsafe { ffi::EVP_CIPHER_nid(self.as_ptr()) };
+        Nid::from_raw(nid)
+    }
+
+    /// Returns the length of keys used with this cipher.
+    pub fn key_length(&self) -> usize {
+        unsafe { EVP_CIPHER_key_length(self.as_ptr()) as usize }
+    }
+
+    /// Returns the length of the IV used with this cipher.
+    ///
+    /// # Note
+    ///
+    /// Ciphers that do not use an IV have an IV length of 0.
+    pub fn iv_length(&self) -> usize {
+        unsafe { EVP_CIPHER_iv_length(self.as_ptr()) as usize }
+    }
+
+    /// Returns the block size of the cipher.
+    ///
+    /// # Note
+    ///
+    /// Stream ciphers have a block size of 1.
+    pub fn block_size(&self) -> usize {
+        unsafe { EVP_CIPHER_block_size(self.as_ptr()) as usize }
+    }
+}

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -680,10 +680,10 @@ mod test {
             .unwrap();
 
         let mut ctx = CipherCtx::new().unwrap();
-        ctx.set_padding(false);
 
         ctx.encrypt_init(Some(cipher), Some(&key), Some(&iv))
             .unwrap();
+        ctx.set_padding(false);
 
         let mut buf = vec![];
         ctx.cipher_update_vec(&pt, &mut buf).unwrap();
@@ -693,6 +693,7 @@ mod test {
 
         ctx.decrypt_init(Some(cipher), Some(&key), Some(&iv))
             .unwrap();
+        ctx.set_padding(false);
 
         let mut buf = vec![];
         ctx.cipher_update_vec(&ct, &mut buf).unwrap();

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -320,6 +320,29 @@ impl CipherCtxRef {
         unsafe { ffi::EVP_CIPHER_CTX_key_length(self.as_ptr()) as usize }
     }
 
+    /// Generates a random key based on the configured cipher.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the context has not been initialized with a cipher or if the buffer is smaller than the cipher's key
+    /// length.
+    ///
+    /// This corresponds to [`EVP_CIPHER_CTX_rand_key`].
+    ///
+    /// [`EVP_CIPHER_CTX_rand_key`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_rand_key.html
+    pub fn rand_key(&self, buf: &mut [u8]) -> Result<(), ErrorStack> {
+        assert!(buf.len() >= self.key_length());
+
+        unsafe {
+            cvt(ffi::EVP_CIPHER_CTX_rand_key(
+                self.as_ptr(),
+                buf.as_mut_ptr(),
+            ))?;
+        }
+
+        Ok(())
+    }
+
     /// Sets the length of the key expected by the context.
     ///
     /// Only some ciphers support configurable key lengths.

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -411,7 +411,7 @@ impl CipherCtxRef {
         Ok(())
     }
 
-    /// Returns the length of the authenticationt tag expected by this context.
+    /// Returns the length of the authentication tag expected by this context.
     ///
     /// Returns 0 if the cipher is not authenticated.
     ///
@@ -421,11 +421,14 @@ impl CipherCtxRef {
     ///
     /// This corresponds to [`EVP_CIPHER_CTX_tag_length`].
     ///
+    /// Requires OpenSSL 3.0.0 or newer.
+    ///
     /// [`EVP_CIPHER_CTX_tag_length`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_tag_length.html
+    #[cfg(ossl300)]
     pub fn tag_length(&self) -> usize {
         self.assert_cipher();
 
-        unsafe { ffi::EVP_CIPHER_CTX_tag_length(self.as_ptr()) as usize }
+        unsafe { ffi::EVP_CIPHER_CTX_get_tag_length(self.as_ptr()) as usize }
     }
 
     /// Retrieves the calculated authentication tag from the context.

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -1,0 +1,273 @@
+use crate::error::ErrorStack;
+use crate::symm::{Cipher, Mode};
+use crate::{cvt, cvt_p};
+use cfg_if::cfg_if;
+use foreign_types::{ForeignType, ForeignTypeRef};
+use libc::c_int;
+use std::convert::TryFrom;
+use std::ptr;
+
+cfg_if! {
+    if #[cfg(ossl300)] {
+        use ffi::EVP_CIPHER_CTX_get0_cipher;
+    } else {
+        use ffi::EVP_CIPHER_CTX_cipher as EVP_CIPHER_CTX_get0_cipher;
+    }
+}
+
+foreign_type_and_impl_send_sync! {
+    type CType = ffi::EVP_CIPHER_CTX;
+    fn drop = ffi::EVP_CIPHER_CTX_free;
+
+    pub struct CipherCtx;
+    pub struct CipherCtxRef;
+}
+
+impl CipherCtx {
+    pub fn new() -> Result<Self, ErrorStack> {
+        ffi::init();
+
+        unsafe {
+            let ptr = cvt_p(ffi::EVP_CIPHER_CTX_new())?;
+            Ok(CipherCtx::from_ptr(ptr))
+        }
+    }
+}
+
+impl CipherCtxRef {
+    pub fn init(
+        &mut self,
+        // FIXME CipherRef
+        type_: Option<&Cipher>,
+        key: Option<&[u8]>,
+        iv: Option<&[u8]>,
+        mode: Mode,
+    ) -> Result<(), ErrorStack> {
+        if let Some(key) = key {
+            if let Some(len) = self.key_length() {
+                assert_eq!(len, key.len());
+            }
+        }
+
+        if let Some(iv) = iv {
+            if let Some(len) = self.iv_length() {
+                assert_eq!(len, iv.len());
+            }
+        }
+
+        let mode = match mode {
+            Mode::Encrypt => 1,
+            Mode::Decrypt => 0,
+        };
+
+        unsafe {
+            cvt(ffi::EVP_CipherInit_ex(
+                self.as_ptr(),
+                type_.map_or(ptr::null(), Cipher::as_ptr),
+                ptr::null_mut(),
+                key.map_or(ptr::null(), |k| k.as_ptr()),
+                iv.map_or(ptr::null(), |iv| iv.as_ptr()),
+                mode,
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    fn assert_cipher(&self) {
+        unsafe {
+            assert!(!EVP_CIPHER_CTX_get0_cipher(self.as_ptr()).is_null());
+        }
+    }
+
+    pub fn block_size(&self) -> Option<usize> {
+        self.assert_cipher();
+
+        unsafe {
+            let r = ffi::EVP_CIPHER_CTX_block_size(self.as_ptr());
+            if r > 0 {
+                Some(r as usize)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn key_length(&self) -> Option<usize> {
+        self.assert_cipher();
+
+        unsafe {
+            let r = ffi::EVP_CIPHER_CTX_key_length(self.as_ptr());
+            if r > 0 {
+                Some(r as usize)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn set_key_length(&mut self, len: usize) -> Result<(), ErrorStack> {
+        self.assert_cipher();
+
+        let len = c_int::try_from(len).unwrap();
+
+        unsafe {
+            cvt(ffi::EVP_CIPHER_CTX_set_key_length(self.as_ptr(), len))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn iv_length(&self) -> Option<usize> {
+        self.assert_cipher();
+
+        unsafe {
+            let r = ffi::EVP_CIPHER_CTX_iv_length(self.as_ptr());
+            if r > 0 {
+                Some(r as usize)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn set_iv_length(&mut self, len: usize) -> Result<(), ErrorStack> {
+        self.assert_cipher();
+
+        let len = c_int::try_from(len).unwrap();
+
+        unsafe {
+            cvt(ffi::EVP_CIPHER_CTX_ctrl(
+                self.as_ptr(),
+                ffi::EVP_CTRL_GCM_SET_IVLEN,
+                len,
+                ptr::null_mut(),
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn tag_length(&self) -> Option<usize> {
+        self.assert_cipher();
+
+        unsafe {
+            let r = ffi::EVP_CIPHER_CTX_tag_length(self.as_ptr());
+            if r > 0 {
+                Some(r as usize)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn tag(&self, tag: &mut [u8]) -> Result<(), ErrorStack> {
+        let len = c_int::try_from(tag.len()).unwrap();
+
+        unsafe {
+            cvt(ffi::EVP_CIPHER_CTX_ctrl(
+                self.as_ptr(),
+                ffi::EVP_CTRL_GCM_GET_TAG,
+                len,
+                tag.as_mut_ptr() as *mut _,
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn set_tag_length(&mut self, len: usize) -> Result<(), ErrorStack> {
+        let len = c_int::try_from(len).unwrap();
+
+        unsafe {
+            cvt(ffi::EVP_CIPHER_CTX_ctrl(
+                self.as_ptr(),
+                ffi::EVP_CTRL_GCM_SET_TAG,
+                len,
+                ptr::null_mut(),
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn set_tag(&mut self, tag: &[u8]) -> Result<(), ErrorStack> {
+        let len = c_int::try_from(tag.len()).unwrap();
+
+        unsafe {
+            cvt(ffi::EVP_CIPHER_CTX_ctrl(
+                self.as_ptr(),
+                ffi::EVP_CTRL_GCM_SET_TAG,
+                len,
+                tag.as_ptr() as *mut _,
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn set_padding(&mut self, padding: bool) {
+        unsafe {
+            ffi::EVP_CIPHER_CTX_set_padding(self.as_ptr(), padding as c_int);
+        }
+    }
+
+    pub fn set_data_len(&mut self, len: usize) -> Result<(), ErrorStack> {
+        let len = c_int::try_from(len).unwrap();
+
+        unsafe {
+            cvt(ffi::EVP_CipherUpdate(
+                self.as_ptr(),
+                ptr::null_mut(),
+                &mut 0,
+                ptr::null(),
+                len,
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn update(&mut self, input: &[u8], output: Option<&mut [u8]>) -> Result<usize, ErrorStack> {
+        let inlen = c_int::try_from(input.len()).unwrap();
+
+        if let (Some(mut block_size), Some(output)) = (self.block_size(), &output) {
+            if block_size == 1 {
+                block_size = 0;
+            }
+            assert!(output.len() >= input.len() + block_size);
+        }
+
+        let mut outlen = 0;
+        unsafe {
+            cvt(ffi::EVP_CipherUpdate(
+                self.as_ptr(),
+                output.map_or(ptr::null_mut(), |b| b.as_mut_ptr()),
+                &mut outlen,
+                input.as_ptr(),
+                inlen,
+            ))?;
+        }
+
+        Ok(outlen as usize)
+    }
+
+    pub fn finalize(&mut self, output: &mut [u8]) -> Result<usize, ErrorStack> {
+        if let Some(block_size) = self.block_size() {
+            if block_size > 1 {
+                assert!(output.len() >= block_size);
+            }
+        }
+
+        let mut outl = 0;
+        unsafe {
+            cvt(ffi::EVP_CipherFinal(
+                self.as_ptr(),
+                output.as_mut_ptr(),
+                &mut outl,
+            ))?;
+        }
+
+        Ok(outl as usize)
+    }
+}

--- a/openssl/src/envelope.rs
+++ b/openssl/src/envelope.rs
@@ -21,19 +21,14 @@
 //! enc_len += seal.finalize(&mut encrypted[enc_len..]).unwrap();
 //! encrypted.truncate(enc_len);
 //! ```
+use crate::cipher_ctx::CipherCtx;
 use crate::error::ErrorStack;
 use crate::pkey::{HasPrivate, HasPublic, PKey, PKeyRef};
 use crate::symm::Cipher;
-use crate::{cvt, cvt_p};
-use foreign_types::{ForeignType, ForeignTypeRef};
-use libc::c_int;
-use std::cmp;
-use std::ptr;
 
 /// Represents an EVP_Seal context.
 pub struct Seal {
-    ctx: *mut ffi::EVP_CIPHER_CTX,
-    block_size: usize,
+    ctx: CipherCtx,
     iv: Option<Vec<u8>>,
     enc_keys: Vec<Vec<u8>>,
 }
@@ -44,45 +39,13 @@ impl Seal {
     where
         T: HasPublic,
     {
-        unsafe {
-            assert!(pub_keys.len() <= c_int::max_value() as usize);
+        let mut iv = cipher.iv_len().map(|len| vec![0; len]);
+        let mut enc_keys = vec![vec![]; pub_keys.len()];
 
-            let ctx = cvt_p(ffi::EVP_CIPHER_CTX_new())?;
-            let mut enc_key_ptrs = vec![];
-            let mut pub_key_ptrs = vec![];
-            let mut enc_keys = vec![];
-            for key in pub_keys {
-                let mut enc_key = vec![0; key.size()];
-                let enc_key_ptr = enc_key.as_mut_ptr();
-                enc_keys.push(enc_key);
-                enc_key_ptrs.push(enc_key_ptr);
-                pub_key_ptrs.push(key.as_ptr());
-            }
-            let mut iv = cipher.iv_len().map(|len| vec![0; len]);
-            let iv_ptr = iv.as_mut().map_or(ptr::null_mut(), |v| v.as_mut_ptr());
-            let mut enc_key_lens = vec![0; enc_keys.len()];
+        let mut ctx = CipherCtx::new()?;
+        ctx.seal_init(Some(&cipher), pub_keys, &mut enc_keys, iv.as_deref_mut())?;
 
-            cvt(ffi::EVP_SealInit(
-                ctx,
-                cipher.as_ptr(),
-                enc_key_ptrs.as_mut_ptr(),
-                enc_key_lens.as_mut_ptr(),
-                iv_ptr,
-                pub_key_ptrs.as_mut_ptr(),
-                pub_key_ptrs.len() as c_int,
-            ))?;
-
-            for (buf, len) in enc_keys.iter_mut().zip(&enc_key_lens) {
-                buf.truncate(*len as usize);
-            }
-
-            Ok(Seal {
-                ctx,
-                block_size: cipher.block_size(),
-                iv,
-                enc_keys,
-            })
-        }
+        Ok(Seal { ctx, iv, enc_keys })
     }
 
     /// Returns the initialization vector, if the cipher uses one.
@@ -107,20 +70,7 @@ impl Seal {
     /// the block size of the cipher (see `Cipher::block_size`), or if
     /// `output.len() > c_int::max_value()`.
     pub fn update(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize, ErrorStack> {
-        unsafe {
-            assert!(output.len() >= input.len() + self.block_size);
-            assert!(output.len() <= c_int::max_value() as usize);
-            let mut outl = output.len() as c_int;
-            let inl = input.len() as c_int;
-            cvt(ffi::EVP_EncryptUpdate(
-                self.ctx,
-                output.as_mut_ptr(),
-                &mut outl,
-                input.as_ptr(),
-                inl,
-            ))?;
-            Ok(outl as usize)
-        }
+        self.ctx.update(input, Some(output))
     }
 
     /// Finishes the encryption process, writing any remaining data to `output`.
@@ -133,29 +83,13 @@ impl Seal {
     ///
     /// Panics if `output` is less than the cipher's block size.
     pub fn finalize(&mut self, output: &mut [u8]) -> Result<usize, ErrorStack> {
-        unsafe {
-            assert!(output.len() >= self.block_size);
-            let mut outl = cmp::min(output.len(), c_int::max_value() as usize) as c_int;
-
-            cvt(ffi::EVP_SealFinal(self.ctx, output.as_mut_ptr(), &mut outl))?;
-
-            Ok(outl as usize)
-        }
-    }
-}
-
-impl Drop for Seal {
-    fn drop(&mut self) {
-        unsafe {
-            ffi::EVP_CIPHER_CTX_free(self.ctx);
-        }
+        self.ctx.finalize(output)
     }
 }
 
 /// Represents an EVP_Open context.
 pub struct Open {
-    ctx: *mut ffi::EVP_CIPHER_CTX,
-    block_size: usize,
+    ctx: CipherCtx,
 }
 
 impl Open {
@@ -169,29 +103,10 @@ impl Open {
     where
         T: HasPrivate,
     {
-        unsafe {
-            assert!(encrypted_key.len() <= c_int::max_value() as usize);
-            match (cipher.iv_len(), iv) {
-                (Some(len), Some(iv)) => assert_eq!(len, iv.len(), "IV length mismatch"),
-                (None, None) => {}
-                (Some(_), None) => panic!("an IV was required but not provided"),
-                (None, Some(_)) => panic!("an IV was provided but not required"),
-            }
+        let mut ctx = CipherCtx::new()?;
+        ctx.open_init(Some(&cipher), encrypted_key, iv, Some(priv_key))?;
 
-            let ctx = cvt_p(ffi::EVP_CIPHER_CTX_new())?;
-            cvt(ffi::EVP_OpenInit(
-                ctx,
-                cipher.as_ptr(),
-                encrypted_key.as_ptr(),
-                encrypted_key.len() as c_int,
-                iv.map_or(ptr::null(), |v| v.as_ptr()),
-                priv_key.as_ptr(),
-            ))?;
-            Ok(Open {
-                ctx,
-                block_size: cipher.block_size(),
-            })
-        }
+        Ok(Open { ctx })
     }
 
     /// Feeds data from `input` through the cipher, writing decrypted bytes into `output`.
@@ -205,20 +120,7 @@ impl Open {
     /// `block_size` is the block size of the cipher (see `Cipher::block_size`),
     /// or if `output.len() > c_int::max_value()`.
     pub fn update(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize, ErrorStack> {
-        unsafe {
-            assert!(output.len() >= input.len() + self.block_size);
-            assert!(output.len() <= c_int::max_value() as usize);
-            let mut outl = output.len() as c_int;
-            let inl = input.len() as c_int;
-            cvt(ffi::EVP_DecryptUpdate(
-                self.ctx,
-                output.as_mut_ptr(),
-                &mut outl,
-                input.as_ptr(),
-                inl,
-            ))?;
-            Ok(outl as usize)
-        }
+        self.ctx.update(input, Some(output))
     }
 
     /// Finishes the decryption process, writing any remaining data to `output`.
@@ -231,22 +133,7 @@ impl Open {
     ///
     /// Panics if `output` is less than the cipher's block size.
     pub fn finalize(&mut self, output: &mut [u8]) -> Result<usize, ErrorStack> {
-        unsafe {
-            assert!(output.len() >= self.block_size);
-            let mut outl = cmp::min(output.len(), c_int::max_value() as usize) as c_int;
-
-            cvt(ffi::EVP_OpenFinal(self.ctx, output.as_mut_ptr(), &mut outl))?;
-
-            Ok(outl as usize)
-        }
-    }
-}
-
-impl Drop for Open {
-    fn drop(&mut self) {
-        unsafe {
-            ffi::EVP_CIPHER_CTX_free(self.ctx);
-        }
+        self.ctx.finalize(output)
     }
 }
 

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -151,6 +151,8 @@ pub mod ex_data;
 #[cfg(not(any(libressl, ossl300)))]
 pub mod fips;
 pub mod hash;
+#[cfg(ossl300)]
+pub mod lib_ctx;
 pub mod memcmp;
 pub mod nid;
 #[cfg(not(osslconf = "OPENSSL_NO_OCSP"))]

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -134,6 +134,7 @@ pub mod aes;
 pub mod asn1;
 pub mod base64;
 pub mod bn;
+pub mod cipher;
 pub mod cipher_ctx;
 #[cfg(all(not(libressl), not(osslconf = "OPENSSL_NO_CMS")))]
 pub mod cms;

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -134,6 +134,7 @@ pub mod aes;
 pub mod asn1;
 pub mod base64;
 pub mod bn;
+pub mod cipher_ctx;
 #[cfg(all(not(libressl), not(osslconf = "OPENSSL_NO_CMS")))]
 pub mod cms;
 pub mod conf;

--- a/openssl/src/lib_ctx.rs
+++ b/openssl/src/lib_ctx.rs
@@ -1,0 +1,20 @@
+use crate::cvt_p;
+use crate::error::ErrorStack;
+use foreign_types::ForeignType;
+
+foreign_type_and_impl_send_sync! {
+    type CType = ffi::OSSL_LIB_CTX;
+    fn drop = ffi::OSSL_LIB_CTX_free;
+
+    pub struct LibCtx;
+    pub struct LibCtxRef;
+}
+
+impl LibCtx {
+    pub fn new() -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::OSSL_LIB_CTX_new())?;
+            Ok(LibCtx::from_ptr(ptr))
+        }
+    }
+}

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -451,7 +451,7 @@ impl Crypter {
         iv: Option<&[u8]>,
     ) -> Result<Crypter, ErrorStack> {
         let mut ctx = CipherCtx::new()?;
-        ctx.init(Some(&t), None, None, mode)?;
+        ctx.cipher_init(Some(&t), None, None, mode)?;
 
         ctx.set_key_length(key.len())?;
 
@@ -459,7 +459,7 @@ impl Crypter {
             ctx.set_iv_length(iv.len())?;
         }
 
-        ctx.init(None, Some(key), iv, mode)?;
+        ctx.cipher_init(None, Some(key), iv, mode)?;
 
         Ok(Crypter { ctx })
     }

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -469,7 +469,9 @@ impl Crypter {
         ctx.set_key_length(key.len())?;
 
         if let Some(iv) = iv {
-            ctx.set_iv_length(iv.len())?;
+            if t.iv_len().unwrap_or(0) != iv.len() {
+                ctx.set_iv_length(iv.len())?;
+            }
         }
 
         f(&mut ctx, None, Some(key), iv)?;
@@ -1104,17 +1106,6 @@ mod tests {
 
     #[test]
     #[cfg_attr(ossl300, ignore)]
-    fn test_bf_ecb() {
-        let pt = "5CD54CA83DEF57DA";
-        let ct = "B1B8CC0B250F09A0";
-        let key = "0131D9619DC1376E";
-        let iv = "0000000000000000";
-
-        cipher_test_nopad(super::Cipher::bf_ecb(), pt, ct, key, iv);
-    }
-
-    #[test]
-    #[cfg_attr(ossl300, ignore)]
     fn test_bf_cfb64() {
         let pt = "37363534333231204E6F77206973207468652074696D6520666F722000";
         let ct = "E73214A2822139CAF26ECF6D2EB9E76E3DA3DE04D1517200519D57A6C3";
@@ -1144,27 +1135,6 @@ mod tests {
         let iv = "0001020304050607";
 
         cipher_test(super::Cipher::des_cbc(), pt, ct, key, iv);
-    }
-
-    #[test]
-    #[cfg_attr(ossl300, ignore)]
-    fn test_des_ecb() {
-        let pt = "54686973206973206120746573742e";
-        let ct = "0050ab8aecec758843fe157b4dde938c";
-        let key = "7cb66337f3d3c0fe";
-        let iv = "0001020304050607";
-
-        cipher_test(super::Cipher::des_ecb(), pt, ct, key, iv);
-    }
-
-    #[test]
-    fn test_des_ede3() {
-        let pt = "9994f4c69d40ae4f34ff403b5cf39d4c8207ea5d3e19a5fd";
-        let ct = "9e5c4297d60582f81071ac8ab7d0698d4c79de8b94c519858207ea5d3e19a5fd";
-        let key = "010203040506070801020304050607080102030405060708";
-        let iv = "5cc118306dc702e4";
-
-        cipher_test(super::Cipher::des_ede3(), pt, ct, key, iv);
     }
 
     #[test]
@@ -1468,16 +1438,7 @@ mod tests {
 
         cipher_test(super::Cipher::seed_cfb128(), pt, ct, key, iv);
     }
-    #[test]
-    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
-    fn test_seed_ecb() {
-        let pt = "5363686f6b6f6c6164656e6b756368656e0a";
-        let ct = "0263a9cd498cf0edb0ef72a3231761d00ce601f7d08ad19ad74f0815f2c77f7e";
-        let key = "41414141414141414141414141414141";
-        let iv = "41414141414141414141414141414141";
 
-        cipher_test(super::Cipher::seed_ecb(), pt, ct, key, iv);
-    }
     #[test]
     #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
     fn test_seed_ofb() {

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -735,6 +735,8 @@ cfg_if! {
     if #[cfg(any(ossl110, libressl273))] {
         use ffi::{EVP_CIPHER_block_size, EVP_CIPHER_iv_length, EVP_CIPHER_key_length};
     } else {
+        use libc::c_int;
+
         #[allow(bad_style)]
         pub unsafe fn EVP_CIPHER_iv_length(ptr: *const ffi::EVP_CIPHER) -> c_int {
             (*ptr).iv_len

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -51,15 +51,10 @@
 //! assert_eq!("Foo bar", output_string);
 //! println!("Decrypted: '{}'", output_string);
 //! ```
-
-use cfg_if::cfg_if;
-use libc::c_int;
-use std::cmp;
-use std::ptr;
-
+use crate::cipher_ctx::CipherCtx;
 use crate::error::ErrorStack;
 use crate::nid::Nid;
-use crate::{cvt, cvt_p};
+use cfg_if::cfg_if;
 
 #[derive(Copy, Clone)]
 pub enum Mode {
@@ -438,12 +433,8 @@ unsafe impl Send for Cipher {}
 /// assert_eq!(b"Some Stream of Crypto Text", &plaintext[..]);
 /// ```
 pub struct Crypter {
-    ctx: *mut ffi::EVP_CIPHER_CTX,
-    block_size: usize,
+    ctx: CipherCtx,
 }
-
-unsafe impl Sync for Crypter {}
-unsafe impl Send for Crypter {}
 
 impl Crypter {
     /// Creates a new `Crypter`.  The initialisation vector, `iv`, is not necessary for certain
@@ -459,63 +450,18 @@ impl Crypter {
         key: &[u8],
         iv: Option<&[u8]>,
     ) -> Result<Crypter, ErrorStack> {
-        ffi::init();
+        let mut ctx = CipherCtx::new()?;
+        ctx.init(Some(&t), None, None, mode)?;
 
-        unsafe {
-            let ctx = cvt_p(ffi::EVP_CIPHER_CTX_new())?;
-            let crypter = Crypter {
-                ctx,
-                block_size: t.block_size(),
-            };
+        ctx.set_key_length(key.len())?;
 
-            let mode = match mode {
-                Mode::Encrypt => 1,
-                Mode::Decrypt => 0,
-            };
-
-            cvt(ffi::EVP_CipherInit_ex(
-                crypter.ctx,
-                t.as_ptr(),
-                ptr::null_mut(),
-                ptr::null_mut(),
-                ptr::null_mut(),
-                mode,
-            ))?;
-
-            assert!(key.len() <= c_int::max_value() as usize);
-            cvt(ffi::EVP_CIPHER_CTX_set_key_length(
-                crypter.ctx,
-                key.len() as c_int,
-            ))?;
-
-            let key = key.as_ptr() as *mut _;
-            let iv = match (iv, t.iv_len()) {
-                (Some(iv), Some(len)) => {
-                    if iv.len() != len {
-                        assert!(iv.len() <= c_int::max_value() as usize);
-                        cvt(ffi::EVP_CIPHER_CTX_ctrl(
-                            crypter.ctx,
-                            ffi::EVP_CTRL_GCM_SET_IVLEN,
-                            iv.len() as c_int,
-                            ptr::null_mut(),
-                        ))?;
-                    }
-                    iv.as_ptr() as *mut _
-                }
-                (Some(_), None) | (None, None) => ptr::null_mut(),
-                (None, Some(_)) => panic!("an IV is required for this cipher"),
-            };
-            cvt(ffi::EVP_CipherInit_ex(
-                crypter.ctx,
-                ptr::null(),
-                ptr::null_mut(),
-                key,
-                iv,
-                mode,
-            ))?;
-
-            Ok(crypter)
+        if let Some(iv) = iv {
+            ctx.set_iv_length(iv.len())?;
         }
+
+        ctx.init(None, Some(key), iv, mode)?;
+
+        Ok(Crypter { ctx })
     }
 
     /// Enables or disables padding.
@@ -523,26 +469,14 @@ impl Crypter {
     /// If padding is disabled, total amount of data encrypted/decrypted must
     /// be a multiple of the cipher's block size.
     pub fn pad(&mut self, padding: bool) {
-        unsafe {
-            ffi::EVP_CIPHER_CTX_set_padding(self.ctx, padding as c_int);
-        }
+        self.ctx.set_padding(padding)
     }
 
     /// Sets the tag used to authenticate ciphertext in AEAD ciphers such as AES GCM.
     ///
     /// When decrypting cipher text using an AEAD cipher, this must be called before `finalize`.
     pub fn set_tag(&mut self, tag: &[u8]) -> Result<(), ErrorStack> {
-        unsafe {
-            assert!(tag.len() <= c_int::max_value() as usize);
-            // NB: this constant is actually more general than just GCM.
-            cvt(ffi::EVP_CIPHER_CTX_ctrl(
-                self.ctx,
-                ffi::EVP_CTRL_GCM_SET_TAG,
-                tag.len() as c_int,
-                tag.as_ptr() as *mut _,
-            ))
-            .map(|_| ())
-        }
+        self.ctx.set_tag(tag)
     }
 
     /// Sets the length of the authentication tag to generate in AES CCM.
@@ -550,17 +484,7 @@ impl Crypter {
     /// When encrypting with AES CCM, the tag length needs to be explicitly set in order
     /// to use a value different than the default 12 bytes.
     pub fn set_tag_len(&mut self, tag_len: usize) -> Result<(), ErrorStack> {
-        unsafe {
-            assert!(tag_len <= c_int::max_value() as usize);
-            // NB: this constant is actually more general than just GCM.
-            cvt(ffi::EVP_CIPHER_CTX_ctrl(
-                self.ctx,
-                ffi::EVP_CTRL_GCM_SET_TAG,
-                tag_len as c_int,
-                ptr::null_mut(),
-            ))
-            .map(|_| ())
-        }
+        self.ctx.set_tag_length(tag_len)
     }
 
     /// Feeds total plaintext length to the cipher.
@@ -568,18 +492,7 @@ impl Crypter {
     /// The total plaintext or ciphertext length MUST be passed to the cipher when it operates in
     /// CCM mode.
     pub fn set_data_len(&mut self, data_len: usize) -> Result<(), ErrorStack> {
-        unsafe {
-            assert!(data_len <= c_int::max_value() as usize);
-            let mut len = 0;
-            cvt(ffi::EVP_CipherUpdate(
-                self.ctx,
-                ptr::null_mut(),
-                &mut len,
-                ptr::null_mut(),
-                data_len as c_int,
-            ))
-            .map(|_| ())
-        }
+        self.ctx.set_data_len(data_len)
     }
 
     /// Feeds Additional Authenticated Data (AAD) through the cipher.
@@ -588,18 +501,8 @@ impl Crypter {
     /// is factored into the authentication tag. It must be called before the first call to
     /// `update`.
     pub fn aad_update(&mut self, input: &[u8]) -> Result<(), ErrorStack> {
-        unsafe {
-            assert!(input.len() <= c_int::max_value() as usize);
-            let mut len = 0;
-            cvt(ffi::EVP_CipherUpdate(
-                self.ctx,
-                ptr::null_mut(),
-                &mut len,
-                input.as_ptr(),
-                input.len() as c_int,
-            ))
-            .map(|_| ())
-        }
+        self.ctx.update(input, None)?;
+        Ok(())
     }
 
     /// Feeds data from `input` through the cipher, writing encrypted/decrypted
@@ -617,27 +520,7 @@ impl Crypter {
     ///
     /// Panics if `output.len() > c_int::max_value()`.
     pub fn update(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize, ErrorStack> {
-        unsafe {
-            let block_size = if self.block_size > 1 {
-                self.block_size
-            } else {
-                0
-            };
-            assert!(output.len() >= input.len() + block_size);
-            assert!(output.len() <= c_int::max_value() as usize);
-            let mut outl = output.len() as c_int;
-            let inl = input.len() as c_int;
-
-            cvt(ffi::EVP_CipherUpdate(
-                self.ctx,
-                output.as_mut_ptr(),
-                &mut outl,
-                input.as_ptr(),
-                inl,
-            ))?;
-
-            Ok(outl as usize)
-        }
+        self.ctx.update(input, Some(output))
     }
 
     /// Finishes the encryption/decryption process, writing any remaining data
@@ -652,20 +535,7 @@ impl Crypter {
     /// Panics for block ciphers if `output.len() < block_size`,
     /// where `block_size` is the block size of the cipher (see `Cipher::block_size`).
     pub fn finalize(&mut self, output: &mut [u8]) -> Result<usize, ErrorStack> {
-        unsafe {
-            if self.block_size > 1 {
-                assert!(output.len() >= self.block_size);
-            }
-            let mut outl = cmp::min(output.len(), c_int::max_value() as usize) as c_int;
-
-            cvt(ffi::EVP_CipherFinal(
-                self.ctx,
-                output.as_mut_ptr(),
-                &mut outl,
-            ))?;
-
-            Ok(outl as usize)
-        }
+        self.ctx.finalize(output)
     }
 
     /// Retrieves the authentication tag used to authenticate ciphertext in AEAD ciphers such
@@ -677,24 +547,7 @@ impl Crypter {
     /// range of tag sizes, it is recommended to pick the maximum size. For AES GCM, this is 16
     /// bytes, for example.
     pub fn get_tag(&self, tag: &mut [u8]) -> Result<(), ErrorStack> {
-        unsafe {
-            assert!(tag.len() <= c_int::max_value() as usize);
-            cvt(ffi::EVP_CIPHER_CTX_ctrl(
-                self.ctx,
-                ffi::EVP_CTRL_GCM_GET_TAG,
-                tag.len() as c_int,
-                tag.as_mut_ptr() as *mut _,
-            ))
-            .map(|_| ())
-        }
-    }
-}
-
-impl Drop for Crypter {
-    fn drop(&mut self) {
-        unsafe {
-            ffi::EVP_CIPHER_CTX_free(self.ctx);
-        }
+        self.ctx.tag(tag)
     }
 }
 

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -468,8 +468,8 @@ impl Crypter {
 
         ctx.set_key_length(key.len())?;
 
-        if let Some(iv) = iv {
-            if t.iv_len().unwrap_or(0) != iv.len() {
+        if let (Some(iv), Some(iv_len)) = (iv, t.iv_len()) {
+            if iv.len() != iv_len {
                 ctx.set_iv_length(iv.len())?;
             }
         }
@@ -1108,6 +1108,17 @@ mod tests {
 
     #[test]
     #[cfg_attr(ossl300, ignore)]
+    fn test_bf_ecb() {
+        let pt = "5CD54CA83DEF57DA";
+        let ct = "B1B8CC0B250F09A0";
+        let key = "0131D9619DC1376E";
+        let iv = "0000000000000000";
+
+        cipher_test_nopad(super::Cipher::bf_ecb(), pt, ct, key, iv);
+    }
+
+    #[test]
+    #[cfg_attr(ossl300, ignore)]
     fn test_bf_cfb64() {
         let pt = "37363534333231204E6F77206973207468652074696D6520666F722000";
         let ct = "E73214A2822139CAF26ECF6D2EB9E76E3DA3DE04D1517200519D57A6C3";
@@ -1137,6 +1148,27 @@ mod tests {
         let iv = "0001020304050607";
 
         cipher_test(super::Cipher::des_cbc(), pt, ct, key, iv);
+    }
+
+    #[test]
+    #[cfg_attr(ossl300, ignore)]
+    fn test_des_ecb() {
+        let pt = "54686973206973206120746573742e";
+        let ct = "0050ab8aecec758843fe157b4dde938c";
+        let key = "7cb66337f3d3c0fe";
+        let iv = "0001020304050607";
+
+        cipher_test(super::Cipher::des_ecb(), pt, ct, key, iv);
+    }
+
+    #[test]
+    fn test_des_ede3() {
+        let pt = "9994f4c69d40ae4f34ff403b5cf39d4c8207ea5d3e19a5fd";
+        let ct = "9e5c4297d60582f81071ac8ab7d0698d4c79de8b94c519858207ea5d3e19a5fd";
+        let key = "010203040506070801020304050607080102030405060708";
+        let iv = "5cc118306dc702e4";
+
+        cipher_test(super::Cipher::des_ede3(), pt, ct, key, iv);
     }
 
     #[test]
@@ -1439,6 +1471,17 @@ mod tests {
         let iv = "41414141414141414141414141414141";
 
         cipher_test(super::Cipher::seed_cfb128(), pt, ct, key, iv);
+    }
+
+    #[test]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
+    fn test_seed_ecb() {
+        let pt = "5363686f6b6f6c6164656e6b756368656e0a";
+        let ct = "0263a9cd498cf0edb0ef72a3231761d00ce601f7d08ad19ad74f0815f2c77f7e";
+        let key = "41414141414141414141414141414141";
+        let iv = "41414141414141414141414141414141";
+
+        cipher_test(super::Cipher::seed_ecb(), pt, ct, key, iv);
     }
 
     #[test]


### PR DESCRIPTION
This provides much more direct bindings to EVP_CIPHER_CTX. The existing `symm` and `seal` modules are now implemented on top of this module, and will be deprecated/removed in the future.