### PR TITLE
Use a macro to reference the OpenSSL function a method calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: sfackler/actions/rustup@master
         with:
-          version: 1.46.0
+          version: 1.48.0
       - run: echo "::set-output name=version::$(rustc --version)"
         id: rust-version
       - uses: actions/cache@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "openssl",
     "openssl-errors",
+    "openssl-macros",
     "openssl-sys",
     "systest",
 ]

--- a/openssl-macros/Cargo.toml
+++ b/openssl-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "openssl-macros"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["full"] }

--- a/openssl-macros/src/lib.rs
+++ b/openssl-macros/src/lib.rs
@@ -9,9 +9,8 @@ pub fn corresponds(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
 
     let function = function.to_string();
-    let line1 = format!("This corresponds to [`{}`].", function);
-    let line2 = format!(
-        "[`{0}`]: https://www.openssl.org/docs/manmaster/man3/{0}.html",
+    let line = format!(
+        "This corresponds to [`{0}`](https://www.openssl.org/docs/manmaster/man3/{0}.html).",
         function
     );
 
@@ -23,9 +22,7 @@ pub fn corresponds(attr: TokenStream, item: TokenStream) -> TokenStream {
     let out = quote! {
         #(#attrs)*
         #[doc = ""]
-        #[doc = #line1]
-        #[doc = ""]
-        #[doc = #line2]
+        #[doc = #line]
         #[doc(alias = #function)]
         #vis #sig #block
     };

--- a/openssl-macros/src/lib.rs
+++ b/openssl-macros/src/lib.rs
@@ -1,0 +1,33 @@
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
+
+#[proc_macro_attribute]
+pub fn corresponds(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let function = parse_macro_input!(attr as Ident);
+    let item = parse_macro_input!(item as ItemFn);
+
+    let function = function.to_string();
+    let line1 = format!("This corresponds to [`{}`].", function);
+    let line2 = format!(
+        "[`{0}`]: https://www.openssl.org/docs/manmaster/man3/{0}.html",
+        function
+    );
+
+    let attrs = item.attrs;
+    let vis = item.vis;
+    let sig = item.sig;
+    let block = item.block;
+
+    let out = quote! {
+        #(#attrs)*
+        #[doc = ""]
+        #[doc = #line1]
+        #[doc = ""]
+        #[doc = #line2]
+        #[doc(alias = #function)]
+        #vis #sig #block
+    };
+    out.into()
+}

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -26,6 +26,7 @@ foreign-types = "0.3.1"
 libc = "0.2"
 once_cell = "1.5.2"
 
+openssl-macros = { path = "../openssl-macros" }
 ffi = { package = "openssl-sys", version = "0.9.69", path = "../openssl-sys" }
 
 [dev-dependencies]

--- a/openssl/src/aes.rs
+++ b/openssl/src/aes.rs
@@ -60,6 +60,7 @@ use std::mem::MaybeUninit;
 use std::ptr;
 
 use crate::symm::Mode;
+use openssl_macros::corresponds;
 
 /// Provides Error handling for parsing keys.
 #[derive(Debug)]
@@ -74,6 +75,7 @@ impl AesKey {
     /// # Failure
     ///
     /// Returns an error if the key is not 128, 192, or 256 bits.
+    #[corresponds(AES_set_encrypt_key)]
     pub fn new_encrypt(key: &[u8]) -> Result<AesKey, KeyError> {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize / 8);
@@ -97,6 +99,7 @@ impl AesKey {
     /// # Failure
     ///
     /// Returns an error if the key is not 128, 192, or 256 bits.
+    #[corresponds(AES_set_decrypt_key)]
     pub fn new_decrypt(key: &[u8]) -> Result<AesKey, KeyError> {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize / 8);
@@ -135,6 +138,7 @@ impl AesKey {
 ///
 /// Panics if `in_` is not the same length as `out`, if that length is not a multiple of 16, or if
 /// `iv` is not at least 32 bytes.
+#[corresponds(AES_ige_encrypt)]
 pub fn aes_ige(in_: &[u8], out: &mut [u8], key: &AesKey, iv: &mut [u8], mode: Mode) {
     unsafe {
         assert!(in_.len() == out.len());
@@ -169,6 +173,7 @@ pub fn aes_ige(in_: &[u8], out: &mut [u8], key: &AesKey, iv: &mut [u8], mode: Mo
 ///
 /// Panics if either `out` or `in_` do not have sizes that are a multiple of 8, or if
 /// `out` is not 8 bytes longer than `in_`
+#[corresponds(AES_wrap_key)]
 pub fn wrap_key(
     key: &AesKey,
     iv: Option<[u8; 8]>,
@@ -207,6 +212,7 @@ pub fn wrap_key(
 ///
 /// Panics if either `out` or `in_` do not have sizes that are a multiple of 8, or
 /// if `in_` is not 8 bytes longer than `out`
+#[corresponds(AES_unwrap_key)]
 pub fn unwrap_key(
     key: &AesKey,
     iv: Option<[u8; 8]>,

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -41,6 +41,7 @@ use crate::error::ErrorStack;
 use crate::nid::Nid;
 use crate::string::OpensslString;
 use crate::{cvt, cvt_p};
+use openssl_macros::corresponds;
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_GENERALIZEDTIME;
@@ -196,10 +197,7 @@ foreign_type_and_impl_send_sync! {
 
 impl Asn1TimeRef {
     /// Find difference between two times
-    ///
-    /// This corresponds to [`ASN1_TIME_diff`].
-    ///
-    /// [`ASN1_TIME_diff`]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_TIME_diff.html
+    #[corresponds(ASN1_TIME_diff)]
     #[cfg(ossl102)]
     pub fn diff(&self, compare: &Self) -> Result<TimeDiff, ErrorStack> {
         let mut days = 0;
@@ -215,12 +213,7 @@ impl Asn1TimeRef {
     }
 
     /// Compare two times
-    ///
-    /// This corresponds to [`ASN1_TIME_compare`] but is implemented using [`diff`] so that it is
-    /// also supported on older versions of OpenSSL.
-    ///
-    /// [`ASN1_TIME_compare`]: https://www.openssl.org/docs/man1.1.1/man3/ASN1_TIME_compare.html
-    /// [`diff`]: struct.Asn1TimeRef.html#method.diff
+    #[corresponds(ASN1_TIME_compare)]
     #[cfg(ossl102)]
     pub fn compare(&self, other: &Self) -> Result<Ordering, ErrorStack> {
         let d = self.diff(other)?;
@@ -306,6 +299,7 @@ impl fmt::Debug for Asn1TimeRef {
 }
 
 impl Asn1Time {
+    #[corresponds(ASN1_TIME_new)]
     fn new() -> Result<Asn1Time, ErrorStack> {
         ffi::init();
 
@@ -315,6 +309,7 @@ impl Asn1Time {
         }
     }
 
+    #[corresponds(X509_gmtime_adj)]
     fn from_period(period: c_long) -> Result<Asn1Time, ErrorStack> {
         ffi::init();
 
@@ -330,6 +325,7 @@ impl Asn1Time {
     }
 
     /// Creates a new time from the specified `time_t` value
+    #[corresponds(ASN1_TIME_set)]
     pub fn from_unix(time: time_t) -> Result<Asn1Time, ErrorStack> {
         ffi::init();
 
@@ -340,10 +336,7 @@ impl Asn1Time {
     }
 
     /// Creates a new time corresponding to the specified ASN1 time string.
-    ///
-    /// This corresponds to [`ASN1_TIME_set_string`].
-    ///
-    /// [`ASN1_TIME_set_string`]: https://www.openssl.org/docs/manmaster/man3/ASN1_TIME_set_string.html
+    #[corresponds(ASN1_TIME_set_string)]
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Result<Asn1Time, ErrorStack> {
         unsafe {
@@ -358,11 +351,8 @@ impl Asn1Time {
 
     /// Creates a new time corresponding to the specified X509 time string.
     ///
-    /// This corresponds to [`ASN1_TIME_set_string_X509`].
-    ///
     /// Requires OpenSSL 1.1.1 or newer.
-    ///
-    /// [`ASN1_TIME_set_string_X509`]: https://www.openssl.org/docs/manmaster/man3/ASN1_TIME_set_string.html
+    #[corresponds(ASN1_TIME_set_string_X509)]
     #[cfg(ossl111)]
     pub fn from_str_x509(s: &str) -> Result<Asn1Time, ErrorStack> {
         unsafe {
@@ -435,9 +425,7 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [ASN1_STRING-to_UTF8]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_STRING_to_UTF8.html
     pub struct Asn1String;
-    /// Reference to [`Asn1String`]
-    ///
-    /// [`Asn1String`]: struct.Asn1String.html
+    /// A reference to an [`Asn1String`].
     pub struct Asn1StringRef;
 }
 
@@ -447,6 +435,7 @@ impl Asn1StringRef {
     /// ASN.1 strings may utilize UTF-16, ASCII, BMP, or UTF8.  This is important to
     /// consume the string in a meaningful way without knowing the underlying
     /// format.
+    #[corresponds(ASN1_STRING_to_UTF8)]
     pub fn as_utf8(&self) -> Result<OpensslString, ErrorStack> {
         unsafe {
             let mut ptr = ptr::null_mut();
@@ -465,11 +454,13 @@ impl Asn1StringRef {
     /// strings in rust, it is preferable to use [`as_utf8`]
     ///
     /// [`as_utf8`]: struct.Asn1String.html#method.as_utf8
+    #[corresponds(ASN1_STRING_get0_data)]
     pub fn as_slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(ASN1_STRING_get0_data(self.as_ptr()), self.len()) }
     }
 
     /// Returns the number of bytes in the string.
+    #[corresponds(ASN1_STRING_length)]
     pub fn len(&self) -> usize {
         unsafe { ffi::ASN1_STRING_length(self.as_ptr()) as usize }
     }
@@ -503,9 +494,7 @@ foreign_type_and_impl_send_sync! {
     /// [`bn`]: ../bn/index.html
     /// [`ASN1_INTEGER_set`]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_INTEGER_set.html
     pub struct Asn1Integer;
-    /// Reference to [`Asn1Integer`]
-    ///
-    /// [`Asn1Integer`]: struct.Asn1Integer.html
+    /// A reference to an [`Asn1Integer`].
     pub struct Asn1IntegerRef;
 }
 
@@ -530,10 +519,7 @@ impl Asn1IntegerRef {
     }
 
     /// Converts the integer to a `BigNum`.
-    ///
-    /// This corresponds to [`ASN1_INTEGER_to_BN`].
-    ///
-    /// [`ASN1_INTEGER_to_BN`]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_INTEGER_get.html
+    #[corresponds(ASN1_INTEGER_to_BN)]
     pub fn to_bn(&self) -> Result<BigNum, ErrorStack> {
         unsafe {
             cvt_p(ffi::ASN1_INTEGER_to_BN(self.as_ptr(), ptr::null_mut()))
@@ -544,10 +530,8 @@ impl Asn1IntegerRef {
     /// Sets the ASN.1 value to the value of a signed 32-bit integer, for larger numbers
     /// see [`bn`].
     ///
-    /// OpenSSL documentation at [`ASN1_INTEGER_set`]
-    ///
     /// [`bn`]: ../bn/struct.BigNumRef.html#method.to_asn1_integer
-    /// [`ASN1_INTEGER_set`]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_INTEGER_set.html
+    #[corresponds(ASN1_INTEGER_set)]
     pub fn set(&mut self, value: i32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::ASN1_INTEGER_set(self.as_ptr(), value as c_long)).map(|_| ()) }
     }
@@ -563,19 +547,19 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [`x509`]: ../x509/struct.X509.html#method.signature
     pub struct Asn1BitString;
-    /// Reference to [`Asn1BitString`]
-    ///
-    /// [`Asn1BitString`]: struct.Asn1BitString.html
+    /// A reference to an [`Asn1BitString`].
     pub struct Asn1BitStringRef;
 }
 
 impl Asn1BitStringRef {
     /// Returns the Asn1BitString as a slice.
+    #[corresponds(ASN1_STRING_get0_data)]
     pub fn as_slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(ASN1_STRING_get0_data(self.as_ptr() as *mut _), self.len()) }
     }
 
     /// Returns the number of bytes in the string.
+    #[corresponds(ASN1_STRING_length)]
     pub fn len(&self) -> usize {
         unsafe { ffi::ASN1_STRING_length(self.as_ptr() as *const _) as usize }
     }
@@ -604,19 +588,13 @@ foreign_type_and_impl_send_sync! {
     /// [`nid::COMMONNAME`]: ../nid/constant.COMMONNAME.html
     /// [`OBJ_nid2obj`]: https://www.openssl.org/docs/man1.1.0/crypto/OBJ_obj2nid.html
     pub struct Asn1Object;
-    /// Reference to [`Asn1Object`]
-    ///
-    /// [`Asn1Object`]: struct.Asn1Object.html
+    /// A reference to an [`Asn1Object`].
     pub struct Asn1ObjectRef;
 }
 
 impl Asn1Object {
-    /// Constructs an ASN.1 Object Identifier from a string representation of
-    /// the OID.
-    ///
-    /// This corresponds to [`OBJ_txt2obj`].
-    ///
-    /// [`OBJ_txt2obj`]: https://www.openssl.org/docs/man1.1.0/man3/OBJ_txt2obj.html
+    /// Constructs an ASN.1 Object Identifier from a string representation of the OID.
+    #[corresponds(OBJ_txt2obj)]
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(txt: &str) -> Result<Asn1Object, ErrorStack> {
         unsafe {
@@ -630,11 +608,8 @@ impl Asn1Object {
     /// Return the OID as an DER encoded array of bytes. This is the ASN.1
     /// value, not including tag or length.
     ///
-    /// This corresponds to [`OBJ_get0_data`].
-    ///
     /// Requires OpenSSL 1.1.1 or newer.
-    ///
-    /// [`OBJ_get0_data`]: https://www.openssl.org/docs/man1.1.0/man3/OBJ_get0_data.html
+    #[corresponds(OBJ_get0_data)]
     #[cfg(ossl111)]
     pub fn as_slice(&self) -> &[u8] {
         unsafe {

--- a/openssl/src/base64.rs
+++ b/openssl/src/base64.rs
@@ -2,16 +2,14 @@
 use crate::cvt_n;
 use crate::error::ErrorStack;
 use libc::c_int;
+use openssl_macros::corresponds;
 
 /// Encodes a slice of bytes to a base64 string.
-///
-/// This corresponds to [`EVP_EncodeBlock`].
 ///
 /// # Panics
 ///
 /// Panics if the input length or computed output length overflow a signed C integer.
-///
-/// [`EVP_EncodeBlock`]: https://www.openssl.org/docs/man1.1.1/man3/EVP_DecodeBlock.html
+#[corresponds(EVP_EncodeBlock)]
 pub fn encode_block(src: &[u8]) -> String {
     assert!(src.len() <= c_int::max_value() as usize);
     let src_len = src.len() as c_int;
@@ -32,13 +30,10 @@ pub fn encode_block(src: &[u8]) -> String {
 
 /// Decodes a base64-encoded string to bytes.
 ///
-/// This corresponds to [`EVP_DecodeBlock`].
-///
 /// # Panics
 ///
 /// Panics if the input length or computed output length overflow a signed C integer.
-///
-/// [`EVP_DecodeBlock`]: https://www.openssl.org/docs/man1.1.1/man3/EVP_DecodeBlock.html
+#[corresponds(EVP_DecodeBlock)]
 pub fn decode_block(src: &str) -> Result<Vec<u8>, ErrorStack> {
     let src = src.trim();
 

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -34,6 +34,7 @@ use crate::asn1::Asn1Integer;
 use crate::error::ErrorStack;
 use crate::string::OpensslString;
 use crate::{cvt, cvt_n, cvt_p};
+use openssl_macros::corresponds;
 
 cfg_if! {
     if #[cfg(ossl110)] {
@@ -98,10 +99,7 @@ foreign_type_and_impl_send_sync! {
 
 impl BigNumContext {
     /// Returns a new `BigNumContext`.
-    ///
-    /// See OpenSSL documentation at [`BN_CTX_new`].
-    ///
-    /// [`BN_CTX_new`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_CTX_new.html
+    #[corresponds(BN_CTX_new)]
     pub fn new() -> Result<BigNumContext, ErrorStack> {
         unsafe {
             ffi::init();
@@ -110,10 +108,7 @@ impl BigNumContext {
     }
 
     /// Returns a new secure `BigNumContext`.
-    ///
-    /// See OpenSSL documentation at [`BN_CTX_secure_new`].
-    ///
-    /// [`BN_CTX_secure_new`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_CTX_secure_new.html
+    #[corresponds(BN_CTX_secure_new)]
     #[cfg(ossl110)]
     pub fn new_secure() -> Result<BigNumContext, ErrorStack> {
         unsafe {
@@ -161,46 +156,31 @@ impl BigNumRef {
     /// Erases the memory used by this `BigNum`, resetting its value to 0.
     ///
     /// This can be used to destroy sensitive data such as keys when they are no longer needed.
-    ///
-    /// OpenSSL documentation at [`BN_clear`]
-    ///
-    /// [`BN_clear`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_clear.html
+    #[corresponds(BN_clear)]
     pub fn clear(&mut self) {
         unsafe { ffi::BN_clear(self.as_ptr()) }
     }
 
     /// Adds a `u32` to `self`.
-    ///
-    /// OpenSSL documentation at [`BN_add_word`]
-    ///
-    /// [`BN_add_word`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_add_word.html
+    #[corresponds(BN_add_word)]
     pub fn add_word(&mut self, w: u32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_add_word(self.as_ptr(), w as ffi::BN_ULONG)).map(|_| ()) }
     }
 
     /// Subtracts a `u32` from `self`.
-    ///
-    /// OpenSSL documentation at [`BN_sub_word`]
-    ///
-    /// [`BN_sub_word`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_sub_word.html
+    #[corresponds(BN_sub_word)]
     pub fn sub_word(&mut self, w: u32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_sub_word(self.as_ptr(), w as ffi::BN_ULONG)).map(|_| ()) }
     }
 
     /// Multiplies a `u32` by `self`.
-    ///
-    /// OpenSSL documentation at [`BN_mul_word`]
-    ///
-    /// [`BN_mul_word`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_mul_word.html
+    #[corresponds(BN_mul_word)]
     pub fn mul_word(&mut self, w: u32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_mul_word(self.as_ptr(), w as ffi::BN_ULONG)).map(|_| ()) }
     }
 
     /// Divides `self` by a `u32`, returning the remainder.
-    ///
-    /// OpenSSL documentation at [`BN_div_word`]
-    ///
-    /// [`BN_div_word`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_div_word.html
+    #[corresponds(BN_div_word)]
     #[allow(clippy::useless_conversion)]
     pub fn div_word(&mut self, w: u32) -> Result<u64, ErrorStack> {
         unsafe {
@@ -214,10 +194,7 @@ impl BigNumRef {
     }
 
     /// Returns the result of `self` modulo `w`.
-    ///
-    /// OpenSSL documentation at [`BN_mod_word`]
-    ///
-    /// [`BN_mod_word`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_mod_word.html
+    #[corresponds(BN_mod_word)]
     #[allow(clippy::useless_conversion)]
     pub fn mod_word(&self, w: u32) -> Result<u64, ErrorStack> {
         unsafe {
@@ -232,19 +209,13 @@ impl BigNumRef {
 
     /// Places a cryptographically-secure pseudo-random nonnegative
     /// number less than `self` in `rnd`.
-    ///
-    /// OpenSSL documentation at [`BN_rand_range`]
-    ///
-    /// [`BN_rand_range`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_rand_range.html
+    #[corresponds(BN_rand_range)]
     pub fn rand_range(&self, rnd: &mut BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_rand_range(rnd.as_ptr(), self.as_ptr())).map(|_| ()) }
     }
 
     /// The cryptographically weak counterpart to `rand_in_range`.
-    ///
-    /// OpenSSL documentation at [`BN_pseudo_rand_range`]
-    ///
-    /// [`BN_pseudo_rand_range`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_pseudo_rand_range.html
+    #[corresponds(BN_pseudo_rand_range)]
     pub fn pseudo_rand_range(&self, rnd: &mut BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_pseudo_rand_range(rnd.as_ptr(), self.as_ptr())).map(|_| ()) }
     }
@@ -252,10 +223,7 @@ impl BigNumRef {
     /// Sets bit `n`. Equivalent to `self |= (1 << n)`.
     ///
     /// When setting a bit outside of `self`, it is expanded.
-    ///
-    /// OpenSSL documentation at [`BN_set_bit`]
-    ///
-    /// [`BN_set_bit`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_set_bit.html
+    #[corresponds(BN_set_bit)]
     #[allow(clippy::useless_conversion)]
     pub fn set_bit(&mut self, n: i32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_set_bit(self.as_ptr(), n.into())).map(|_| ()) }
@@ -264,20 +232,14 @@ impl BigNumRef {
     /// Clears bit `n`, setting it to 0. Equivalent to `self &= ~(1 << n)`.
     ///
     /// When clearing a bit outside of `self`, an error is returned.
-    ///
-    /// OpenSSL documentation at [`BN_clear_bit`]
-    ///
-    /// [`BN_clear_bit`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_clear_bit.html
+    #[corresponds(BN_clear_bit)]
     #[allow(clippy::useless_conversion)]
     pub fn clear_bit(&mut self, n: i32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_clear_bit(self.as_ptr(), n.into())).map(|_| ()) }
     }
 
     /// Returns `true` if the `n`th bit of `self` is set to 1, `false` otherwise.
-    ///
-    /// OpenSSL documentation at [`BN_is_bit_set`]
-    ///
-    /// [`BN_is_bit_set`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_is_bit_set.html
+    #[corresponds(BN_is_bit_set)]
     #[allow(clippy::useless_conversion)]
     pub fn is_bit_set(&self, n: i32) -> bool {
         unsafe { ffi::BN_is_bit_set(self.as_ptr(), n.into()) == 1 }
@@ -286,93 +248,68 @@ impl BigNumRef {
     /// Truncates `self` to the lowest `n` bits.
     ///
     /// An error occurs if `self` is already shorter than `n` bits.
-    ///
-    /// OpenSSL documentation at [`BN_mask_bits`]
-    ///
-    /// [`BN_mask_bits`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_mask_bits.html
+    #[corresponds(BN_mask_bits)]
     #[allow(clippy::useless_conversion)]
     pub fn mask_bits(&mut self, n: i32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_mask_bits(self.as_ptr(), n.into())).map(|_| ()) }
     }
 
     /// Places `a << 1` in `self`.  Equivalent to `self * 2`.
-    ///
-    /// OpenSSL documentation at [`BN_lshift1`]
-    ///
-    /// [`BN_lshift1`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_lshift1.html
+    #[corresponds(BN_lshift1)]
     pub fn lshift1(&mut self, a: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_lshift1(self.as_ptr(), a.as_ptr())).map(|_| ()) }
     }
 
     /// Places `a >> 1` in `self`. Equivalent to `self / 2`.
-    ///
-    /// OpenSSL documentation at [`BN_rshift1`]
-    ///
-    /// [`BN_rshift1`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_rshift1.html
+    #[corresponds(BN_rshift1)]
     pub fn rshift1(&mut self, a: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_rshift1(self.as_ptr(), a.as_ptr())).map(|_| ()) }
     }
 
     /// Places `a + b` in `self`.  [`core::ops::Add`] is also implemented for `BigNumRef`.
     ///
-    /// OpenSSL documentation at [`BN_add`]
-    ///
     /// [`core::ops::Add`]: struct.BigNumRef.html#method.add
-    /// [`BN_add`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_add.html
+    #[corresponds(BN_add)]
     pub fn checked_add(&mut self, a: &BigNumRef, b: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_add(self.as_ptr(), a.as_ptr(), b.as_ptr())).map(|_| ()) }
     }
 
     /// Places `a - b` in `self`. [`core::ops::Sub`] is also implemented for `BigNumRef`.
     ///
-    /// OpenSSL documentation at [`BN_sub`]
-    ///
     /// [`core::ops::Sub`]: struct.BigNumRef.html#method.sub
-    /// [`BN_sub`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_sub.html
+    #[corresponds(BN_sub)]
     pub fn checked_sub(&mut self, a: &BigNumRef, b: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_sub(self.as_ptr(), a.as_ptr(), b.as_ptr())).map(|_| ()) }
     }
 
     /// Places `a << n` in `self`.  Equivalent to `a * 2 ^ n`.
-    ///
-    /// OpenSSL documentation at [`BN_lshift`]
-    ///
-    /// [`BN_lshift`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_lshift.html
+    #[corresponds(BN_lshift)]
     #[allow(clippy::useless_conversion)]
     pub fn lshift(&mut self, a: &BigNumRef, n: i32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_lshift(self.as_ptr(), a.as_ptr(), n.into())).map(|_| ()) }
     }
 
     /// Places `a >> n` in `self`. Equivalent to `a / 2 ^ n`.
-    ///
-    /// OpenSSL documentation at [`BN_rshift`]
-    ///
-    /// [`BN_rshift`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_rshift.html
+    #[corresponds(BN_rshift)]
     #[allow(clippy::useless_conversion)]
     pub fn rshift(&mut self, a: &BigNumRef, n: i32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_rshift(self.as_ptr(), a.as_ptr(), n.into())).map(|_| ()) }
     }
 
     /// Creates a new BigNum with the same value.
-    ///
-    /// OpenSSL documentation at [`BN_dup`]
-    ///
-    /// [`BN_dup`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_dup.html
+    #[corresponds(BN_dup)]
     pub fn to_owned(&self) -> Result<BigNum, ErrorStack> {
         unsafe { cvt_p(ffi::BN_dup(self.as_ptr())).map(|b| BigNum::from_ptr(b)) }
     }
 
     /// Sets the sign of `self`.  Pass true to set `self` to a negative.  False sets
     /// `self` positive.
+    #[corresponds(BN_set_negative)]
     pub fn set_negative(&mut self, negative: bool) {
         unsafe { ffi::BN_set_negative(self.as_ptr(), negative as c_int) }
     }
 
     /// Compare the absolute values of `self` and `oth`.
-    ///
-    /// OpenSSL documentation at [`BN_ucmp`]
-    ///
-    /// [`BN_ucmp`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_ucmp.html
     ///
     /// # Examples
     ///
@@ -384,20 +321,19 @@ impl BigNumRef {
     ///
     /// assert_eq!(s.ucmp(&o), Ordering::Equal);
     /// ```
+    #[corresponds(BN_ucmp)]
     pub fn ucmp(&self, oth: &BigNumRef) -> Ordering {
         unsafe { ffi::BN_ucmp(self.as_ptr(), oth.as_ptr()).cmp(&0) }
     }
 
     /// Returns `true` if `self` is negative.
+    #[corresponds(BN_is_negative)]
     pub fn is_negative(&self) -> bool {
         unsafe { BN_is_negative(self.as_ptr()) == 1 }
     }
 
     /// Returns the number of significant bits in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_num_bits`]
-    ///
-    /// [`BN_num_bits`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_num_bits.html
+    #[corresponds(BN_num_bits)]
     pub fn num_bits(&self) -> i32 {
         unsafe { ffi::BN_num_bits(self.as_ptr()) as i32 }
     }
@@ -430,10 +366,8 @@ impl BigNumRef {
     /// }
     /// ```
     ///
-    /// OpenSSL documentation at [`BN_rand`]
-    ///
     /// [`constants`]: index.html#constants
-    /// [`BN_rand`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_rand.html
+    #[corresponds(BN_rand)]
     #[allow(clippy::useless_conversion)]
     pub fn rand(&mut self, bits: i32, msb: MsbOption, odd: bool) -> Result<(), ErrorStack> {
         unsafe {
@@ -448,10 +382,7 @@ impl BigNumRef {
     }
 
     /// The cryptographically weak counterpart to `rand`.  Not suitable for key generation.
-    ///
-    /// OpenSSL documentation at [`BN_psuedo_rand`]
-    ///
-    /// [`BN_psuedo_rand`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_pseudo_rand.html
+    #[corresponds(BN_pseudo_rand)]
     #[allow(clippy::useless_conversion)]
     pub fn pseudo_rand(&mut self, bits: i32, msb: MsbOption, odd: bool) -> Result<(), ErrorStack> {
         unsafe {
@@ -488,10 +419,7 @@ impl BigNumRef {
     ///    Ok((big))
     /// }
     /// ```
-    ///
-    /// OpenSSL documentation at [`BN_generate_prime_ex`]
-    ///
-    /// [`BN_generate_prime_ex`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_generate_prime_ex.html
+    #[corresponds(BN_generate_prime_ex)]
     pub fn generate_prime(
         &mut self,
         bits: i32,
@@ -515,10 +443,8 @@ impl BigNumRef {
     /// Places the result of `a * b` in `self`.
     /// [`core::ops::Mul`] is also implemented for `BigNumRef`.
     ///
-    /// OpenSSL documentation at [`BN_mul`]
-    ///
     /// [`core::ops::Mul`]: struct.BigNumRef.html#method.mul
-    /// [`BN_mul`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_mul.html
+    #[corresponds(BN_mul)]
     pub fn checked_mul(
         &mut self,
         a: &BigNumRef,
@@ -539,10 +465,8 @@ impl BigNumRef {
     /// Places the result of `a / b` in `self`. The remainder is discarded.
     /// [`core::ops::Div`] is also implemented for `BigNumRef`.
     ///
-    /// OpenSSL documentation at [`BN_div`]
-    ///
     /// [`core::ops::Div`]: struct.BigNumRef.html#method.div
-    /// [`BN_div`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_div.html
+    #[corresponds(BN_div)]
     pub fn checked_div(
         &mut self,
         a: &BigNumRef,
@@ -562,10 +486,7 @@ impl BigNumRef {
     }
 
     /// Places the result of `a % b` in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_div`]
-    ///
-    /// [`BN_div`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_div.html
+    #[corresponds(BN_div)]
     pub fn checked_rem(
         &mut self,
         a: &BigNumRef,
@@ -585,10 +506,7 @@ impl BigNumRef {
     }
 
     /// Places the result of `a / b` in `self` and `a % b` in `rem`.
-    ///
-    /// OpenSSL documentation at [`BN_div`]
-    ///
-    /// [`BN_div`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_div.html
+    #[corresponds(BN_div)]
     pub fn div_rem(
         &mut self,
         rem: &mut BigNumRef,
@@ -609,20 +527,14 @@ impl BigNumRef {
     }
 
     /// Places the result of `a²` in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_sqr`]
-    ///
-    /// [`BN_sqr`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_sqr.html
+    #[corresponds(BN_sqr)]
     pub fn sqr(&mut self, a: &BigNumRef, ctx: &mut BigNumContextRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_sqr(self.as_ptr(), a.as_ptr(), ctx.as_ptr())).map(|_| ()) }
     }
 
     /// Places the result of `a mod m` in `self`.  As opposed to `div_rem`
     /// the result is non-negative.
-    ///
-    /// OpenSSL documentation at [`BN_nnmod`]
-    ///
-    /// [`BN_nnmod`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_nnmod.html
+    #[corresponds(BN_nnmod)]
     pub fn nnmod(
         &mut self,
         a: &BigNumRef,
@@ -641,10 +553,7 @@ impl BigNumRef {
     }
 
     /// Places the result of `(a + b) mod m` in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_mod_add`]
-    ///
-    /// [`BN_mod_add`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_mod_add.html
+    #[corresponds(BN_mod_add)]
     pub fn mod_add(
         &mut self,
         a: &BigNumRef,
@@ -665,10 +574,7 @@ impl BigNumRef {
     }
 
     /// Places the result of `(a - b) mod m` in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_mod_sub`]
-    ///
-    /// [`BN_mod_sub`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_mod_sub.html
+    #[corresponds(BN_mod_sub)]
     pub fn mod_sub(
         &mut self,
         a: &BigNumRef,
@@ -689,10 +595,7 @@ impl BigNumRef {
     }
 
     /// Places the result of `(a * b) mod m` in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_mod_mul`]
-    ///
-    /// [`BN_mod_mul`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_mod_mul.html
+    #[corresponds(BN_mod_mul)]
     pub fn mod_mul(
         &mut self,
         a: &BigNumRef,
@@ -713,10 +616,7 @@ impl BigNumRef {
     }
 
     /// Places the result of `a² mod m` in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_mod_sqr`]
-    ///
-    /// [`BN_mod_sqr`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_mod_sqr.html
+    #[corresponds(BN_mod_sqr)]
     pub fn mod_sqr(
         &mut self,
         a: &BigNumRef,
@@ -735,10 +635,7 @@ impl BigNumRef {
     }
 
     /// Places the result of `a^p` in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_exp`]
-    ///
-    /// [`BN_exp`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_exp.html
+    #[corresponds(BN_exp)]
     pub fn exp(
         &mut self,
         a: &BigNumRef,
@@ -757,10 +654,7 @@ impl BigNumRef {
     }
 
     /// Places the result of `a^p mod m` in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_mod_exp`]
-    ///
-    /// [`BN_mod_exp`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_mod_exp.html
+    #[corresponds(BN_mod_exp)]
     pub fn mod_exp(
         &mut self,
         a: &BigNumRef,
@@ -781,6 +675,7 @@ impl BigNumRef {
     }
 
     /// Places the inverse of `a` modulo `n` in `self`.
+    #[corresponds(BN_mod_inverse)]
     pub fn mod_inverse(
         &mut self,
         a: &BigNumRef,
@@ -799,10 +694,7 @@ impl BigNumRef {
     }
 
     /// Places the greatest common denominator of `a` and `b` in `self`.
-    ///
-    /// OpenSSL documentation at [`BN_gcd`]
-    ///
-    /// [`BN_gcd`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_gcd.html
+    #[corresponds(BN_gcd)]
     pub fn gcd(
         &mut self,
         a: &BigNumRef,
@@ -824,13 +716,10 @@ impl BigNumRef {
     ///
     /// Performs a Miller-Rabin probabilistic primality test with `checks` iterations.
     ///
-    /// OpenSSL documentation at [`BN_is_prime_ex`]
-    ///
-    /// [`BN_is_prime_ex`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_is_prime_ex.html
-    ///
     /// # Return Value
     ///
     /// Returns `true` if `self` is prime with an error probability of less than `0.25 ^ checks`.
+    #[corresponds(BN_is_prime_ex)]
     #[allow(clippy::useless_conversion)]
     pub fn is_prime(&self, checks: i32, ctx: &mut BigNumContextRef) -> Result<bool, ErrorStack> {
         unsafe {
@@ -850,13 +739,10 @@ impl BigNumRef {
     /// Then, like `is_prime`, performs a Miller-Rabin probabilistic primality test with `checks`
     /// iterations.
     ///
-    /// OpenSSL documentation at [`BN_is_prime_fasttest_ex`]
-    ///
-    /// [`BN_is_prime_fasttest_ex`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_is_prime_fasttest_ex.html
-    ///
     /// # Return Value
     ///
     /// Returns `true` if `self` is prime with an error probability of less than `0.25 ^ checks`.
+    #[corresponds(BN_is_prime_fasttest_ex)]
     #[allow(clippy::useless_conversion)]
     pub fn is_prime_fasttest(
         &self,
@@ -888,6 +774,7 @@ impl BigNumRef {
     /// let s_vec = s.to_vec();
     /// assert_eq!(BigNum::from_slice(&s_vec).unwrap(), r);
     /// ```
+    #[corresponds(BN_bn2bin)]
     pub fn to_vec(&self) -> Vec<u8> {
         let size = self.num_bytes() as usize;
         let mut v = Vec::with_capacity(size);
@@ -919,6 +806,7 @@ impl BigNumRef {
     /// let bn_vec = bn.to_vec_padded(4).unwrap();
     /// assert_eq!(&bn_vec, &[0, 0, 0x45, 0x43]);
     /// ```
+    #[corresponds(BN_bn2binpad)]
     #[cfg(ossl110)]
     pub fn to_vec_padded(&self, pad_to: i32) -> Result<Vec<u8>, ErrorStack> {
         let mut v = Vec::with_capacity(pad_to as usize);
@@ -937,6 +825,7 @@ impl BigNumRef {
     ///
     /// assert_eq!(&**s.to_dec_str().unwrap(), "-12345");
     /// ```
+    #[corresponds(BN_bn2dec)]
     pub fn to_dec_str(&self) -> Result<OpensslString, ErrorStack> {
         unsafe {
             let buf = cvt_p(ffi::BN_bn2dec(self.as_ptr()))?;
@@ -952,6 +841,7 @@ impl BigNumRef {
     ///
     /// assert_eq!(&**s.to_hex_str().unwrap(), "-99FF");
     /// ```
+    #[corresponds(BN_bn2hex)]
     pub fn to_hex_str(&self) -> Result<OpensslString, ErrorStack> {
         unsafe {
             let buf = cvt_p(ffi::BN_bn2hex(self.as_ptr()))?;
@@ -960,6 +850,7 @@ impl BigNumRef {
     }
 
     /// Returns an `Asn1Integer` containing the value of `self`.
+    #[corresponds(BN_to_ASN1_INTEGER)]
     pub fn to_asn1_integer(&self) -> Result<Asn1Integer, ErrorStack> {
         unsafe {
             cvt_p(ffi::BN_to_ASN1_INTEGER(self.as_ptr(), ptr::null_mut()))
@@ -968,12 +859,14 @@ impl BigNumRef {
     }
 
     /// Force constant time computation on this value.
+    #[corresponds(BN_set_flags)]
     #[cfg(ossl110)]
     pub fn set_const_time(&mut self) {
         unsafe { ffi::BN_set_flags(self.as_ptr(), ffi::BN_FLG_CONSTTIME) }
     }
 
     /// Returns true if `self` is in const time mode.
+    #[corresponds(BN_get_flags)]
     #[cfg(ossl110)]
     pub fn is_const_time(&self) -> bool {
         unsafe {
@@ -983,6 +876,7 @@ impl BigNumRef {
     }
 
     /// Returns true if `self` was created with [`BigNum::new_secure`].
+    #[corresponds(BN_get_flags)]
     #[cfg(ossl110)]
     pub fn is_secure(&self) -> bool {
         unsafe {
@@ -994,6 +888,7 @@ impl BigNumRef {
 
 impl BigNum {
     /// Creates a new `BigNum` with the value 0.
+    #[corresponds(BN_new)]
     pub fn new() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1003,10 +898,7 @@ impl BigNum {
     }
 
     /// Returns a new secure `BigNum`.
-    ///
-    /// See OpenSSL documentation at [`BN_secure_new`].
-    ///
-    /// [`BN_secure_new`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_secure_new.html
+    #[corresponds(BN_secure_new)]
     #[cfg(ossl110)]
     pub fn new_secure() -> Result<BigNum, ErrorStack> {
         unsafe {
@@ -1017,10 +909,7 @@ impl BigNum {
     }
 
     /// Creates a new `BigNum` with the given value.
-    ///
-    /// OpenSSL documentation at [`BN_set_word`]
-    ///
-    /// [`BN_set_word`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_set_word.html
+    #[corresponds(BN_set_word)]
     pub fn from_u32(n: u32) -> Result<BigNum, ErrorStack> {
         BigNum::new().and_then(|v| unsafe {
             cvt(ffi::BN_set_word(v.as_ptr(), n as ffi::BN_ULONG)).map(|_| v)
@@ -1028,10 +917,7 @@ impl BigNum {
     }
 
     /// Creates a `BigNum` from a decimal string.
-    ///
-    /// OpenSSL documentation at [`BN_dec2bn`]
-    ///
-    /// [`BN_dec2bn`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_dec2bn.html
+    #[corresponds(BN_dec2bn)]
     pub fn from_dec_str(s: &str) -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1043,10 +929,7 @@ impl BigNum {
     }
 
     /// Creates a `BigNum` from a hexadecimal string.
-    ///
-    /// OpenSSL documentation at [`BN_hex2bn`]
-    ///
-    /// [`BN_hex2bn`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_hex2bn.html
+    #[corresponds(BN_hex2bn)]
     pub fn from_hex_str(s: &str) -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1061,10 +944,8 @@ impl BigNum {
     /// the order of magnitude of `2 ^ 768`.  This number is used during calculated key
     /// exchanges such as Diffie-Hellman.  This number is labeled Oakley group id 1.
     ///
-    /// OpenSSL documentation at [`BN_get_rfc2409_prime_768`]
-    ///
     /// [`RFC 2409`]: https://tools.ietf.org/html/rfc2409#page-21
-    /// [`BN_get_rfc2409_prime_768`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_get_rfc2409_prime_768.html
+    #[corresponds(BN_get_rfc2409_prime_768)]
     pub fn get_rfc2409_prime_768() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1076,10 +957,8 @@ impl BigNum {
     /// the order of magnitude of `2 ^ 1024`.  This number is used during calculated key
     /// exchanges such as Diffie-Hellman.  This number is labeled Oakly group 2.
     ///
-    /// OpenSSL documentation at [`BN_get_rfc2409_prime_1024`]
-    ///
     /// [`RFC 2409`]: https://tools.ietf.org/html/rfc2409#page-21
-    /// [`BN_get_rfc2409_prime_1024`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_get_rfc2409_prime_1024.html
+    #[corresponds(BN_get_rfc2409_prime_1024)]
     pub fn get_rfc2409_prime_1024() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1091,10 +970,8 @@ impl BigNum {
     /// of magnitude of `2 ^ 1536`.  This number is used during calculated key
     /// exchanges such as Diffie-Hellman.  This number is labeled MODP group 5.
     ///
-    /// OpenSSL documentation at [`BN_get_rfc3526_prime_1536`]
-    ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-3
-    /// [`BN_get_rfc3526_prime_1536`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_get_rfc3526_prime_1536.html
+    #[corresponds(BN_get_rfc3526_prime_1536)]
     pub fn get_rfc3526_prime_1536() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1106,10 +983,8 @@ impl BigNum {
     /// of magnitude of `2 ^ 2048`.  This number is used during calculated key
     /// exchanges such as Diffie-Hellman.  This number is labeled MODP group 14.
     ///
-    /// OpenSSL documentation at [`BN_get_rfc3526_prime_2048`]
-    ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-3
-    /// [`BN_get_rfc3526_prime_2048`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_get_rfc3526_prime_2048.html
+    #[corresponds(BN_get_rfc3526_prime_2048)]
     pub fn get_rfc3526_prime_2048() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1121,10 +996,8 @@ impl BigNum {
     /// of magnitude of `2 ^ 3072`.  This number is used during calculated key
     /// exchanges such as Diffie-Hellman.  This number is labeled MODP group 15.
     ///
-    /// OpenSSL documentation at [`BN_get_rfc3526_prime_3072`]
-    ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-4
-    /// [`BN_get_rfc3526_prime_3072`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_get_rfc3526_prime_3072.html
+    #[corresponds(BN_get_rfc3526_prime_3072)]
     pub fn get_rfc3526_prime_3072() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1136,10 +1009,8 @@ impl BigNum {
     /// of magnitude of `2 ^ 4096`.  This number is used during calculated key
     /// exchanges such as Diffie-Hellman.  This number is labeled MODP group 16.
     ///
-    /// OpenSSL documentation at [`BN_get_rfc3526_prime_4096`]
-    ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-4
-    /// [`BN_get_rfc3526_prime_4096`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_get_rfc3526_prime_4096.html
+    #[corresponds(BN_get_rfc3526_prime_4096)]
     pub fn get_rfc3526_prime_4096() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1151,10 +1022,8 @@ impl BigNum {
     /// of magnitude of `2 ^ 6144`.  This number is used during calculated key
     /// exchanges such as Diffie-Hellman.  This number is labeled MODP group 17.
     ///
-    /// OpenSSL documentation at [`BN_get_rfc3526_prime_6144`]
-    ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-6
-    /// [`BN_get_rfc3526_prime_6144`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_get_rfc3526_prime_6144.html
+    #[corresponds(BN_get_rfc3526_prime_6114)]
     pub fn get_rfc3526_prime_6144() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1166,10 +1035,8 @@ impl BigNum {
     /// of magnitude of `2 ^ 8192`.  This number is used during calculated key
     /// exchanges such as Diffie-Hellman.  This number is labeled MODP group 18.
     ///
-    /// OpenSSL documentation at [`BN_get_rfc3526_prime_8192`]
-    ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-6
-    /// [`BN_get_rfc3526_prime_8192`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_get_rfc3526_prime_8192.html
+    #[corresponds(BN_get_rfc3526_prime_8192)]
     pub fn get_rfc3526_prime_8192() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1189,6 +1056,7 @@ impl BigNum {
     ///
     /// assert_eq!(bignum, BigNum::from_u32(0x120034).unwrap());
     /// ```
+    #[corresponds(BN_bin2bn)]
     pub fn from_slice(n: &[u8]) -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();

--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -9,6 +9,7 @@ use crate::lib_ctx::LibCtxRef;
 use crate::nid::Nid;
 use cfg_if::cfg_if;
 use foreign_types::{ForeignTypeRef, Opaque};
+use openssl_macros::corresponds;
 #[cfg(ossl300)]
 use std::ffi::CString;
 #[cfg(ossl300)]
@@ -100,10 +101,7 @@ unsafe impl Send for Cipher {}
 
 impl Cipher {
     /// Looks up the cipher for a certain nid.
-    ///
-    /// This corresponds to [`EVP_get_cipherbynid`]
-    ///
-    /// [`EVP_get_cipherbynid`]: https://www.openssl.org/docs/man1.0.2/crypto/EVP_get_cipherbyname.html
+    #[corresponds(EVP_get_cipherbynid)]
     pub fn from_nid(nid: Nid) -> Option<&'static CipherRef> {
         unsafe {
             let ptr = ffi::EVP_get_cipherbyname(ffi::OBJ_nid2sn(nid.as_raw()));
@@ -117,11 +115,8 @@ impl Cipher {
 
     /// Fetches a cipher object corresponding to the specified algorithm name and properties.
     ///
-    /// This corresponds to [`EVP_CIPHER_fetch`].
-    ///
     /// Requires OpenSSL 3.0.0 or newer.
-    ///
-    /// [`EVP_CIPHER_fetch`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_fetch.html
+    #[corresponds(EVP_CIPHER_fetch)]
     #[cfg(ossl300)]
     pub fn fetch(
         ctx: Option<&LibCtxRef>,
@@ -359,16 +354,14 @@ unsafe impl Send for CipherRef {}
 
 impl CipherRef {
     /// Returns the cipher's Nid.
-    ///
-    /// This corresponds to [`EVP_CIPHER_nid`]
-    ///
-    /// [`EVP_CIPHER_nid`]: https://www.openssl.org/docs/man1.0.2/crypto/EVP_CIPHER_nid.html
+    #[corresponds(EVP_CIPHER_nid)]
     pub fn nid(&self) -> Nid {
         let nid = unsafe { ffi::EVP_CIPHER_nid(self.as_ptr()) };
         Nid::from_raw(nid)
     }
 
     /// Returns the length of keys used with this cipher.
+    #[corresponds(EVP_CIPHER_key_length)]
     pub fn key_length(&self) -> usize {
         unsafe { EVP_CIPHER_key_length(self.as_ptr()) as usize }
     }
@@ -378,6 +371,7 @@ impl CipherRef {
     /// # Note
     ///
     /// Ciphers that do not use an IV have an IV length of 0.
+    #[corresponds(EVP_CIPHER_iv_length)]
     pub fn iv_length(&self) -> usize {
         unsafe { EVP_CIPHER_iv_length(self.as_ptr()) as usize }
     }
@@ -387,6 +381,7 @@ impl CipherRef {
     /// # Note
     ///
     /// Stream ciphers have a block size of 1.
+    #[corresponds(EVP_CIPHER_block_size)]
     pub fn block_size(&self) -> usize {
         unsafe { EVP_CIPHER_block_size(self.as_ptr()) as usize }
     }

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -57,6 +57,7 @@ use crate::{cvt, cvt_p};
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_uchar};
+use openssl_macros::corresponds;
 use std::convert::TryFrom;
 use std::ptr;
 
@@ -80,10 +81,7 @@ foreign_type_and_impl_send_sync! {
 
 impl CipherCtx {
     /// Creates a new context.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_new`].
-    ///
-    /// [`EVP_CIPHER_CTX_new`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_new.html
+    #[corresponds(EVP_CIPHER_CTX_new)]
     pub fn new() -> Result<Self, ErrorStack> {
         ffi::init();
 
@@ -105,10 +103,7 @@ impl CipherCtxRef {
     ///
     /// Panics if the key buffer is smaller than the key size of the cipher, the IV buffer is smaller than the IV size
     /// of the cipher, or if a key or IV is provided before a cipher.
-    ///
-    /// This corresponds to [`EVP_EncryptInit_ex`].
-    ///
-    /// [`EVP_EncryptInit_ex`]: https://www.openssl.org/docs/manmaster/man3/EVP_EncryptInit_ex.html
+    #[corresponds(EVP_EncryptInit_ex)]
     pub fn encrypt_init(
         &mut self,
         type_: Option<&CipherRef>,
@@ -128,10 +123,7 @@ impl CipherCtxRef {
     ///
     /// Panics if the key buffer is smaller than the key size of the cipher, the IV buffer is smaller than the IV size
     /// of the cipher, or if a key or IV is provided before a cipher.
-    ///
-    /// This corresponds to [`EVP_EncryptInit_ex`].
-    ///
-    /// [`EVP_EncryptInit_ex`]: https://www.openssl.org/docs/manmaster/man3/EVP_EncryptInit_ex.html
+    #[corresponds(EVP_DecryptInit_ex)]
     pub fn decrypt_init(
         &mut self,
         type_: Option<&CipherRef>,
@@ -189,10 +181,7 @@ impl CipherCtxRef {
     ///
     /// Panics if `pub_keys` is not the same size as `encrypted_keys`, the IV buffer is smaller than the cipher's IV
     /// size, or if an IV is provided before the cipher.
-    ///
-    /// This corresponds to [`EVP_SealInit`].
-    ///
-    /// [`EVP_SealInit`]: https://www.openssl.org/docs/manmaster/man3/EVP_SealInit.html.
+    #[corresponds(EVP_SealInit)]
     pub fn seal_init<T>(
         &mut self,
         type_: Option<&CipherRef>,
@@ -248,10 +237,7 @@ impl CipherCtxRef {
     ///
     /// Panics if the IV buffer is smaller than the cipher's required IV size or if the IV is provided before the
     /// cipher.
-    ///
-    /// This corresponds to [`EVP_OpenInit`].
-    ///
-    /// [`EVP_OpenInit`]: https://www.openssl.org/docs/manmaster/man3/EVP_OpenInit.html
+    #[corresponds(EVP_OpenInit)]
     pub fn open_init<T>(
         &mut self,
         type_: Option<&CipherRef>,
@@ -295,10 +281,7 @@ impl CipherCtxRef {
     /// # Panics
     ///
     /// Panics if the context has not been initialized with a cipher.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_block_size`].
-    ///
-    /// [`EVP_CIPHER_CTX_block_size`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_block_size.html
+    #[corresponds(EVP_CIPHER_CTX_block_size)]
     pub fn block_size(&self) -> usize {
         self.assert_cipher();
 
@@ -310,10 +293,7 @@ impl CipherCtxRef {
     /// # Panics
     ///
     /// Panics if the context has not been initialized with a cipher.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_key_length`].
-    ///
-    /// [`EVP_CIPHER_CTX_key_length`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_key_length.html
+    #[corresponds(EVP_CIPHER_CTX_key_length)]
     pub fn key_length(&self) -> usize {
         self.assert_cipher();
 
@@ -330,6 +310,7 @@ impl CipherCtxRef {
     /// This corresponds to [`EVP_CIPHER_CTX_rand_key`].
     ///
     /// [`EVP_CIPHER_CTX_rand_key`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_rand_key.html
+    #[corresponds(EVP_CIPHER_CTX_rand_key)]
     pub fn rand_key(&self, buf: &mut [u8]) -> Result<(), ErrorStack> {
         assert!(buf.len() >= self.key_length());
 
@@ -350,10 +331,7 @@ impl CipherCtxRef {
     /// # Panics
     ///
     /// Panics if the context has not been initialized with a cipher.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_set_key_length`].
-    ///
-    /// [`EVP_CIPHER_CTX_set_key_length`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_set_key_length.html
+    #[corresponds(EVP_CIPHER_CTX_set_key_length)]
     pub fn set_key_length(&mut self, len: usize) -> Result<(), ErrorStack> {
         self.assert_cipher();
 
@@ -373,10 +351,7 @@ impl CipherCtxRef {
     /// # Panics
     ///
     /// Panics if the context has not been initialized with a cipher.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_iv_length`].
-    ///
-    /// [`EVP_CIPHER_CTX_iv_length`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_iv_length.html
+    #[corresponds(EVP_CIPHER_CTX_iv_length)]
     pub fn iv_length(&self) -> usize {
         self.assert_cipher();
 
@@ -390,10 +365,7 @@ impl CipherCtxRef {
     /// # Panics
     ///
     /// Panics if the context has not been initialized with a cipher.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_ctrl`] with `EVP_CTRL_AEAD_SET_IVLEN`.
-    ///
-    /// [`EVP_CIPHER_CTX_ctrl`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_ctrl.html
+    #[corresponds(EVP_CIHPER_CTX_ctrl)]
     pub fn set_iv_length(&mut self, len: usize) -> Result<(), ErrorStack> {
         self.assert_cipher();
 
@@ -419,11 +391,8 @@ impl CipherCtxRef {
     ///
     /// Panics if the context has not been initialized with a cipher.
     ///
-    /// This corresponds to [`EVP_CIPHER_CTX_tag_length`].
-    ///
     /// Requires OpenSSL 3.0.0 or newer.
-    ///
-    /// [`EVP_CIPHER_CTX_tag_length`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_tag_length.html
+    #[corresponds(EVP_CIPHER_CTX_get_tag_length)]
     #[cfg(ossl300)]
     pub fn tag_length(&self) -> usize {
         self.assert_cipher();
@@ -437,10 +406,7 @@ impl CipherCtxRef {
     ///
     /// The size of the buffer indicates the size of the tag. While some ciphers support a range of tag sizes, it is
     /// recommended to pick the maximum size.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_ctrl`] with `EVP_CTRL_AEAD_GET_TAG`.
-    ///
-    /// [`EVP_CIPHER_CTX_ctrl`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_ctrl.html
+    #[corresponds(EVP_CIPHER_CTX_ctrl)]
     pub fn tag(&self, tag: &mut [u8]) -> Result<(), ErrorStack> {
         let len = c_int::try_from(tag.len()).unwrap();
 
@@ -459,10 +425,7 @@ impl CipherCtxRef {
     /// Sets the length of the generated authentication tag.
     ///
     /// This must be called when encrypting with a cipher in CCM mode to use a tag size other than the default.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_ctrl`] with `EVP_CTRL_AEAD_SET_TAG`.
-    ///
-    /// [`EVP_CIPHER_CTX_ctrl`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_ctrl.html
+    #[corresponds(EVP_CIPHER_CTX_ctrl)]
     pub fn set_tag_length(&mut self, len: usize) -> Result<(), ErrorStack> {
         let len = c_int::try_from(len).unwrap();
 
@@ -479,10 +442,7 @@ impl CipherCtxRef {
     }
 
     /// Sets the authentication tag for verification during decryption.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_ctrl`] with `EVP_CTRL_AEAD_SET_TAG`.
-    ///
-    /// [`EVP_CIPHER_CTX_ctrl`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_ctrl.html
+    #[corresponds(EVP_CIPHER_CTX_ctrl)]
     pub fn set_tag(&mut self, tag: &[u8]) -> Result<(), ErrorStack> {
         let len = c_int::try_from(tag.len()).unwrap();
 
@@ -501,10 +461,7 @@ impl CipherCtxRef {
     /// Enables or disables padding.
     ///
     /// If padding is disabled, the plaintext must be an exact multiple of the cipher's block size.
-    ///
-    /// This corresponds to [`EVP_CIPHER_CTX_set_padding`].
-    ///
-    /// [`EVP_CIPHER_CTX_set_padding`]: https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_set_padding.html
+    #[corresponds(EVP_CIPHER_CTX_set_padding)]
     pub fn set_padding(&mut self, padding: bool) {
         unsafe {
             ffi::EVP_CIPHER_CTX_set_padding(self.as_ptr(), padding as c_int);
@@ -514,10 +471,7 @@ impl CipherCtxRef {
     /// Sets the total length of plaintext data.
     ///
     /// This is required for ciphers operating in CCM mode.
-    ///
-    /// This corresponds to [`EVP_CipherUpdate`].
-    ///
-    /// [`EVP_CipherUpdate`]: https://www.openssl.org/docs/manmaster/man3/EVP_CipherUpdate.html
+    #[corresponds(EVP_CipherUpdate)]
     pub fn set_data_len(&mut self, len: usize) -> Result<(), ErrorStack> {
         let len = c_int::try_from(len).unwrap();
 
@@ -543,10 +497,7 @@ impl CipherCtxRef {
     /// # Panics
     ///
     /// Panics if `output.len()` is less than `input.len()` plus the cipher's block size.
-    ///
-    /// This corresponds to [`EVP_CipherUpdate`].
-    ///
-    /// [`EVP_CipherUpdate`]: https://www.openssl.org/docs/manmaster/man3/EVP_CipherUpdate.html
+    #[corresponds(EVP_CipherUpdate)]
     pub fn cipher_update(
         &mut self,
         input: &[u8],
@@ -599,10 +550,7 @@ impl CipherCtxRef {
     /// # Panics
     ///
     /// Panics if `output` is smaller than the cipher's block size.
-    ///
-    /// This corresponds to [`EVP_CipherFinal`].
-    ///
-    /// [`EVP_CipherFinal`]: https://www.openssl.org/docs/manmaster/man3/EVP_CipherFinal.html
+    #[corresponds(EVP_CipherFinal)]
     pub fn cipher_final(&mut self, output: &mut [u8]) -> Result<usize, ErrorStack> {
         let block_size = self.block_size();
         if block_size > 1 {

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -17,6 +17,7 @@ use crate::stack::StackRef;
 use crate::symm::Cipher;
 use crate::x509::{X509Ref, X509};
 use crate::{cvt, cvt_p};
+use openssl_macros::corresponds;
 
 bitflags! {
     pub struct CMSOptions : c_uint {
@@ -69,10 +70,7 @@ foreign_type_and_impl_send_sync! {
 impl CmsContentInfoRef {
     /// Given the sender's private key, `pkey` and the recipient's certificiate, `cert`,
     /// decrypt the data in `self`.
-    ///
-    /// OpenSSL documentation at [`CMS_decrypt`]
-    ///
-    /// [`CMS_decrypt`]: https://www.openssl.org/docs/man1.1.0/crypto/CMS_decrypt.html
+    #[corresponds(CMS_decrypt)]
     pub fn decrypt<T>(&self, pkey: &PKeyRef<T>, cert: &X509) -> Result<Vec<u8>, ErrorStack>
     where
         T: HasPrivate,
@@ -99,9 +97,7 @@ impl CmsContentInfoRef {
     /// decrypt the data in `self` without validating the recipient certificate.
     ///
     /// *Warning*: Not checking the recipient certificate may leave you vulnerable to Bleichenbacher's attack on PKCS#1 v1.5 RSA padding.
-    /// See [`CMS_decrypt`] for more information.
-    ///
-    /// [`CMS_decrypt`]: https://www.openssl.org/docs/man1.1.0/crypto/CMS_decrypt.html
+    #[corresponds(CMS_decrypt)]
     // FIXME merge into decrypt
     pub fn decrypt_without_cert_check<T>(&self, pkey: &PKeyRef<T>) -> Result<Vec<u8>, ErrorStack>
     where
@@ -126,20 +122,14 @@ impl CmsContentInfoRef {
 
     to_der! {
         /// Serializes this CmsContentInfo using DER.
-        ///
-        /// OpenSSL documentation at [`i2d_CMS_ContentInfo`]
-        ///
-        /// [`i2d_CMS_ContentInfo`]: https://www.openssl.org/docs/man1.0.2/crypto/i2d_CMS_ContentInfo.html
+        #[corresponds(i2d_CMS_ContentInfo)]
         to_der,
         ffi::i2d_CMS_ContentInfo
     }
 
     to_pem! {
         /// Serializes this CmsContentInfo using DER.
-        ///
-        /// OpenSSL documentation at [`PEM_write_bio_CMS`]
-        ///
-        /// [`PEM_write_bio_CMS`]: https://www.openssl.org/docs/man1.1.0/man3/PEM_write_bio_CMS.html
+        #[corresponds(PEM_write_bio_CMS)]
         to_pem,
         ffi::PEM_write_bio_CMS
     }
@@ -147,10 +137,7 @@ impl CmsContentInfoRef {
 
 impl CmsContentInfo {
     /// Parses a smime formatted `vec` of bytes into a `CmsContentInfo`.
-    ///
-    /// OpenSSL documentation at [`SMIME_read_CMS`]
-    ///
-    /// [`SMIME_read_CMS`]: https://www.openssl.org/docs/man1.0.2/crypto/SMIME_read_CMS.html
+    #[corresponds(SMIME_read_CMS)]
     pub fn smime_read_cms(smime: &[u8]) -> Result<CmsContentInfo, ErrorStack> {
         unsafe {
             let bio = MemBioSlice::new(smime)?;
@@ -163,10 +150,7 @@ impl CmsContentInfo {
 
     from_der! {
         /// Deserializes a DER-encoded ContentInfo structure.
-        ///
-        /// This corresponds to [`d2i_CMS_ContentInfo`].
-        ///
-        /// [`d2i_CMS_ContentInfo`]: https://www.openssl.org/docs/manmaster/man3/d2i_X509.html
+        #[corresponds(d2i_CMS_ContentInfo)]
         from_der,
         CmsContentInfo,
         ffi::d2i_CMS_ContentInfo
@@ -174,10 +158,7 @@ impl CmsContentInfo {
 
     from_pem! {
         /// Deserializes a PEM-encoded ContentInfo structure.
-        ///
-        /// This corresponds to [`PEM_read_bio_CMS`].
-        ///
-        /// [`PEM_read_bio_CMS`]: https://www.openssl.org/docs/man1.1.0/man3/PEM_read_bio_CMS.html
+        #[corresponds(PEM_read_bio_CMS)]
         from_pem,
         CmsContentInfo,
         ffi::PEM_read_bio_CMS
@@ -187,10 +168,7 @@ impl CmsContentInfo {
     /// data `data` and flags `flags`, create a CmsContentInfo struct.
     ///
     /// All arguments are optional.
-    ///
-    /// OpenSSL documentation at [`CMS_sign`]
-    ///
-    /// [`CMS_sign`]: https://www.openssl.org/docs/manmaster/man3/CMS_sign.html
+    #[corresponds(CMS_sign)]
     pub fn sign<T>(
         signcert: Option<&X509Ref>,
         pkey: Option<&PKeyRef<T>>,
@@ -229,6 +207,7 @@ impl CmsContentInfo {
     /// OpenSSL documentation at [`CMS_encrypt`]
     ///
     /// [`CMS_encrypt`]: https://www.openssl.org/docs/manmaster/man3/CMS_encrypt.html
+    #[corresponds(CMS_encrypt)]
     pub fn encrypt(
         certs: &StackRef<X509>,
         data: &[u8],

--- a/openssl/src/conf.rs
+++ b/openssl/src/conf.rs
@@ -2,11 +2,13 @@
 
 use crate::cvt_p;
 use crate::error::ErrorStack;
+use openssl_macros::corresponds;
 
 pub struct ConfMethod(*mut ffi::CONF_METHOD);
 
 impl ConfMethod {
     /// Retrieve handle to the default OpenSSL configuration file processing function.
+    #[corresponds(NCONF_default)]
     pub fn default() -> ConfMethod {
         unsafe {
             ffi::init();
@@ -49,6 +51,7 @@ impl Conf {
     ///
     /// let conf = Conf::new(ConfMethod::default());
     /// ```
+    #[corresponds(NCONF_new)]
     pub fn new(method: ConfMethod) -> Result<Conf, ErrorStack> {
         unsafe { cvt_p(ffi::NCONF_new(method.as_ptr())).map(Conf) }
     }

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -7,6 +7,7 @@ use crate::bn::{BigNum, BigNumRef};
 use crate::error::ErrorStack;
 use crate::pkey::{HasParams, HasPrivate, HasPublic, Params, Private};
 use crate::{cvt, cvt_p};
+use openssl_macros::corresponds;
 
 generic_foreign_type_and_impl_send_sync! {
     type CType = ffi::DH;
@@ -25,20 +26,14 @@ where
         /// Serializes the parameters into a PEM-encoded PKCS#3 DHparameter structure.
         ///
         /// The output will have a header of `-----BEGIN DH PARAMETERS-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_DHparams`].
-        ///
-        /// [`PEM_write_bio_DHparams`]: https://www.openssl.org/docs/manmaster/man3/PEM_write_bio_DHparams.html
+        #[corresponds(PEM_write_bio_DHparams)]
         params_to_pem,
         ffi::PEM_write_bio_DHparams
     }
 
     to_der! {
         /// Serializes the parameters into a DER-encoded PKCS#3 DHparameter structure.
-        ///
-        /// This corresponds to [`i2d_DHparams`].
-        ///
-        /// [`i2d_DHparams`]: https://www.openssl.org/docs/man1.1.0/crypto/i2d_DHparams.html
+        #[corresponds(i2d_DHparams)]
         params_to_der,
         ffi::i2d_DHparams
     }
@@ -50,11 +45,7 @@ impl Dh<Params> {
     }
 
     /// Creates a DH instance based upon the given primes and generator params.
-    ///
-    /// This corresponds to [`DH_new`] and [`DH_set0_pqg`].
-    ///
-    /// [`DH_new`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_new.html
-    /// [`DH_set0_pqg`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_set0_pqg.html
+    #[corresponds(DH_set0_pqg)]
     pub fn from_pqg(
         prime_p: BigNum,
         prime_q: Option<BigNum>,
@@ -87,10 +78,7 @@ impl Dh<Params> {
     }
 
     /// Generates DH params based on the given `prime_len` and a fixed `generator` value.
-    ///
-    /// This corresponds to [`DH_generate_parameters_ex`].
-    ///
-    /// [`DH_generate_parameters_ex`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_generate_parameters.html
+    #[corresponds(DH_generate_parameters_ex)]
     pub fn generate_params(prime_len: u32, generator: u32) -> Result<Dh<Params>, ErrorStack> {
         unsafe {
             let dh = Dh::from_ptr(cvt_p(ffi::DH_new())?);
@@ -105,10 +93,7 @@ impl Dh<Params> {
     }
 
     /// Generates a public and a private key based on the DH params.
-    ///
-    /// This corresponds to [`DH_generate_key`].
-    ///
-    /// [`DH_generate_key`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_generate_key.html
+    #[corresponds(DH_generate_key)]
     pub fn generate_key(self) -> Result<Dh<Private>, ErrorStack> {
         unsafe {
             let dh_ptr = self.0;
@@ -122,10 +107,7 @@ impl Dh<Params> {
         /// Deserializes a PEM-encoded PKCS#3 DHpararameters structure.
         ///
         /// The input should have a header of `-----BEGIN DH PARAMETERS-----`.
-        ///
-        /// This corresponds to [`PEM_read_bio_DHparams`].
-        ///
-        /// [`PEM_read_bio_DHparams`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_read_bio_DHparams.html
+        #[corresponds(PEM_read_bio_DHparams)]
         params_from_pem,
         Dh<Params>,
         ffi::PEM_read_bio_DHparams
@@ -133,16 +115,14 @@ impl Dh<Params> {
 
     from_der! {
         /// Deserializes a DER-encoded PKCS#3 DHparameters structure.
-        ///
-        /// This corresponds to [`d2i_DHparams`].
-        ///
-        /// [`d2i_DHparams`]: https://www.openssl.org/docs/man1.1.0/crypto/d2i_DHparams.html
+        #[corresponds(d2i_DHparams)]
         params_from_der,
         Dh<Params>,
         ffi::d2i_DHparams
     }
 
     /// Requires OpenSSL 1.0.2 or newer.
+    #[corresponds(DH_get_1024_160)]
     #[cfg(any(ossl102, ossl110))]
     pub fn get_1024_160() -> Result<Dh<Params>, ErrorStack> {
         unsafe {
@@ -152,6 +132,7 @@ impl Dh<Params> {
     }
 
     /// Requires OpenSSL 1.0.2 or newer.
+    #[corresponds(DH_get_2048_224)]
     #[cfg(any(ossl102, ossl110))]
     pub fn get_2048_224() -> Result<Dh<Params>, ErrorStack> {
         unsafe {
@@ -161,6 +142,7 @@ impl Dh<Params> {
     }
 
     /// Requires OpenSSL 1.0.2 or newer.
+    #[corresponds(DH_get_2048_256)]
     #[cfg(any(ossl102, ossl110))]
     pub fn get_2048_256() -> Result<Dh<Params>, ErrorStack> {
         unsafe {
@@ -175,10 +157,7 @@ where
     T: HasParams,
 {
     /// Returns the prime `p` from the DH instance.
-    ///
-    /// This corresponds to [`DH_get0_pqg`].
-    ///
-    /// [`DH_get0_pqg`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_pqg.html
+    #[corresponds(DH_get0_pqg)]
     pub fn prime_p(&self) -> &BigNumRef {
         let mut p = ptr::null();
         unsafe {
@@ -188,10 +167,7 @@ where
     }
 
     /// Returns the prime `q` from the DH instance.
-    ///
-    /// This corresponds to [`DH_get0_pqg`].
-    ///
-    /// [`DH_get0_pqg`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_pqg.html
+    #[corresponds(DH_get0_pqg)]
     pub fn prime_q(&self) -> Option<&BigNumRef> {
         let mut q = ptr::null();
         unsafe {
@@ -205,10 +181,7 @@ where
     }
 
     /// Returns the generator from the DH instance.
-    ///
-    /// This corresponds to [`DH_get0_pqg`].
-    ///
-    /// [`DH_get0_pqg`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_pqg.html
+    #[corresponds(DH_get0_pqg)]
     pub fn generator(&self) -> &BigNumRef {
         let mut g = ptr::null();
         unsafe {
@@ -223,10 +196,7 @@ where
     T: HasPublic,
 {
     /// Returns the public key from the DH instance.
-    ///
-    /// This corresponds to [`DH_get0_key`].
-    ///
-    /// [`DH_get0_key`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_key.html
+    #[corresponds(DH_get0_key)]
     pub fn public_key(&self) -> &BigNumRef {
         let mut pub_key = ptr::null();
         unsafe {
@@ -241,10 +211,7 @@ where
     T: HasPrivate,
 {
     /// Computes a shared secret from the own private key and the given `public_key`.
-    ///
-    /// This corresponds to [`DH_compute_key`].
-    ///
-    /// [`DH_compute_key`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_compute_key.html
+    #[corresponds(DH_compute_key)]
     pub fn compute_key(&self, public_key: &BigNumRef) -> Result<Vec<u8>, ErrorStack> {
         unsafe {
             let key_len = ffi::DH_size(self.as_ptr());
@@ -259,10 +226,7 @@ where
     }
 
     /// Returns the private key from the DH instance.
-    ///
-    /// This corresponds to [`DH_get0_key`].
-    ///
-    /// [`DH_get0_key`]: https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_key.html
+    #[corresponds(DH_get0_key)]
     pub fn private_key(&self) -> &BigNumRef {
         let mut priv_key = ptr::null();
         unsafe {

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -17,6 +17,7 @@ use crate::error::ErrorStack;
 use crate::pkey::{HasParams, HasPrivate, HasPublic, Private, Public};
 use crate::util::ForeignTypeRefExt;
 use crate::{cvt, cvt_p};
+use openssl_macros::corresponds;
 
 generic_foreign_type_and_impl_send_sync! {
     type CType = ffi::DSA;
@@ -85,25 +86,20 @@ where
         /// Serialies the public key into a PEM-encoded SubjectPublicKeyInfo structure.
         ///
         /// The output will have a header of `-----BEGIN PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_DSA_PUBKEY`].
-        ///
-        /// [`PEM_write_bio_DSA_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_DSA_PUBKEY.html
+        #[corresponds(PEM_write_bio_DSA_PUBKEY)]
         public_key_to_pem,
         ffi::PEM_write_bio_DSA_PUBKEY
     }
 
     to_der! {
         /// Serializes the public key into a DER-encoded SubjectPublicKeyInfo structure.
-        ///
-        /// This corresponds to [`i2d_DSA_PUBKEY`].
-        ///
-        /// [`i2d_DSA_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/i2d_DSA_PUBKEY.html
+        #[corresponds(i2d_DSA_PUBKEY)]
         public_key_to_der,
         ffi::i2d_DSA_PUBKEY
     }
 
     /// Returns a reference to the public key component of `self`.
+    #[corresponds(DSA_get0_key)]
     pub fn pub_key(&self) -> &BigNumRef {
         unsafe {
             let mut pub_key = ptr::null();
@@ -121,23 +117,18 @@ where
         /// Serializes the private key to a PEM-encoded DSAPrivateKey structure.
         ///
         /// The output will have a header of `-----BEGIN DSA PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_DSAPrivateKey`].
-        ///
-        /// [`PEM_write_bio_DSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_DSAPrivateKey.html
+        #[corresponds(PEM_write_bio_DSAPrivateKey)]
         private_key_to_pem,
         /// Serializes the private key to a PEM-encoded encrypted DSAPrivateKey structure.
         ///
         /// The output will have a header of `-----BEGIN DSA PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_DSAPrivateKey`].
-        ///
-        /// [`PEM_write_bio_DSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_DSAPrivateKey.html
+        #[corresponds(PEM_write_bio_DSAPrivateKey)]
         private_key_to_pem_passphrase,
         ffi::PEM_write_bio_DSAPrivateKey
     }
 
     /// Returns a reference to the private key component of `self`.
+    #[corresponds(DSA_get0_key)]
     pub fn priv_key(&self) -> &BigNumRef {
         unsafe {
             let mut priv_key = ptr::null();
@@ -152,15 +143,13 @@ where
     T: HasParams,
 {
     /// Returns the maximum size of the signature output by `self` in bytes.
-    ///
-    /// OpenSSL documentation at [`DSA_size`]
-    ///
-    /// [`DSA_size`]: https://www.openssl.org/docs/man1.1.0/crypto/DSA_size.html
+    #[corresponds(DSA_size)]
     pub fn size(&self) -> u32 {
         unsafe { ffi::DSA_size(self.as_ptr()) as u32 }
     }
 
     /// Returns the DSA prime parameter of `self`.
+    #[corresponds(DSA_get0_pqg)]
     pub fn p(&self) -> &BigNumRef {
         unsafe {
             let mut p = ptr::null();
@@ -170,6 +159,7 @@ where
     }
 
     /// Returns the DSA sub-prime parameter of `self`.
+    #[corresponds(DSA_get0_pqg)]
     pub fn q(&self) -> &BigNumRef {
         unsafe {
             let mut q = ptr::null();
@@ -179,6 +169,7 @@ where
     }
 
     /// Returns the DSA base parameter of `self`.
+    #[corresponds(DSA_get0_pqg)]
     pub fn g(&self) -> &BigNumRef {
         unsafe {
             let mut g = ptr::null();
@@ -245,10 +236,7 @@ impl Dsa<Public> {
         /// Decodes a PEM-encoded SubjectPublicKeyInfo structure containing a DSA key.
         ///
         /// The input should have a header of `-----BEGIN PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_read_bio_DSA_PUBKEY`].
-        ///
-        /// [`PEM_read_bio_DSA_PUBKEY`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_read_bio_DSA_PUBKEY.html
+        #[corresponds(PEM_read_bio_DSA_PUBKEY)]
         public_key_from_pem,
         Dsa<Public>,
         ffi::PEM_read_bio_DSA_PUBKEY
@@ -256,10 +244,7 @@ impl Dsa<Public> {
 
     from_der! {
         /// Decodes a DER-encoded SubjectPublicKeyInfo structure containing a DSA key.
-        ///
-        /// This corresponds to [`d2i_DSA_PUBKEY`].
-        ///
-        /// [`d2i_DSA_PUBKEY`]: https://www.openssl.org/docs/man1.0.2/crypto/d2i_DSA_PUBKEY.html
+        #[corresponds(d2i_DSA_PUBKEY)]
         public_key_from_der,
         Dsa<Public>,
         ffi::d2i_DSA_PUBKEY

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -26,6 +26,7 @@ use crate::nid::Nid;
 use crate::pkey::{HasParams, HasPrivate, HasPublic, Params, Private, Public};
 use crate::util::ForeignTypeRefExt;
 use crate::{cvt, cvt_n, cvt_p, init};
+use openssl_macros::corresponds;
 
 /// Compressed or Uncompressed conversion
 ///
@@ -115,10 +116,7 @@ foreign_type_and_impl_send_sync! {
 
 impl EcGroup {
     /// Returns the group of a standard named curve.
-    ///
-    /// OpenSSL documentation at [`EC_GROUP_new`].
-    ///
-    /// [`EC_GROUP_new`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_GROUP_new.html
+    #[corresponds(EC_GROUP_new_by_curve_name)]
     pub fn from_curve_name(nid: Nid) -> Result<EcGroup, ErrorStack> {
         unsafe {
             init();
@@ -130,10 +128,7 @@ impl EcGroup {
 impl EcGroupRef {
     /// Places the components of a curve over a prime field in the provided `BigNum`s.
     /// The components make up the formula `y^2 mod p = x^3 + ax + b mod p`.
-    ///
-    /// OpenSSL documentation available at [`EC_GROUP_get_curve_GFp`]
-    ///
-    /// [`EC_GROUP_get_curve_GFp`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_GROUP_get_curve_GFp.html
+    #[corresponds(EC_GROUP_get_curve_GFp)]
     pub fn components_gfp(
         &self,
         p: &mut BigNumRef,
@@ -159,10 +154,7 @@ impl EcGroupRef {
     /// In this form `p` relates to the irreducible polynomial.  Each bit represents
     /// a term in the polynomial.  It will be set to 3 `1`s or 5 `1`s depending on
     /// using a trinomial or pentanomial.
-    ///
-    /// OpenSSL documentation at [`EC_GROUP_get_curve_GF2m`].
-    ///
-    /// [`EC_GROUP_get_curve_GF2m`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_GROUP_get_curve_GF2m.html
+    #[corresponds(EC_GROUP_get_curve_GF2m)]
     #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn components_gf2m(
         &self,
@@ -184,10 +176,7 @@ impl EcGroupRef {
     }
 
     /// Places the cofactor of the group in the provided `BigNum`.
-    ///
-    /// OpenSSL documentation at [`EC_GROUP_get_cofactor`]
-    ///
-    /// [`EC_GROUP_get_cofactor`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_GROUP_get_cofactor.html
+    #[corresponds(EC_GROUP_get_cofactor)]
     pub fn cofactor(
         &self,
         cofactor: &mut BigNumRef,
@@ -204,29 +193,20 @@ impl EcGroupRef {
     }
 
     /// Returns the degree of the curve.
-    ///
-    /// OpenSSL documentation at [`EC_GROUP_get_degree`]
-    ///
-    /// [`EC_GROUP_get_degree`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_GROUP_get_degree.html
+    #[corresponds(EC_GROUP_get_degree)]
     pub fn degree(&self) -> u32 {
         unsafe { ffi::EC_GROUP_get_degree(self.as_ptr()) as u32 }
     }
 
     /// Returns the number of bits in the group order.
-    ///
-    /// OpenSSL documentation at [`EC_GROUP_order_bits`]
-    ///
-    /// [`EC_GROUP_order_bits`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_GROUP_order_bits.html
+    #[corresponds(EC_GROUP_order_bits)]
     #[cfg(ossl110)]
     pub fn order_bits(&self) -> u32 {
         unsafe { ffi::EC_GROUP_order_bits(self.as_ptr()) as u32 }
     }
 
-    /// Returns the generator for the given curve as a [`EcPoint`].
-    ///
-    /// OpenSSL documentation at [`EC_GROUP_get0_generator`]
-    ///
-    /// [`EC_GROUP_get0_generator`]: https://www.openssl.org/docs/man1.1.0/man3/EC_GROUP_get0_generator.html
+    /// Returns the generator for the given curve as an [`EcPoint`].
+    #[corresponds(EC_GROUP_get0_generator)]
     pub fn generator(&self) -> &EcPointRef {
         unsafe {
             let ptr = ffi::EC_GROUP_get0_generator(self.as_ptr());
@@ -235,10 +215,7 @@ impl EcGroupRef {
     }
 
     /// Places the order of the curve in the provided `BigNum`.
-    ///
-    /// OpenSSL documentation at [`EC_GROUP_get_order`]
-    ///
-    /// [`EC_GROUP_get_order`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_GROUP_get_order.html
+    #[corresponds(EC_GROUP_get_order)]
     pub fn order(
         &self,
         order: &mut BigNumRef,
@@ -259,6 +236,7 @@ impl EcGroupRef {
     ///
     /// This defaults to `EXPLICIT_CURVE` in OpenSSL 1.0.1 and 1.0.2, but `NAMED_CURVE` in OpenSSL
     /// 1.1.0.
+    #[corresponds(EC_GROUP_set_asn1_flag)]
     pub fn set_asn1_flag(&mut self, flag: Asn1Flag) {
         unsafe {
             ffi::EC_GROUP_set_asn1_flag(self.as_ptr(), flag.0);
@@ -266,10 +244,7 @@ impl EcGroupRef {
     }
 
     /// Returns the name of the curve, if a name is associated.
-    ///
-    /// OpenSSL documentation at [`EC_GROUP_get_curve_name`]
-    ///
-    /// [`EC_GROUP_get_curve_name`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_GROUP_get_curve_name.html
+    #[corresponds(EC_GROUP_get_curve_name)]
     pub fn curve_name(&self) -> Option<Nid> {
         let nid = unsafe { ffi::EC_GROUP_get_curve_name(self.as_ptr()) };
         if nid > 0 {
@@ -285,23 +260,14 @@ foreign_type_and_impl_send_sync! {
     fn drop = ffi::EC_POINT_free;
 
     /// Represents a point on the curve
-    ///
-    /// OpenSSL documentation at [`EC_POINT_new`]
-    ///
-    /// [`EC_POINT_new`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_new.html
     pub struct EcPoint;
-    /// Reference to [`EcPoint`]
-    ///
-    /// [`EcPoint`]: struct.EcPoint.html
+    /// A reference a borrowed [`EcPoint`].
     pub struct EcPointRef;
 }
 
 impl EcPointRef {
     /// Computes `a + b`, storing the result in `self`.
-    ///
-    /// OpenSSL documentation at [`EC_POINT_add`]
-    ///
-    /// [`EC_POINT_add`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_add.html
+    #[corresponds(EC_POINT_add)]
     pub fn add(
         &mut self,
         group: &EcGroupRef,
@@ -322,10 +288,7 @@ impl EcPointRef {
     }
 
     /// Computes `q * m`, storing the result in `self`.
-    ///
-    /// OpenSSL documentation at [`EC_POINT_mul`]
-    ///
-    /// [`EC_POINT_mul`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_mul.html
+    #[corresponds(EC_POINT_mul)]
     pub fn mul(
         &mut self,
         group: &EcGroupRef,
@@ -348,6 +311,7 @@ impl EcPointRef {
     }
 
     /// Computes `generator * n`, storing the result in `self`.
+    #[corresponds(EC_POINT_mul)]
     pub fn mul_generator(
         &mut self,
         group: &EcGroupRef,
@@ -369,6 +333,7 @@ impl EcPointRef {
     }
 
     /// Computes `generator * n + q * m`, storing the result in `self`.
+    #[corresponds(EC_POINT_mul)]
     pub fn mul_full(
         &mut self,
         group: &EcGroupRef,
@@ -391,10 +356,8 @@ impl EcPointRef {
     }
 
     /// Inverts `self`.
-    ///
-    /// OpenSSL documentation at [`EC_POINT_invert`]
-    ///
-    /// [`EC_POINT_invert`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_invert.html
+    #[corresponds(EC_POINT_invert)]
+    // FIXME should be mutable
     pub fn invert(&mut self, group: &EcGroupRef, ctx: &BigNumContextRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EC_POINT_invert(
@@ -407,10 +370,7 @@ impl EcPointRef {
     }
 
     /// Serializes the point to a binary representation.
-    ///
-    /// OpenSSL documentation at [`EC_POINT_point2oct`]
-    ///
-    /// [`EC_POINT_point2oct`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_point2oct.html
+    #[corresponds(EC_POINT_point2oct)]
     pub fn to_bytes(
         &self,
         group: &EcGroupRef,
@@ -447,19 +407,13 @@ impl EcPointRef {
     }
 
     /// Creates a new point on the specified curve with the same value.
-    ///
-    /// OpenSSL documentation at [`EC_POINT_dup`]
-    ///
-    /// [`EC_POINT_dup`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_dup.html
+    #[corresponds(EC_POINT_dup)]
     pub fn to_owned(&self, group: &EcGroupRef) -> Result<EcPoint, ErrorStack> {
         unsafe { cvt_p(ffi::EC_POINT_dup(self.as_ptr(), group.as_ptr())).map(EcPoint) }
     }
 
     /// Determines if this point is equal to another.
-    ///
-    /// OpenSSL doucmentation at [`EC_POINT_cmp`]
-    ///
-    /// [`EC_POINT_cmp`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_cmp.html
+    #[corresponds(EC_POINT_cmp)]
     pub fn eq(
         &self,
         group: &EcGroupRef,
@@ -477,12 +431,9 @@ impl EcPointRef {
         }
     }
 
-    /// Place affine coordinates of a curve over a prime field in the provided
-    /// `x` and `y` `BigNum`s
-    ///
-    /// OpenSSL documentation at [`EC_POINT_get_affine_coordinates`]
-    ///
-    /// [`EC_POINT_get_affine_coordinates`]: https://www.openssl.org/docs/man1.1.1/man3/EC_POINT_get_affine_coordinates.html
+    /// Places affine coordinates of a curve over a prime field in the provided
+    /// `x` and `y` `BigNum`s.
+    #[corresponds(EC_POINT_get_affine_coordinates)]
     #[cfg(ossl111)]
     pub fn affine_coordinates(
         &self,
@@ -505,10 +456,7 @@ impl EcPointRef {
 
     /// Place affine coordinates of a curve over a prime field in the provided
     /// `x` and `y` `BigNum`s
-    ///
-    /// OpenSSL documentation at [`EC_POINT_get_affine_coordinates_GFp`]
-    ///
-    /// [`EC_POINT_get_affine_coordinates_GFp`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_get_affine_coordinates_GFp.html
+    #[corresponds(EC_POINT_get_affine_coordinates_GFp)]
     pub fn affine_coordinates_gfp(
         &self,
         group: &EcGroupRef,
@@ -530,10 +478,7 @@ impl EcPointRef {
 
     /// Place affine coordinates of a curve over a binary field in the provided
     /// `x` and `y` `BigNum`s
-    ///
-    /// OpenSSL documentation at [`EC_POINT_get_affine_coordinates_GF2m`]
-    ///
-    /// [`EC_POINT_get_affine_coordinates_GF2m`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_get_affine_coordinates_GF2m.html
+    #[corresponds(EC_POINT_get_affine_coordinates_GF2m)]
     #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn affine_coordinates_gf2m(
         &self,
@@ -555,10 +500,7 @@ impl EcPointRef {
     }
 
     /// Checks if point is infinity
-    ///
-    /// OpenSSL documentation at [`EC_POINT_is_at_infinity`]
-    ///
-    /// [`EC_POINT_is_at_infinity`]: https://www.openssl.org/docs/man1.1.0/man3/EC_POINT_is_at_infinity.html
+    #[corresponds(EC_POINT_is_at_infinity)]
     pub fn is_infinity(&self, group: &EcGroupRef) -> bool {
         unsafe {
             let res = ffi::EC_POINT_is_at_infinity(group.as_ptr(), self.as_ptr());
@@ -567,10 +509,7 @@ impl EcPointRef {
     }
 
     /// Checks if point is on a given curve
-    ///
-    /// OpenSSL documentation at [`EC_POINT_is_on_curve`]
-    ///
-    /// [`EC_POINT_is_on_curve`]: https://www.openssl.org/docs/man1.1.0/man3/EC_POINT_is_on_curve.html
+    #[corresponds(EC_POINT_is_on_curve)]
     pub fn is_on_curve(
         &self,
         group: &EcGroupRef,
@@ -589,19 +528,13 @@ impl EcPointRef {
 
 impl EcPoint {
     /// Creates a new point on the specified curve.
-    ///
-    /// OpenSSL documentation at [`EC_POINT_new`]
-    ///
-    /// [`EC_POINT_new`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_new.html
+    #[corresponds(EC_POINT_new)]
     pub fn new(group: &EcGroupRef) -> Result<EcPoint, ErrorStack> {
         unsafe { cvt_p(ffi::EC_POINT_new(group.as_ptr())).map(EcPoint) }
     }
 
     /// Creates point from a binary representation
-    ///
-    /// OpenSSL documentation at [`EC_POINT_oct2point`]
-    ///
-    /// [`EC_POINT_oct2point`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_oct2point.html
+    #[corresponds(EC_POINT_oct2point)]
     pub fn from_bytes(
         group: &EcGroupRef,
         buf: &[u8],
@@ -625,16 +558,9 @@ generic_foreign_type_and_impl_send_sync! {
     type CType = ffi::EC_KEY;
     fn drop = ffi::EC_KEY_free;
 
-    /// Public and optional Private key on the given curve
-    ///
-    /// OpenSSL documentation at [`EC_KEY_new`]
-    ///
-    /// [`EC_KEY_new`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_KEY_new.html
+    /// Public and optional private key on the given curve.
     pub struct EcKey<T>;
-
-    /// Reference to [`EcKey`]
-    ///
-    /// [`EcKey`]: struct.EcKey.html
+    /// A reference to an [`EcKey`].
     pub struct EcKeyRef<T>;
 }
 
@@ -646,37 +572,25 @@ where
         /// Serializes the private key to a PEM-encoded ECPrivateKey structure.
         ///
         /// The output will have a header of `-----BEGIN EC PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_ECPrivateKey`].
-        ///
-        /// [`PEM_write_bio_ECPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_ECPrivateKey.html
+        #[corresponds(PEM_write_bio_ECPrivateKey)]
         private_key_to_pem,
         /// Serializes the private key to a PEM-encoded encrypted ECPrivateKey structure.
         ///
         /// The output will have a header of `-----BEGIN EC PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_ECPrivateKey`].
-        ///
-        /// [`PEM_write_bio_ECPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_ECPrivateKey.html
+        #[corresponds(PEM_write_bio_ECPrivateKey)]
         private_key_to_pem_passphrase,
         ffi::PEM_write_bio_ECPrivateKey
     }
 
     to_der! {
         /// Serializes the private key into a DER-encoded ECPrivateKey structure.
-        ///
-        /// This corresponds to [`i2d_ECPrivateKey`].
-        ///
-        /// [`i2d_ECPrivateKey`]: https://www.openssl.org/docs/man1.0.2/crypto/d2i_ECPrivate_key.html
+        #[corresponds(i2d_ECPrivateKey)]
         private_key_to_der,
         ffi::i2d_ECPrivateKey
     }
 
-    /// Return [`EcPoint`] associated with the private key
-    ///
-    /// OpenSSL documentation at [`EC_KEY_get0_private_key`]
-    ///
-    /// [`EC_KEY_get0_private_key`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_KEY_get0_private_key.html
+    /// Returns the private key value.
+    #[corresponds(EC_KEY_get0_private_key)]
     pub fn private_key(&self) -> &BigNumRef {
         unsafe {
             let ptr = ffi::EC_KEY_get0_private_key(self.as_ptr());
@@ -690,10 +604,7 @@ where
     T: HasPublic,
 {
     /// Returns the public key.
-    ///
-    /// OpenSSL documentation at [`EC_KEY_get0_public_key`]
-    ///
-    /// [`EC_KEY_get0_public_key`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_KEY_get0_public_key.html
+    #[corresponds(EC_KEY_get0_public_key)]
     pub fn public_key(&self) -> &EcPointRef {
         unsafe {
             let ptr = ffi::EC_KEY_get0_public_key(self.as_ptr());
@@ -705,20 +616,14 @@ where
         /// Serialies the public key into a PEM-encoded SubjectPublicKeyInfo structure.
         ///
         /// The output will have a header of `-----BEGIN PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_EC_PUBKEY`].
-        ///
-        /// [`PEM_write_bio_EC_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_EC_PUBKEY.html
+        #[corresponds(PEM_write_bio_EC_PUBKEY)]
         public_key_to_pem,
         ffi::PEM_write_bio_EC_PUBKEY
     }
 
     to_der! {
         /// Serializes the public key into a DER-encoded SubjectPublicKeyInfo structure.
-        ///
-        /// This corresponds to [`i2d_EC_PUBKEY`].
-        ///
-        /// [`i2d_EC_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/i2d_EC_PUBKEY.html
+        #[corresponds(i2d_EC_PUBKEY)]
         public_key_to_der,
         ffi::i2d_EC_PUBKEY
     }
@@ -728,11 +633,8 @@ impl<T> EcKeyRef<T>
 where
     T: HasParams,
 {
-    /// Return [`EcGroup`] of the `EcKey`
-    ///
-    /// OpenSSL documentation at [`EC_KEY_get0_group`]
-    ///
-    /// [`EC_KEY_get0_group`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_KEY_get0_group.html
+    /// Returns the key's group.
+    #[corresponds(EC_KEY_get0_group)]
     pub fn group(&self) -> &EcGroupRef {
         unsafe {
             let ptr = ffi::EC_KEY_get0_group(self.as_ptr());
@@ -741,10 +643,7 @@ where
     }
 
     /// Checks the key for validity.
-    ///
-    /// OpenSSL documentation at [`EC_KEY_check_key`]
-    ///
-    /// [`EC_KEY_check_key`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_KEY_check_key.html
+    #[corresponds(EC_KEY_check_key)]
     pub fn check_key(&self) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::EC_KEY_check_key(self.as_ptr())).map(|_| ()) }
     }
@@ -767,10 +666,7 @@ impl EcKey<Params> {
     ///
     /// It will not have an associated public or private key. This kind of key is primarily useful
     /// to be provided to the `set_tmp_ecdh` methods on `Ssl` and `SslContextBuilder`.
-    ///
-    /// OpenSSL documentation at [`EC_KEY_new_by_curve_name`]
-    ///
-    /// [`EC_KEY_new_by_curve_name`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_KEY_new_by_curve_name.html
+    #[corresponds(EC_KEY_new_by_curve_name)]
     pub fn from_curve_name(nid: Nid) -> Result<EcKey<Params>, ErrorStack> {
         unsafe {
             init();
@@ -779,10 +675,7 @@ impl EcKey<Params> {
     }
 
     /// Constructs an `EcKey` corresponding to a curve.
-    ///
-    /// This corresponds to [`EC_KEY_set_group`].
-    ///
-    /// [`EC_KEY_set_group`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_KEY_new.html
+    #[corresponds(EC_KEY_set_group)]
     pub fn from_group(group: &EcGroupRef) -> Result<EcKey<Params>, ErrorStack> {
         unsafe {
             cvt_p(ffi::EC_KEY_new())
@@ -816,6 +709,7 @@ impl EcKey<Public> {
     /// let point = EcPoint::from_bytes(&group, &public_key, &mut ctx).unwrap();
     /// let key = EcKey::from_public_key(&group, &point);
     /// ```
+    #[corresponds(EC_KEY_set_public_key)]
     pub fn from_public_key(
         group: &EcGroupRef,
         public_key: &EcPointRef,
@@ -837,6 +731,7 @@ impl EcKey<Public> {
     }
 
     /// Constructs a public key from its affine coordinates.
+    #[corresponds(EC_KEY_set_public_key_affine_coordinates)]
     pub fn from_public_key_affine_coordinates(
         group: &EcGroupRef,
         x: &BigNumRef,
@@ -863,10 +758,7 @@ impl EcKey<Public> {
         /// Decodes a PEM-encoded SubjectPublicKeyInfo structure containing a EC key.
         ///
         /// The input should have a header of `-----BEGIN PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_read_bio_EC_PUBKEY`].
-        ///
-        /// [`PEM_read_bio_EC_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_read_bio_EC_PUBKEY.html
+        #[corresponds(PEM_read_bio_EC_PUBKEY)]
         public_key_from_pem,
         EcKey<Public>,
         ffi::PEM_read_bio_EC_PUBKEY
@@ -874,10 +766,7 @@ impl EcKey<Public> {
 
     from_der! {
         /// Decodes a DER-encoded SubjectPublicKeyInfo structure containing a EC key.
-        ///
-        /// This corresponds to [`d2i_EC_PUBKEY`].
-        ///
-        /// [`d2i_EC_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/d2i_EC_PUBKEY.html
+        #[corresponds(d2i_EC_PUBKEY)]
         public_key_from_der,
         EcKey<Public>,
         ffi::d2i_EC_PUBKEY
@@ -886,6 +775,7 @@ impl EcKey<Public> {
 
 impl EcKey<Private> {
     /// Generates a new public/private key pair on the specified curve.
+    #[corresponds(EC_KEY_generate_key)]
     pub fn generate(group: &EcGroupRef) -> Result<EcKey<Private>, ErrorStack> {
         unsafe {
             cvt_p(ffi::EC_KEY_new())
@@ -898,6 +788,7 @@ impl EcKey<Private> {
     }
 
     /// Constructs an public/private key pair given a curve, a private key and a public key point.
+    #[corresponds(EC_KEY_set_private_key)]
     pub fn from_private_components(
         group: &EcGroupRef,
         private_number: &BigNumRef,
@@ -930,15 +821,13 @@ impl EcKey<Private> {
         /// Deserializes a private key from a PEM-encoded ECPrivateKey structure.
         ///
         /// The input should have a header of `-----BEGIN EC PRIVATE KEY-----`.
-        ///
-        /// This corresponds to `PEM_read_bio_ECPrivateKey`.
+        #[corresponds(PEM_read_bio_ECPrivateKey)]
         private_key_from_pem,
 
         /// Deserializes a private key from a PEM-encoded encrypted ECPrivateKey structure.
         ///
         /// The input should have a header of `-----BEGIN EC PRIVATE KEY-----`.
-        ///
-        /// This corresponds to `PEM_read_bio_ECPrivateKey`.
+        #[corresponds(PEM_read_bio_ECPrivateKey)]
         private_key_from_pem_passphrase,
 
         /// Deserializes a private key from a PEM-encoded encrypted ECPrivateKey structure.
@@ -946,8 +835,7 @@ impl EcKey<Private> {
         /// The callback should fill the password into the provided buffer and return its length.
         ///
         /// The input should have a header of `-----BEGIN EC PRIVATE KEY-----`.
-        ///
-        /// This corresponds to `PEM_read_bio_ECPrivateKey`.
+        #[corresponds(PEM_read_bio_ECPrivateKey)]
         private_key_from_pem_callback,
         EcKey<Private>,
         ffi::PEM_read_bio_ECPrivateKey
@@ -955,10 +843,7 @@ impl EcKey<Private> {
 
     from_der! {
         /// Decodes a DER-encoded elliptic curve private key structure.
-        ///
-        /// This corresponds to [`d2i_ECPrivateKey`].
-        ///
-        /// [`d2i_ECPrivateKey`]: https://www.openssl.org/docs/man1.0.2/crypto/d2i_ECPrivate_key.html
+        #[corresponds(d2i_ECPrivateKey)]
         private_key_from_der,
         EcKey<Private>,
         ffi::d2i_ECPrivateKey

--- a/openssl/src/ecdsa.rs
+++ b/openssl/src/ecdsa.rs
@@ -12,29 +12,21 @@ use crate::error::ErrorStack;
 use crate::pkey::{HasPrivate, HasPublic};
 use crate::util::ForeignTypeRefExt;
 use crate::{cvt_n, cvt_p};
+use openssl_macros::corresponds;
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::ECDSA_SIG;
     fn drop = ffi::ECDSA_SIG_free;
 
-    /// A low level interface to ECDSA
-    ///
-    /// OpenSSL documentation at [`ECDSA_sign`]
-    ///
-    /// [`ECDSA_sign`]: https://www.openssl.org/docs/man1.1.0/crypto/ECDSA_sign.html
+    /// A low level interface to ECDSA.
     pub struct EcdsaSig;
-    /// Reference to [`EcdsaSig`]
-    ///
-    /// [`EcdsaSig`]: struct.EcdsaSig.html
+    /// A reference to an [`EcdsaSig`].
     pub struct EcdsaSigRef;
 }
 
 impl EcdsaSig {
     /// Computes a digital signature of the hash value `data` using the private EC key eckey.
-    ///
-    /// OpenSSL documentation at [`ECDSA_do_sign`]
-    ///
-    /// [`ECDSA_do_sign`]: https://www.openssl.org/docs/man1.1.0/crypto/ECDSA_do_sign.html
+    #[corresponds(ECDSA_do_sign)]
     pub fn sign<T>(data: &[u8], eckey: &EcKeyRef<T>) -> Result<EcdsaSig, ErrorStack>
     where
         T: HasPrivate,
@@ -50,12 +42,8 @@ impl EcdsaSig {
         }
     }
 
-    /// Returns a new `EcdsaSig` by setting the `r` and `s` values associated with a
-    /// ECDSA signature.
-    ///
-    /// OpenSSL documentation at [`ECDSA_SIG_set0`]
-    ///
-    /// [`ECDSA_SIG_set0`]: https://www.openssl.org/docs/man1.1.0/crypto/ECDSA_SIG_set0.html
+    /// Returns a new `EcdsaSig` by setting the `r` and `s` values associated with an ECDSA signature.
+    #[corresponds(ECDSA_SIG_set0)]
     pub fn from_private_components(r: BigNum, s: BigNum) -> Result<EcdsaSig, ErrorStack> {
         unsafe {
             let sig = cvt_p(ffi::ECDSA_SIG_new())?;
@@ -67,10 +55,7 @@ impl EcdsaSig {
 
     from_der! {
         /// Decodes a DER-encoded ECDSA signature.
-        ///
-        /// This corresponds to [`d2i_ECDSA_SIG`].
-        ///
-        /// [`d2i_ECDSA_SIG`]: https://www.openssl.org/docs/man1.1.0/crypto/d2i_ECDSA_SIG.html
+        #[corresponds(d2i_ECDSA_SIG)]
         from_der,
         EcdsaSig,
         ffi::d2i_ECDSA_SIG
@@ -80,19 +65,13 @@ impl EcdsaSig {
 impl EcdsaSigRef {
     to_der! {
         /// Serializes the ECDSA signature into a DER-encoded ECDSASignature structure.
-        ///
-        /// This corresponds to [`i2d_ECDSA_SIG`].
-        ///
-        /// [`i2d_ECDSA_SIG`]: https://www.openssl.org/docs/man1.1.0/crypto/i2d_ECDSA_SIG.html
+        #[corresponds(i2d_ECDSA_SIG)]
         to_der,
         ffi::i2d_ECDSA_SIG
     }
 
     /// Verifies if the signature is a valid ECDSA signature using the given public key.
-    ///
-    /// OpenSSL documentation at [`ECDSA_do_verify`]
-    ///
-    /// [`ECDSA_do_verify`]: https://www.openssl.org/docs/man1.1.0/crypto/ECDSA_do_verify.html
+    #[corresponds(ECDSA_do_verify)]
     pub fn verify<T>(&self, data: &[u8], eckey: &EcKeyRef<T>) -> Result<bool, ErrorStack>
     where
         T: HasPublic,
@@ -110,10 +89,7 @@ impl EcdsaSigRef {
     }
 
     /// Returns internal component: `r` of an `EcdsaSig`. (See X9.62 or FIPS 186-2)
-    ///
-    /// OpenSSL documentation at [`ECDSA_SIG_get0`]
-    ///
-    /// [`ECDSA_SIG_get0`]: https://www.openssl.org/docs/man1.1.0/crypto/ECDSA_SIG_get0.html
+    #[corresponds(ECDSA_SIG_get0)]
     pub fn r(&self) -> &BigNumRef {
         unsafe {
             let mut r = ptr::null();
@@ -123,10 +99,7 @@ impl EcdsaSigRef {
     }
 
     /// Returns internal components: `s` of an `EcdsaSig`. (See X9.62 or FIPS 186-2)
-    ///
-    /// OpenSSL documentation at [`ECDSA_SIG_get0`]
-    ///
-    /// [`ECDSA_SIG_get0`]: https://www.openssl.org/docs/man1.1.0/crypto/ECDSA_SIG_get0.html
+    #[corresponds(ECDSA_SIG_get0)]
     pub fn s(&self) -> &BigNumRef {
         unsafe {
             let mut s = ptr::null();

--- a/openssl/src/fips.rs
+++ b/openssl/src/fips.rs
@@ -5,18 +5,17 @@
 //! [OpenSSL's documentation]: https://www.openssl.org/docs/fips/UserGuide-2.0.pdf
 use crate::cvt;
 use crate::error::ErrorStack;
+use openssl_macros::corresponds;
 
 /// Moves the library into or out of the FIPS 140-2 mode of operation.
-///
-/// This corresponds to `FIPS_mode_set`.
+#[corresponds(FIPS_mode_set)]
 pub fn enable(enabled: bool) -> Result<(), ErrorStack> {
     ffi::init();
     unsafe { cvt(ffi::FIPS_mode_set(enabled as _)).map(|_| ()) }
 }
 
 /// Determines if the library is running in the FIPS 140-2 mode of operation.
-///
-/// This corresponds to `FIPS_mode`.
+#[corresponds(FIPS_mode)]
 pub fn enabled() -> bool {
     unsafe { ffi::FIPS_mode() != 0 }
 }

--- a/openssl/src/lib_ctx.rs
+++ b/openssl/src/lib_ctx.rs
@@ -1,6 +1,7 @@
 use crate::cvt_p;
 use crate::error::ErrorStack;
 use foreign_types::ForeignType;
+use openssl_macros::corresponds;
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::OSSL_LIB_CTX;
@@ -11,6 +12,7 @@ foreign_type_and_impl_send_sync! {
 }
 
 impl LibCtx {
+    #[corresponds(OSSL_LIB_CTX_new)]
     pub fn new() -> Result<Self, ErrorStack> {
         unsafe {
             let ptr = cvt_p(ffi::OSSL_LIB_CTX_new())?;

--- a/openssl/src/md.rs
+++ b/openssl/src/md.rs
@@ -7,6 +7,7 @@ use crate::lib_ctx::LibCtxRef;
 use crate::nid::Nid;
 use cfg_if::cfg_if;
 use foreign_types::{ForeignTypeRef, Opaque};
+use openssl_macros::corresponds;
 #[cfg(ossl300)]
 use std::ffi::CString;
 #[cfg(ossl300)]
@@ -75,10 +76,7 @@ unsafe impl Send for Md {}
 
 impl Md {
     /// Returns the `Md` corresponding to an [`Nid`].
-    ///
-    /// This corresponds to [`EVP_get_digestbynid`].
-    ///
-    /// [`EVP_get_digestbynid`]: https://www.openssl.org/docs/manmaster/crypto/EVP_DigestInit.html
+    #[corresponds(EVP_get_digestbynid)]
     pub fn from_nid(type_: Nid) -> Option<&'static MdRef> {
         unsafe {
             let ptr = ffi::EVP_get_digestbynid(type_.as_raw());
@@ -92,11 +90,8 @@ impl Md {
 
     /// Fetches an `Md` object corresponding to the specified algorithm name and properties.
     ///
-    /// This corresponds to [`EVP_MD_fetch`].
-    ///
     /// Requires OpenSSL 3.0.0 or newer.
-    ///
-    /// [`EVP_MD_fetch`]: https://www.openssl.org/docs/manmaster/man3/EVP_MD_fetch.html
+    #[corresponds(EVP_MD_fetch)]
     #[cfg(ossl300)]
     pub fn fetch(
         ctx: Option<&LibCtxRef>,
@@ -213,20 +208,14 @@ unsafe impl Send for MdRef {}
 
 impl MdRef {
     /// Returns the size of the digest in bytes.
-    ///
-    /// This corresponds to [`EVP_MD_size`].
-    ///
-    /// [`EVP_MD_size`]: https://www.openssl.org/docs/manmaster/man3/EVP_MD_size.html
+    #[corresponds(EVP_MD_size)]
     #[inline]
     pub fn size(&self) -> usize {
         unsafe { ffi::EVP_MD_size(self.as_ptr()) as usize }
     }
 
     /// Returns the [`Nid`] of the digest.
-    ///
-    /// This corresponds to [`EVP_MD_type`].
-    ///
-    /// [`EVP_MD_type`]: https://www.openssl.org/docs/manmaster/man3/EVP_MD_type.html
+    #[corresponds(EVP_MD_type)]
     #[inline]
     pub fn type_(&self) -> Nid {
         unsafe { Nid::from_raw(ffi::EVP_MD_type(self.as_ptr())) }

--- a/openssl/src/md_ctx.rs
+++ b/openssl/src/md_ctx.rs
@@ -82,6 +82,7 @@ use crate::pkey_ctx::PkeyCtxRef;
 use crate::{cvt, cvt_p};
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
+use openssl_macros::corresponds;
 use std::convert::TryFrom;
 use std::ptr;
 
@@ -104,10 +105,7 @@ foreign_type_and_impl_send_sync! {
 
 impl MdCtx {
     /// Creates a new context.
-    ///
-    /// This corresponds to [`EVP_MD_CTX_new`].
-    ///
-    /// [`EVP_MD_CTX_new`]: https://www.openssl.org/docs/manmaster/crypto/EVP_MD_CTX_new.html
+    #[corresponds(EVP_MD_CTX_new)]
     #[inline]
     pub fn new() -> Result<Self, ErrorStack> {
         ffi::init();
@@ -121,10 +119,7 @@ impl MdCtx {
 
 impl MdCtxRef {
     /// Initializes the context to compute the digest of data.
-    ///
-    /// This corresponds to [`EVP_DigestInit_ex`].
-    ///
-    /// [`EVP_DigestInit_ex`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestInit_ex.html
+    #[corresponds(EVP_DigestInit_ex)]
     #[inline]
     pub fn digest_init(&mut self, digest: &MdRef) -> Result<(), ErrorStack> {
         unsafe {
@@ -141,10 +136,7 @@ impl MdCtxRef {
     /// Initializes the context to compute the signature of data.
     ///
     /// A reference to the context's inner `PkeyCtx` is returned, allowing signature settings to be configured.
-    ///
-    /// This corresponds to [`EVP_DigestSignInit`].
-    ///
-    /// [`EVP_DigestSignInit`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestSignInit.html
+    #[corresponds(EVP_DigestSignInit)]
     #[inline]
     pub fn digest_sign_init<'a, T>(
         &'a mut self,
@@ -170,10 +162,7 @@ impl MdCtxRef {
     /// Initializes the context to verify the signature of data.
     ///
     /// A reference to the context's inner `PkeyCtx` is returned, allowing signature settings to be configured.
-    ///
-    /// This corresponds to [`EVP_DigestVerifyInit`].
-    ///
-    /// [`EVP_DigestVerifyInit`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestSignInit.html
+    #[corresponds(EVP_DigestVerifyInit)]
     #[inline]
     pub fn digest_verify_init<'a, T>(
         &'a mut self,
@@ -197,10 +186,7 @@ impl MdCtxRef {
     }
 
     /// Updates the context with more data.
-    ///
-    /// This corresponds to [`EVP_DigestUpdate`].
-    ///
-    /// [`EVP_DigestUpdate`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestUpdate.html
+    #[corresponds(EVP_DigestUpdate)]
     #[inline]
     pub fn digest_update(&mut self, data: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
@@ -215,10 +201,7 @@ impl MdCtxRef {
     }
 
     /// Updates the context with more data.
-    ///
-    /// This corresponds to [`EVP_DigestSignUpdate`].
-    ///
-    /// [`EVP_DigestSignUpdate`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestSignUpdate.html
+    #[corresponds(EVP_DigestSignUpdate)]
     #[inline]
     pub fn digest_sign_update(&mut self, data: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
@@ -233,10 +216,7 @@ impl MdCtxRef {
     }
 
     /// Updates the context with more data.
-    ///
-    /// This corresponds to [`EVP_DigestVerifyUpdate`].
-    ///
-    /// [`EVP_DigestVerifyUpdate`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestVerifyUpdate.html
+    #[corresponds(EVP_DigestVerifyUpdate)]
     #[inline]
     pub fn digest_verify_update(&mut self, data: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
@@ -251,10 +231,7 @@ impl MdCtxRef {
     }
 
     /// Copies the computed digest into the buffer, returning the number of bytes written.
-    ///
-    /// This corresponds to [`EVP_DigestFinal`].
-    ///
-    /// [`EVP_DigestFinal`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestFinal.html
+    #[corresponds(EVP_DigestFinal)]
     #[inline]
     pub fn digest_final(&mut self, out: &mut [u8]) -> Result<usize, ErrorStack> {
         let mut len = u32::try_from(out.len()).unwrap_or(u32::MAX);
@@ -273,10 +250,7 @@ impl MdCtxRef {
     /// Copies the computed digest into the buffer.
     ///
     /// Requires OpenSSL 1.1.1 or newer.
-    ///
-    /// This corresponds to [`EVP_DigestFinalXOF`].
-    ///
-    /// [`EVP_DigestFinalXOF`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestFinalXOF.html
+    #[corresponds(EVP_DigestFinalXOF)]
     #[inline]
     #[cfg(ossl111)]
     pub fn digest_final_xof(&mut self, out: &mut [u8]) -> Result<(), ErrorStack> {
@@ -295,10 +269,7 @@ impl MdCtxRef {
     ///
     /// If `out` is set to `None`, an upper bound on the number of bytes required for the output buffer will be
     /// returned.
-    ///
-    /// This corresponds to [`EVP_DigestSignFinal`].
-    ///
-    /// [`EVP_DigestSignFinal`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestSignFinal.html
+    #[corresponds(EVP_DigestSignFinal)]
     #[inline]
     pub fn digest_sign_final(&mut self, out: Option<&mut [u8]>) -> Result<usize, ErrorStack> {
         let mut len = out.as_ref().map_or(0, |b| b.len());
@@ -328,10 +299,7 @@ impl MdCtxRef {
     ///
     /// Returns `Ok(true)` if the signature is valid, `Ok(false)` if the signature is invalid, and `Err` if an error
     /// occurred.
-    ///
-    /// This corresponds to [`EVP_DigestVerifyFinal`].
-    ///
-    /// [`EVP_DigestVerifyFinal`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestVerifyFinal.html
+    #[corresponds(EVP_DigestVerifyFinal)]
     #[inline]
     pub fn digest_verify_final(&mut self, signature: &[u8]) -> Result<bool, ErrorStack> {
         unsafe {
@@ -350,10 +318,7 @@ impl MdCtxRef {
     /// returned.
     ///
     /// Requires OpenSSL 1.1.1 or newer.
-    ///
-    /// This corresponds to [`EVP_DigestSign`].
-    ///
-    /// [`EVP_DigestSign`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestSign.html
+    #[corresponds(EVP_DigestSign)]
     #[cfg(ossl111)]
     #[inline]
     pub fn digest_sign(&mut self, from: &[u8], to: Option<&mut [u8]>) -> Result<usize, ErrorStack> {
@@ -393,10 +358,7 @@ impl MdCtxRef {
     /// occurred.
     ///
     /// Requires OpenSSL 1.1.1 or newer.
-    ///
-    /// This corresponds to [`EVP_DigestVerify`].
-    ///
-    /// [`EVP_DigestVerify`]: https://www.openssl.org/docs/manmaster/man3/EVP_DigestVerify.html
+    #[corresponds(EVP_DigestVerify)]
     #[cfg(ossl111)]
     #[inline]
     pub fn digest_verify(&mut self, data: &[u8], signature: &[u8]) -> Result<bool, ErrorStack> {

--- a/openssl/src/memcmp.rs
+++ b/openssl/src/memcmp.rs
@@ -30,6 +30,7 @@
 //! assert!(!eq(&a, &c));
 //! ```
 use libc::size_t;
+use openssl_macros::corresponds;
 
 /// Returns `true` iff `a` and `b` contain the same bytes.
 ///
@@ -60,6 +61,7 @@ use libc::size_t;
 /// assert!(!eq(&a, &b));
 /// assert!(!eq(&a, &c));
 /// ```
+#[corresponds(CRYPTO_memcmp)]
 pub fn eq(a: &[u8], b: &[u8]) -> bool {
     assert!(a.len() == b.len());
     let ret = unsafe {

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -7,6 +7,7 @@ use std::str;
 
 use crate::cvt_p;
 use crate::error::ErrorStack;
+use openssl_macros::corresponds;
 
 /// The digest and public-key algorithms associated with a signature.
 pub struct SignatureAlgorithms {
@@ -61,8 +62,7 @@ impl Nid {
     }
 
     /// Creates a new `Nid` for the `oid` with short name `sn` and long name `ln`.
-    ///
-    /// This corresponds to `OBJ_create`
+    #[corresponds(OBJ_create)]
     pub fn create(oid: &str, sn: &str, ln: &str) -> Result<Nid, ErrorStack> {
         unsafe {
             ffi::init();
@@ -81,6 +81,7 @@ impl Nid {
     /// Returns the `Nid`s of the digest and public key algorithms associated with a signature ID.
     ///
     /// This corresponds to `OBJ_find_sigid_algs`.
+    #[corresponds(OBJ_find_sigid_algs)]
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn signature_algorithms(&self) -> Option<SignatureAlgorithms> {
         unsafe {
@@ -97,10 +98,8 @@ impl Nid {
         }
     }
 
-    /// Return the string representation of a `Nid` (long)
-    /// This corresponds to [`OBJ_nid2ln`]
-    ///
-    /// [`OBJ_nid2ln`]: https://www.openssl.org/docs/man1.1.0/crypto/OBJ_nid2ln.html
+    /// Returns the string representation of a `Nid` (long).
+    #[corresponds(OBJ_nid2ln)]
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn long_name(&self) -> Result<&'static str, ErrorStack> {
         unsafe {
@@ -109,10 +108,8 @@ impl Nid {
         }
     }
 
-    /// Return the string representation of a `Nid` (short)
-    /// This corresponds to [`OBJ_nid2sn`]
-    ///
-    /// [`OBJ_nid2sn`]: https://www.openssl.org/docs/man1.1.0/crypto/OBJ_nid2sn.html
+    /// Returns the string representation of a `Nid` (short).
+    #[corresponds(OBJ_nid2sn)]
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn short_name(&self) -> Result<&'static str, ErrorStack> {
         unsafe {

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -12,6 +12,7 @@ use crate::stack::Stack;
 use crate::util::ForeignTypeExt;
 use crate::x509::{X509Ref, X509};
 use crate::{cvt, cvt_p};
+use openssl_macros::corresponds;
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::PKCS12;
@@ -24,15 +25,13 @@ foreign_type_and_impl_send_sync! {
 impl Pkcs12Ref {
     to_der! {
         /// Serializes the `Pkcs12` to its standard DER encoding.
-        ///
-        /// This corresponds to [`i2d_PKCS12`].
-        ///
-        /// [`i2d_PKCS12`]: https://www.openssl.org/docs/manmaster/man3/i2d_PKCS12.html
+        #[corresponds(i2d_PKCS12)]
         to_der,
         ffi::i2d_PKCS12
     }
 
     /// Extracts the contents of the `Pkcs12`.
+    #[corresponds(PKCS12_parse)]
     pub fn parse(&self, pass: &str) -> Result<ParsedPkcs12, ErrorStack> {
         unsafe {
             let pass = CString::new(pass.as_bytes()).unwrap();
@@ -62,10 +61,7 @@ impl Pkcs12Ref {
 impl Pkcs12 {
     from_der! {
         /// Deserializes a DER-encoded PKCS#12 archive.
-        ///
-        /// This corresponds to [`d2i_PKCS12`].
-        ///
-        /// [`d2i_PKCS12`]: https://www.openssl.org/docs/man1.1.0/crypto/d2i_PKCS12.html
+        #[corresponds(d2i_PKCS12)]
         from_der,
         Pkcs12,
         ffi::d2i_PKCS12
@@ -149,6 +145,7 @@ impl Pkcs12Builder {
     /// * `friendly_name` - user defined name for the certificate
     /// * `pkey` - key to store
     /// * `cert` - certificate to store
+    #[corresponds(PKCS12_create)]
     pub fn build<T>(
         self,
         password: &str,

--- a/openssl/src/pkcs5.rs
+++ b/openssl/src/pkcs5.rs
@@ -5,6 +5,7 @@ use crate::cvt;
 use crate::error::ErrorStack;
 use crate::hash::MessageDigest;
 use crate::symm::Cipher;
+use openssl_macros::corresponds;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct KeyIvPair {
@@ -22,6 +23,7 @@ pub struct KeyIvPair {
 ///
 /// New applications should not use this and instead use
 /// `pbkdf2_hmac` or another more modern key derivation algorithm.
+#[corresponds(EVP_BytesToKey)]
 #[allow(clippy::useless_conversion)]
 pub fn bytes_to_key(
     cipher: Cipher,
@@ -80,6 +82,7 @@ pub fn bytes_to_key(
 }
 
 /// Derives a key from a password and salt using the PBKDF2-HMAC algorithm with a digest function.
+#[corresponds(PKCS5_PBKDF2_HMAC)]
 pub fn pbkdf2_hmac(
     pass: &[u8],
     salt: &[u8],
@@ -110,6 +113,7 @@ pub fn pbkdf2_hmac(
 /// Derives a key from a password and salt using the scrypt algorithm.
 ///
 /// Requires OpenSSL 1.1.0 or newer.
+#[corresponds(EVP_PBE_scrypt)]
 #[cfg(any(ossl110))]
 pub fn scrypt(
     pass: &[u8],

--- a/openssl/src/pkcs7.rs
+++ b/openssl/src/pkcs7.rs
@@ -12,6 +12,7 @@ use crate::symm::Cipher;
 use crate::x509::store::X509StoreRef;
 use crate::x509::{X509Ref, X509};
 use crate::{cvt, cvt_p};
+use openssl_macros::corresponds;
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::PKCS7;
@@ -54,10 +55,7 @@ impl Pkcs7 {
         /// Deserializes a PEM-encoded PKCS#7 signature
         ///
         /// The input should have a header of `-----BEGIN PKCS7-----`.
-        ///
-        /// This corresponds to [`PEM_read_bio_PKCS7`].
-        ///
-        /// [`PEM_read_bio_PKCS7`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_read_bio_PKCS7.html
+        #[corresponds(PEM_read_bio_PKCS7)]
         from_pem,
         Pkcs7,
         ffi::PEM_read_bio_PKCS7
@@ -65,10 +63,7 @@ impl Pkcs7 {
 
     from_der! {
         /// Deserializes a DER-encoded PKCS#7 signature
-        ///
-        /// This corresponds to [`d2i_PKCS7`].
-        ///
-        /// [`d2i_PKCS7`]: https://www.openssl.org/docs/man1.1.0/man3/d2i_PKCS7.html
+        #[corresponds(d2i_PKCS7)]
         from_der,
         Pkcs7,
         ffi::d2i_PKCS7
@@ -78,10 +73,7 @@ impl Pkcs7 {
     ///
     /// Returns the loaded signature, along with the cleartext message (if
     /// available).
-    ///
-    /// This corresponds to [`SMIME_read_PKCS7`].
-    ///
-    /// [`SMIME_read_PKCS7`]: https://www.openssl.org/docs/man1.1.0/crypto/SMIME_read_PKCS7.html
+    #[corresponds(SMIME_read_PKCS7)]
     pub fn from_smime(input: &[u8]) -> Result<(Pkcs7, Option<Vec<u8>>), ErrorStack> {
         ffi::init();
 
@@ -105,10 +97,7 @@ impl Pkcs7 {
     /// `certs` is a list of recipient certificates. `input` is the content to be
     /// encrypted. `cipher` is the symmetric cipher to use. `flags` is an optional
     /// set of flags.
-    ///
-    /// This corresponds to [`PKCS7_encrypt`].
-    ///
-    /// [`PKCS7_encrypt`]: https://www.openssl.org/docs/man1.0.2/crypto/PKCS7_encrypt.html
+    #[corresponds(PKCS7_encrypt)]
     pub fn encrypt(
         certs: &StackRef<X509>,
         input: &[u8],
@@ -134,10 +123,7 @@ impl Pkcs7 {
     /// private key. `certs` is an optional additional set of certificates to
     /// include in the PKCS#7 structure (for example any intermediate CAs in the
     /// chain).
-    ///
-    /// This corresponds to [`PKCS7_sign`].
-    ///
-    /// [`PKCS7_sign`]: https://www.openssl.org/docs/man1.0.2/crypto/PKCS7_sign.html
+    #[corresponds(PKCS7_sign)]
     pub fn sign<PT>(
         signcert: &X509Ref,
         pkey: &PKeyRef<PT>,
@@ -164,10 +150,7 @@ impl Pkcs7 {
 
 impl Pkcs7Ref {
     /// Converts PKCS#7 structure to S/MIME format
-    ///
-    /// This corresponds to [`SMIME_write_PKCS7`].
-    ///
-    /// [`SMIME_write_PKCS7`]: https://www.openssl.org/docs/man1.1.0/crypto/SMIME_write_PKCS7.html
+    #[corresponds(SMIME_write_PKCS7)]
     pub fn to_smime(&self, input: &[u8], flags: Pkcs7Flags) -> Result<Vec<u8>, ErrorStack> {
         let input_bio = MemBioSlice::new(input)?;
         let output = MemBio::new()?;
@@ -186,20 +169,14 @@ impl Pkcs7Ref {
         /// Serializes the data into a PEM-encoded PKCS#7 structure.
         ///
         /// The output will have a header of `-----BEGIN PKCS7-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_PKCS7`].
-        ///
-        /// [`PEM_write_bio_PKCS7`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_write_bio_PKCS7.html
+        #[corresponds(PEM_write_bio_PKCS7)]
         to_pem,
         ffi::PEM_write_bio_PKCS7
     }
 
     to_der! {
         /// Serializes the data into a DER-encoded PKCS#7 structure.
-        ///
-        /// This corresponds to [`i2d_PKCS7`].
-        ///
-        /// [`i2d_PKCS7`]: https://www.openssl.org/docs/man1.1.0/man3/i2d_PKCS7.html
+        #[corresponds(i2d_PKCS7)]
         to_der,
         ffi::i2d_PKCS7
     }
@@ -210,10 +187,7 @@ impl Pkcs7Ref {
     /// certificate.
     ///
     /// Returns the decrypted message.
-    ///
-    /// This corresponds to [`PKCS7_decrypt`].
-    ///
-    /// [`PKCS7_decrypt`]: https://www.openssl.org/docs/man1.0.2/crypto/PKCS7_decrypt.html
+    #[corresponds(PKCS7_decrypt)]
     pub fn decrypt<PT>(
         &self,
         pkey: &PKeyRef<PT>,
@@ -243,10 +217,7 @@ impl Pkcs7Ref {
     /// certificate. `store` is a trusted certificate store (used for chain
     /// verification). `indata` is the signed data if the content is not present
     /// in `&self`. The content is written to `out` if it is not `None`.
-    ///
-    /// This corresponds to [`PKCS7_verify`].
-    ///
-    /// [`PKCS7_verify`]: https://www.openssl.org/docs/man1.0.2/crypto/PKCS7_verify.html
+    #[corresponds(PKCS7_verify)]
     pub fn verify(
         &self,
         certs: &StackRef<X509>,
@@ -284,10 +255,7 @@ impl Pkcs7Ref {
     }
 
     /// Retrieve the signer's certificates from the PKCS#7 structure without verifying them.
-    ///
-    /// This corresponds to [`PKCS7_get0_signers`].
-    ///
-    /// [`PKCS7_get0_signers`]: https://www.openssl.org/docs/man1.0.2/crypto/PKCS7_verify.html
+    #[corresponds(PKCS7_get0_signers)]
     pub fn signers(
         &self,
         certs: &StackRef<X509>,

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -55,6 +55,7 @@ use crate::{cvt, cvt_p};
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_long};
+use openssl_macros::corresponds;
 use std::convert::TryFrom;
 use std::ffi::CString;
 use std::fmt;
@@ -145,10 +146,7 @@ impl<T> ToOwned for PKeyRef<T> {
 
 impl<T> PKeyRef<T> {
     /// Returns a copy of the internal RSA key.
-    ///
-    /// This corresponds to [`EVP_PKEY_get1_RSA`].
-    ///
-    /// [`EVP_PKEY_get1_RSA`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_get1_RSA.html
+    #[corresponds(EVP_PKEY_get1_RSA)]
     pub fn rsa(&self) -> Result<Rsa<T>, ErrorStack> {
         unsafe {
             let rsa = cvt_p(ffi::EVP_PKEY_get1_RSA(self.as_ptr()))?;
@@ -157,10 +155,7 @@ impl<T> PKeyRef<T> {
     }
 
     /// Returns a copy of the internal DSA key.
-    ///
-    /// This corresponds to [`EVP_PKEY_get1_DSA`].
-    ///
-    /// [`EVP_PKEY_get1_DSA`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_get1_DSA.html
+    #[corresponds(EVP_PKEY_get1_DSA)]
     pub fn dsa(&self) -> Result<Dsa<T>, ErrorStack> {
         unsafe {
             let dsa = cvt_p(ffi::EVP_PKEY_get1_DSA(self.as_ptr()))?;
@@ -169,10 +164,7 @@ impl<T> PKeyRef<T> {
     }
 
     /// Returns a copy of the internal DH key.
-    ///
-    /// This corresponds to [`EVP_PKEY_get1_DH`].
-    ///
-    /// [`EVP_PKEY_get1_DH`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_get1_DH.html
+    #[corresponds(EVP_PKEY_get1_DH)]
     pub fn dh(&self) -> Result<Dh<T>, ErrorStack> {
         unsafe {
             let dh = cvt_p(ffi::EVP_PKEY_get1_DH(self.as_ptr()))?;
@@ -181,10 +173,7 @@ impl<T> PKeyRef<T> {
     }
 
     /// Returns a copy of the internal elliptic curve key.
-    ///
-    /// This corresponds to [`EVP_PKEY_get1_EC_KEY`].
-    ///
-    /// [`EVP_PKEY_get1_EC_KEY`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_get1_EC_KEY.html
+    #[corresponds(EVP_PKEY_get1_EC_KEY)]
     pub fn ec_key(&self) -> Result<EcKey<T>, ErrorStack> {
         unsafe {
             let ec_key = cvt_p(ffi::EVP_PKEY_get1_EC_KEY(self.as_ptr()))?;
@@ -193,19 +182,13 @@ impl<T> PKeyRef<T> {
     }
 
     /// Returns the `Id` that represents the type of this key.
-    ///
-    /// This corresponds to [`EVP_PKEY_id`].
-    ///
-    /// [`EVP_PKEY_id`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_id.html
+    #[corresponds(EVP_PKEY_id)]
     pub fn id(&self) -> Id {
         unsafe { Id::from_raw(ffi::EVP_PKEY_id(self.as_ptr())) }
     }
 
     /// Returns the maximum size of a signature in bytes.
-    ///
-    /// This corresponds to [`EVP_PKEY_size`].
-    ///
-    /// [`EVP_PKEY_size`]: https://www.openssl.org/docs/man1.1.1/man3/EVP_PKEY_size.html
+    #[corresponds(EVP_PKEY_size)]
     pub fn size(&self) -> usize {
         unsafe { ffi::EVP_PKEY_size(self.as_ptr()) as usize }
     }
@@ -219,20 +202,14 @@ where
         /// Serializes the public key into a PEM-encoded SubjectPublicKeyInfo structure.
         ///
         /// The output will have a header of `-----BEGIN PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_PUBKEY`].
-        ///
-        /// [`PEM_write_bio_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_PUBKEY.html
+        #[corresponds(PEM_write_bio_PUBKEY)]
         public_key_to_pem,
         ffi::PEM_write_bio_PUBKEY
     }
 
     to_der! {
         /// Serializes the public key into a DER-encoded SubjectPublicKeyInfo structure.
-        ///
-        /// This corresponds to [`i2d_PUBKEY`].
-        ///
-        /// [`i2d_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/i2d_PUBKEY.html
+        #[corresponds(i2d_PUBKEY)]
         public_key_to_der,
         ffi::i2d_PUBKEY
     }
@@ -241,11 +218,13 @@ where
     ///
     /// This corresponds to the bit length of the modulus of an RSA key, and the bit length of the
     /// group order for an elliptic curve key, for example.
+    #[corresponds(EVP_PKEY_bits)]
     pub fn bits(&self) -> u32 {
         unsafe { ffi::EVP_PKEY_bits(self.as_ptr()) as u32 }
     }
 
     /// Compares the public component of this key with another.
+    #[corresponds(EVP_PKEY_cmp)]
     pub fn public_eq<U>(&self, other: &PKeyRef<U>) -> bool
     where
         U: HasPublic,
@@ -257,10 +236,7 @@ where
     ///
     /// This function only works for algorithms that support raw public keys.
     /// Currently this is: X25519, ED25519, X448 or ED448
-    ///
-    /// This corresponds to [`EVP_PKEY_get_raw_public_key`].
-    ///
-    /// [`EVP_PKEY_get_raw_public_key`]: https://www.openssl.org/docs/man1.1.1/man3/EVP_PKEY_get_raw_public_key.html
+    #[corresponds(EVP_PKEY_get_raw_public_key)]
     #[cfg(ossl111)]
     pub fn raw_public_key(&self) -> Result<Vec<u8>, ErrorStack> {
         unsafe {
@@ -290,28 +266,19 @@ where
         /// Serializes the private key to a PEM-encoded PKCS#8 PrivateKeyInfo structure.
         ///
         /// The output will have a header of `-----BEGIN PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_PKCS8PrivateKey`].
-        ///
-        /// [`PEM_write_bio_PKCS8PrivateKey`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_write_bio_PKCS8PrivateKey.html
+        #[corresponds(PEM_write_bio_PKCS8PrivateKey)]
         private_key_to_pem_pkcs8,
         /// Serializes the private key to a PEM-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
         ///
         /// The output will have a header of `-----BEGIN ENCRYPTED PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_PKCS8PrivateKey`].
-        ///
-        /// [`PEM_write_bio_PKCS8PrivateKey`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_write_bio_PKCS8PrivateKey.html
+        #[corresponds(PEM_write_bio_PKCS8PrivateKey)]
         private_key_to_pem_pkcs8_passphrase,
         ffi::PEM_write_bio_PKCS8PrivateKey
     }
 
     to_der! {
         /// Serializes the private key to a DER-encoded key type specific format.
-        ///
-        /// This corresponds to [`i2d_PrivateKey`].
-        ///
-        /// [`i2d_PrivateKey`]: https://www.openssl.org/docs/man1.0.2/crypto/i2d_PrivateKey.html
+        #[corresponds(i2d_PrivateKey)]
         private_key_to_der,
         ffi::i2d_PrivateKey
     }
@@ -320,10 +287,7 @@ where
     ///
     /// This function only works for algorithms that support raw private keys.
     /// Currently this is: HMAC, X25519, ED25519, X448 or ED448
-    ///
-    /// This corresponds to [`EVP_PKEY_get_raw_private_key`].
-    ///
-    /// [`EVP_PKEY_get_raw_private_key`]: https://www.openssl.org/docs/man1.1.1/man3/EVP_PKEY_get_raw_private_key.html
+    #[corresponds(EVP_PKEY_get_raw_private_key)]
     #[cfg(ossl111)]
     pub fn raw_private_key(&self) -> Result<Vec<u8>, ErrorStack> {
         unsafe {
@@ -350,6 +314,7 @@ where
     /// # Panics
     ///
     /// Panics if `passphrase` contains an embedded null.
+    #[corresponds(i2d_PKCS8PrivateKey_bio)]
     pub fn private_key_to_pkcs8_passphrase(
         &self,
         cipher: Cipher,
@@ -401,10 +366,7 @@ impl<T> Clone for PKey<T> {
 
 impl<T> PKey<T> {
     /// Creates a new `PKey` containing an RSA key.
-    ///
-    /// This corresponds to [`EVP_PKEY_assign_RSA`].
-    ///
-    /// [`EVP_PKEY_assign_RSA`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_assign_RSA.html
+    #[corresponds(EVP_PKEY_assign_RSA)]
     pub fn from_rsa(rsa: Rsa<T>) -> Result<PKey<T>, ErrorStack> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
@@ -420,10 +382,7 @@ impl<T> PKey<T> {
     }
 
     /// Creates a new `PKey` containing a DSA key.
-    ///
-    /// This corresponds to [`EVP_PKEY_assign_DSA`].
-    ///
-    /// [`EVP_PKEY_assign_DSA`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_assign_DSA.html
+    #[corresponds(EVP_PKEY_assign_DSA)]
     pub fn from_dsa(dsa: Dsa<T>) -> Result<PKey<T>, ErrorStack> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
@@ -439,10 +398,7 @@ impl<T> PKey<T> {
     }
 
     /// Creates a new `PKey` containing a Diffie-Hellman key.
-    ///
-    /// This corresponds to [`EVP_PKEY_assign_DH`].
-    ///
-    /// [`EVP_PKEY_assign_DH`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_assign_DH.html
+    #[corresponds(EVP_PKEY_assign_DH)]
     pub fn from_dh(dh: Dh<T>) -> Result<PKey<T>, ErrorStack> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
@@ -458,10 +414,7 @@ impl<T> PKey<T> {
     }
 
     /// Creates a new `PKey` containing an elliptic curve key.
-    ///
-    /// This corresponds to [`EVP_PKEY_assign_EC_KEY`].
-    ///
-    /// [`EVP_PKEY_assign_EC_KEY`]: https://www.openssl.org/docs/man1.1.0/crypto/EVP_PKEY_assign_EC_KEY.html
+    #[corresponds(EVP_PKEY_assign_EC_KEY)]
     pub fn from_ec_key(ec_key: EcKey<T>) -> Result<PKey<T>, ErrorStack> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
@@ -483,6 +436,7 @@ impl PKey<Private> {
     /// # Note
     ///
     /// To compute HMAC values, use the `sign` module.
+    #[corresponds(EVP_PKEY_new_mac_key)]
     pub fn hmac(key: &[u8]) -> Result<PKey<Private>, ErrorStack> {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize);
@@ -546,11 +500,8 @@ impl PKey<Private> {
 
     /// Generates a new EC key using the provided curve.
     ///
-    /// This corresponds to [`EVP_EC_gen`].
-    ///
     /// Requires OpenSSL 3.0.0 or newer.
-    ///
-    /// [`EVP_EC_gen`]: https://www.openssl.org/docs/manmaster/man3/EVP_EC_gen.html
+    #[corresponds(EVP_EC_gen)]
     #[cfg(ossl300)]
     pub fn ec_gen(curve: &str) -> Result<PKey<Private>, ErrorStack> {
         let curve = CString::new(curve).unwrap();
@@ -562,26 +513,17 @@ impl PKey<Private> {
 
     private_key_from_pem! {
         /// Deserializes a private key from a PEM-encoded key type specific format.
-        ///
-        /// This corresponds to [`PEM_read_bio_PrivateKey`].
-        ///
-        /// [`PEM_read_bio_PrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_read_bio_PrivateKey.html
+        #[corresponds(PEM_read_bio_PrivateKey)]
         private_key_from_pem,
 
         /// Deserializes a private key from a PEM-encoded encrypted key type specific format.
-        ///
-        /// This corresponds to [`PEM_read_bio_PrivateKey`].
-        ///
-        /// [`PEM_read_bio_PrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_read_bio_PrivateKey.html
+        #[corresponds(PEM_read_bio_PrivateKey)]
         private_key_from_pem_passphrase,
 
         /// Deserializes a private key from a PEM-encoded encrypted key type specific format.
         ///
         /// The callback should fill the password into the provided buffer and return its length.
-        ///
-        /// This corresponds to [`PEM_read_bio_PrivateKey`].
-        ///
-        /// [`PEM_read_bio_PrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_read_bio_PrivateKey.html
+        #[corresponds(PEM_read_bio_PrivateKey)]
         private_key_from_pem_callback,
         PKey<Private>,
         ffi::PEM_read_bio_PrivateKey
@@ -590,13 +532,10 @@ impl PKey<Private> {
     from_der! {
         /// Decodes a DER-encoded private key.
         ///
-        /// This function will automatically attempt to detect the underlying key format, and
+        /// This function will attempt to automatically detect the underlying key format, and
         /// supports the unencrypted PKCS#8 PrivateKeyInfo structures as well as key type specific
         /// formats.
-        ///
-        /// This corresponds to [`d2i_AutoPrivateKey`].
-        ///
-        /// [`d2i_AutoPrivateKey`]: https://www.openssl.org/docs/man1.0.2/crypto/d2i_AutoPrivateKey.html
+        #[corresponds(d2i_AutoPrivateKey)]
         private_key_from_der,
         PKey<Private>,
         ffi::d2i_AutoPrivateKey
@@ -625,6 +564,7 @@ impl PKey<Private> {
     ///
     /// The callback should copy the password into the provided buffer and return the number of
     /// bytes written.
+    #[corresponds(d2i_PKCS8PrivateKey_bio)]
     pub fn private_key_from_pkcs8_callback<F>(
         der: &[u8],
         callback: F,
@@ -652,6 +592,7 @@ impl PKey<Private> {
     /// # Panics
     ///
     /// Panics if `passphrase` contains an embedded null.
+    #[corresponds(d2i_PKCS8PrivateKey_bio)]
     pub fn private_key_from_pkcs8_passphrase(
         der: &[u8],
         passphrase: &[u8],
@@ -673,10 +614,7 @@ impl PKey<Private> {
     /// Creates a private key from its raw byte representation
     ///
     /// Algorithm types that support raw private keys are HMAC, X25519, ED25519, X448 or ED448
-    ///
-    /// This corresponds to [`EVP_PKEY_new_raw_private_key`].
-    ///
-    /// [`EVP_PKEY_new_raw_private_key`]: https://www.openssl.org/docs/man1.1.1/man3/EVP_PKEY_new_raw_private_key.html
+    #[corresponds(EVP_PKEY_new_raw_private_key)]
     #[cfg(ossl111)]
     pub fn private_key_from_raw_bytes(
         bytes: &[u8],
@@ -700,10 +638,7 @@ impl PKey<Public> {
         /// Decodes a PEM-encoded SubjectPublicKeyInfo structure.
         ///
         /// The input should have a header of `-----BEGIN PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_read_bio_PUBKEY`].
-        ///
-        /// [`PEM_read_bio_PUBKEY`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_read_bio_PUBKEY.html
+        #[corresponds(PEM_read_bio_PUBKEY)]
         public_key_from_pem,
         PKey<Public>,
         ffi::PEM_read_bio_PUBKEY
@@ -711,10 +646,7 @@ impl PKey<Public> {
 
     from_der! {
         /// Decodes a DER-encoded SubjectPublicKeyInfo structure.
-        ///
-        /// This corresponds to [`d2i_PUBKEY`].
-        ///
-        /// [`d2i_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/d2i_PUBKEY.html
+        #[corresponds(d2i_PUBKEY)]
         public_key_from_der,
         PKey<Public>,
         ffi::d2i_PUBKEY
@@ -723,10 +655,7 @@ impl PKey<Public> {
     /// Creates a public key from its raw byte representation
     ///
     /// Algorithm types that support raw public keys are X25519, ED25519, X448 or ED448
-    ///
-    /// This corresponds to [`EVP_PKEY_new_raw_public_key`].
-    ///
-    /// [`EVP_PKEY_new_raw_public_key`]: https://www.openssl.org/docs/man1.1.1/man3/EVP_PKEY_new_raw_public_key.html
+    #[corresponds(EVP_PKEY_new_raw_public_key)]
     #[cfg(ossl111)]
     pub fn public_key_from_raw_bytes(
         bytes: &[u8],

--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -41,6 +41,7 @@ use crate::rsa::Padding;
 use crate::{cvt, cvt_p};
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
+use openssl_macros::corresponds;
 use std::convert::TryFrom;
 use std::ptr;
 
@@ -56,10 +57,7 @@ generic_foreign_type_and_impl_send_sync! {
 
 impl<T> PkeyCtx<T> {
     /// Creates a new pkey context using the provided key.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_new`].
-    ///
-    /// [`EVP_PKEY_CTX_new`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_new.html
+    #[corresponds(EVP_PKEY_CTX_new)]
     #[inline]
     pub fn new(pkey: &PKeyRef<T>) -> Result<Self, ErrorStack> {
         unsafe {
@@ -71,10 +69,7 @@ impl<T> PkeyCtx<T> {
 
 impl PkeyCtx<()> {
     /// Creates a new pkey context for the specified algorithm ID.
-    ///
-    /// This corresponds to [`EVP_PKEY_new_id`].
-    ///
-    /// [`EVP_PKEY_new_id`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_new_id.html
+    #[corresponds(EVP_PKEY_new_id)]
     #[inline]
     pub fn new_id(id: Id) -> Result<Self, ErrorStack> {
         unsafe {
@@ -89,10 +84,7 @@ where
     T: HasPublic,
 {
     /// Prepares the context for encryption using the public key.
-    ///
-    /// This corresponds to [`EVP_PKEY_encrypt_init`].
-    ///
-    /// [`EVP_PKEY_encrypt_init`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt_init.html
+    #[corresponds(EVP_PKEY_encrypt_init)]
     #[inline]
     pub fn encrypt_init(&mut self) -> Result<(), ErrorStack> {
         unsafe {
@@ -106,10 +98,7 @@ where
     ///
     /// If `to` is set to `None`, an upper bound on the number of bytes required for the output buffer will be
     /// returned.
-    ///
-    /// This corresponds to [`EVP_PKEY_encrypt`].
-    ///
-    /// [`EVP_PKEY_encrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt.html
+    #[corresponds(EVP_PKEY_encrypt)]
     #[inline]
     pub fn encrypt(&mut self, from: &[u8], to: Option<&mut [u8]>) -> Result<usize, ErrorStack> {
         let mut written = to.as_ref().map_or(0, |b| b.len());
@@ -142,10 +131,7 @@ where
     T: HasPrivate,
 {
     /// Prepares the context for encryption using the private key.
-    ///
-    /// This corresponds to [`EVP_PKEY_decrypt_init`].
-    ///
-    /// [`EVP_PKEY_decrypt_init`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_decrypt_init.html
+    #[corresponds(EVP_PKEY_decrypt_init)]
     #[inline]
     pub fn decrypt_init(&mut self) -> Result<(), ErrorStack> {
         unsafe {
@@ -156,10 +142,7 @@ where
     }
 
     /// Prepares the context for shared secret derivation.
-    ///
-    /// This corresponds to [`EVP_PKEY_derive_init`].
-    ///
-    /// [`EVP_PKEY_derive_init`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_derive_init.html
+    #[corresponds(EVP_PKEY_derive_init)]
     #[inline]
     pub fn derive_init(&mut self) -> Result<(), ErrorStack> {
         unsafe {
@@ -170,10 +153,7 @@ where
     }
 
     /// Sets the peer key used for secret derivation.
-    ///
-    /// This corresponds to [`EVP_PKEY_derive_set_peer`].
-    ///
-    /// [`EVP_PKEY_derive_set_peer`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_derive_set_peer.html
+    #[corresponds(EVP_PKEY_derive_set_peer)]
     pub fn derive_set_peer<U>(&mut self, key: &PKeyRef<U>) -> Result<(), ErrorStack>
     where
         U: HasPublic,
@@ -189,10 +169,7 @@ where
     ///
     /// If `to` is set to `None`, an upper bound on the number of bytes required for the output buffer will be
     /// returned.
-    ///
-    /// This corresponds to [`EVP_PKEY_decrypt`].
-    ///
-    /// [`EVP_PKEY_decrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt.html
+    #[corresponds(EVP_PKEY_decrypt)]
     #[inline]
     pub fn decrypt(&mut self, from: &[u8], to: Option<&mut [u8]>) -> Result<usize, ErrorStack> {
         let mut written = to.as_ref().map_or(0, |b| b.len());
@@ -222,10 +199,7 @@ where
     /// Derives a shared secrete between two keys.
     ///
     /// If `buf` is set to `None`, an upper bound on the number of bytes required for the buffer will be returned.
-    ///
-    /// This corresponds to [`EVP_PKEY_derive`].
-    ///
-    /// [`EVP_PKEY_derive`]: https://www.openssl.org/docs/manmaster/crypto/EVP_PKEY_derive_init.html
+    #[corresponds(EVP_PKEY_derive)]
     pub fn derive(&mut self, buf: Option<&mut [u8]>) -> Result<usize, ErrorStack> {
         let mut len = buf.as_ref().map_or(0, |b| b.len());
         unsafe {
@@ -252,10 +226,7 @@ where
 
 impl<T> PkeyCtxRef<T> {
     /// Prepares the context for key generation.
-    ///
-    /// This corresponds to [`EVP_PKEY_keygen_init`].
-    ///
-    /// [`EVP_PKEY_keygen_init`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_keygen_init.html
+    #[corresponds(EVP_PKEY_keygen_init)]
     pub fn keygen_init(&mut self) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_keygen_init(self.as_ptr()))?;
@@ -267,10 +238,7 @@ impl<T> PkeyCtxRef<T> {
     /// Returns the RSA padding mode in use.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_get_rsa_padding`].
-    ///
-    /// [`EVP_PKEY_CTX_get_rsa_padding`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_get_rsa_padding.html
+    #[corresponds(EVP_PKEY_CTX_get_rsa_padding)]
     #[inline]
     pub fn rsa_padding(&self) -> Result<Padding, ErrorStack> {
         let mut pad = 0;
@@ -284,10 +252,7 @@ impl<T> PkeyCtxRef<T> {
     /// Sets the RSA padding mode.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_padding`].
-    ///
-    /// [`EVP_PKEY_CTX_set_rsa_padding`]: https://www.openssl.org/docs/manmaster/crypto/EVP_PKEY_CTX_set_rsa_padding.html
+    #[corresponds(EVP_PKEY_CTX_set_rsa_padding)]
     #[inline]
     pub fn set_rsa_padding(&mut self, padding: Padding) -> Result<(), ErrorStack> {
         unsafe {
@@ -303,10 +268,7 @@ impl<T> PkeyCtxRef<T> {
     /// Sets the RSA MGF1 algorithm.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_mgf1_md`].
-    ///
-    /// [`EVP_PKEY_CTX_set_rsa_mgf1_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_mgf1_md.html
+    #[corresponds(EVP_PKEY_CTX_set_rsa_mgf1_md)]
     #[inline]
     pub fn set_rsa_mgf1_md(&mut self, md: &MdRef) -> Result<(), ErrorStack> {
         unsafe {
@@ -322,10 +284,7 @@ impl<T> PkeyCtxRef<T> {
     /// Sets the RSA OAEP algorithm.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
-    ///
-    /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
+    #[corresponds(EVP_PKEY_CTX_set_rsa_oaep_md)]
     #[cfg(any(ossl102, libressl310))]
     #[inline]
     pub fn set_rsa_oaep_md(&mut self, md: &MdRef) -> Result<(), ErrorStack> {
@@ -342,10 +301,7 @@ impl<T> PkeyCtxRef<T> {
     /// Sets the RSA OAEP label.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set0_rsa_oaep_label`].
-    ///
-    /// [`EVP_PKEY_CTX_set0_rsa_oaep_label`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set0_rsa_oaep_label.html
+    #[corresponds(EVP_PKEY_CTX_set0_rsa_oaep_label)]
     #[cfg(any(ossl102, libressl310))]
     pub fn set_rsa_oaep_label(&mut self, label: &[u8]) -> Result<(), ErrorStack> {
         let len = c_int::try_from(label.len()).unwrap();
@@ -365,10 +321,7 @@ impl<T> PkeyCtxRef<T> {
     }
 
     /// Sets the cipher used during key generation.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_ctrl`] with `EVP_PKEY_CTRL_CIPHER`.
-    ///
-    /// [`EVP_PKEY_CTX_ctrl`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_ctrl.html
+    #[corresponds(EVP_PKEY_CTX_ctrl)]
     pub fn set_keygen_cipher(&mut self, cipher: &CipherRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_ctrl(
@@ -385,10 +338,7 @@ impl<T> PkeyCtxRef<T> {
     }
 
     /// Sets the key MAC key used during key generation.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_ctrl`] with `EVP_PKEY_CTRL_SET_MAC_KEY`.
-    ///
-    /// [`EVP_PKEY_CTX_ctrl`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_ctrl.html
+    #[corresponds(EVP_PKEY_CTX_ctrl)]
     pub fn set_keygen_mac_key(&mut self, key: &[u8]) -> Result<(), ErrorStack> {
         let len = c_int::try_from(key.len()).unwrap();
 
@@ -407,10 +357,7 @@ impl<T> PkeyCtxRef<T> {
     }
 
     /// Generates a new public/private keypair.
-    ///
-    /// This corresponds to [`EVP_PKEY_keygen`].
-    ///
-    /// [`EVP_PKEY_keygen`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_ctrl.html
+    #[corresponds(EVP_PKEY_keygen)]
     pub fn keygen(&mut self) -> Result<PKey<Private>, ErrorStack> {
         unsafe {
             let mut key = ptr::null_mut();

--- a/openssl/src/rand.rs
+++ b/openssl/src/rand.rs
@@ -14,14 +14,13 @@ use libc::c_int;
 
 use crate::cvt;
 use crate::error::ErrorStack;
+use openssl_macros::corresponds;
 
 /// Fill buffer with cryptographically strong pseudo-random bytes.
 ///
-/// This corresponds to [`RAND_bytes`].
-///
 /// # Examples
 ///
-/// To generate a buffer with cryptographically strong bytes:
+/// To generate a buffer with cryptographically strong random bytes:
 ///
 /// ```
 /// use openssl::rand::rand_bytes;
@@ -29,8 +28,7 @@ use crate::error::ErrorStack;
 /// let mut buf = [0; 256];
 /// rand_bytes(&mut buf).unwrap();
 /// ```
-///
-/// [`RAND_bytes`]: https://www.openssl.org/docs/man1.1.0/crypto/RAND_bytes.html
+#[corresponds(RAND_bytes)]
 pub fn rand_bytes(buf: &mut [u8]) -> Result<(), ErrorStack> {
     unsafe {
         ffi::init();
@@ -42,10 +40,7 @@ pub fn rand_bytes(buf: &mut [u8]) -> Result<(), ErrorStack> {
 /// Controls random device file descriptor behavior.
 ///
 /// Requires OpenSSL 1.1.1 or newer.
-///
-/// This corresponds to [`RAND_keep_random_devices_open`].
-///
-/// [`RAND_keep_random_devices_open`]: https://www.openssl.org/docs/manmaster/man3/RAND_keep_random_devices_open.html
+#[corresponds(RAND_keep_random_devices_open)]
 #[cfg(ossl111)]
 pub fn keep_random_devices_open(keep: bool) {
     unsafe {

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -35,6 +35,7 @@ use crate::error::ErrorStack;
 use crate::pkey::{HasPrivate, HasPublic, Private, Public};
 use crate::util::ForeignTypeRefExt;
 use crate::{cvt, cvt_n, cvt_p};
+use openssl_macros::corresponds;
 
 /// Type of encryption padding to use.
 ///
@@ -98,28 +99,19 @@ where
         /// Serializes the private key to a PEM-encoded PKCS#1 RSAPrivateKey structure.
         ///
         /// The output will have a header of `-----BEGIN RSA PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_RSAPrivateKey`].
-        ///
-        /// [`PEM_write_bio_RSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_RSAPrivateKey.html
+        #[corresponds(PEM_write_bio_RSAPrivateKey)]
         private_key_to_pem,
         /// Serializes the private key to a PEM-encoded encrypted PKCS#1 RSAPrivateKey structure.
         ///
         /// The output will have a header of `-----BEGIN RSA PRIVATE KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_RSAPrivateKey`].
-        ///
-        /// [`PEM_write_bio_RSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_write_bio_RSAPrivateKey.html
+        #[corresponds(PEM_write_bio_RSAPrivateKey)]
         private_key_to_pem_passphrase,
         ffi::PEM_write_bio_RSAPrivateKey
     }
 
     to_der! {
         /// Serializes the private key to a DER-encoded PKCS#1 RSAPrivateKey structure.
-        ///
-        /// This corresponds to [`i2d_RSAPrivateKey`].
-        ///
-        /// [`i2d_RSAPrivateKey`]: https://www.openssl.org/docs/man1.0.2/crypto/i2d_RSAPrivateKey.html
+        #[corresponds(i2d_RSAPrivateKey)]
         private_key_to_der,
         ffi::i2d_RSAPrivateKey
     }
@@ -130,6 +122,7 @@ where
     ///
     /// Panics if `self` has no private components, or if `to` is smaller
     /// than `self.size()`.
+    #[corresponds(RSA_private_decrypt)]
     pub fn private_decrypt(
         &self,
         from: &[u8],
@@ -157,6 +150,7 @@ where
     ///
     /// Panics if `self` has no private components, or if `to` is smaller
     /// than `self.size()`.
+    #[corresponds(RSA_private_encrypt)]
     pub fn private_encrypt(
         &self,
         from: &[u8],
@@ -179,10 +173,7 @@ where
     }
 
     /// Returns a reference to the private exponent of the key.
-    ///
-    /// This corresponds to [`RSA_get0_key`].
-    ///
-    /// [`RSA_get0_key`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_get0_key.html
+    #[corresponds(RSA_get0_key)]
     pub fn d(&self) -> &BigNumRef {
         unsafe {
             let mut d = ptr::null();
@@ -192,10 +183,7 @@ where
     }
 
     /// Returns a reference to the first factor of the exponent of the key.
-    ///
-    /// This corresponds to [`RSA_get0_factors`].
-    ///
-    /// [`RSA_get0_factors`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_get0_key.html
+    #[corresponds(RSA_get0_factors)]
     pub fn p(&self) -> Option<&BigNumRef> {
         unsafe {
             let mut p = ptr::null();
@@ -205,10 +193,7 @@ where
     }
 
     /// Returns a reference to the second factor of the exponent of the key.
-    ///
-    /// This corresponds to [`RSA_get0_factors`].
-    ///
-    /// [`RSA_get0_factors`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_get0_key.html
+    #[corresponds(RSA_get0_factors)]
     pub fn q(&self) -> Option<&BigNumRef> {
         unsafe {
             let mut q = ptr::null();
@@ -218,10 +203,7 @@ where
     }
 
     /// Returns a reference to the first exponent used for CRT calculations.
-    ///
-    /// This corresponds to [`RSA_get0_crt_params`].
-    ///
-    /// [`RSA_get0_crt_params`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_get0_key.html
+    #[corresponds(RSA_get0_crt_params)]
     pub fn dmp1(&self) -> Option<&BigNumRef> {
         unsafe {
             let mut dp = ptr::null();
@@ -231,10 +213,7 @@ where
     }
 
     /// Returns a reference to the second exponent used for CRT calculations.
-    ///
-    /// This corresponds to [`RSA_get0_crt_params`].
-    ///
-    /// [`RSA_get0_crt_params`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_get0_key.html
+    #[corresponds(RSA_get0_crt_params)]
     pub fn dmq1(&self) -> Option<&BigNumRef> {
         unsafe {
             let mut dq = ptr::null();
@@ -244,10 +223,7 @@ where
     }
 
     /// Returns a reference to the coefficient used for CRT calculations.
-    ///
-    /// This corresponds to [`RSA_get0_crt_params`].
-    ///
-    /// [`RSA_get0_crt_params`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_get0_key.html
+    #[corresponds(RSA_get0_crt_params)]
     pub fn iqmp(&self) -> Option<&BigNumRef> {
         unsafe {
             let mut qi = ptr::null();
@@ -257,10 +233,7 @@ where
     }
 
     /// Validates RSA parameters for correctness
-    ///
-    /// This corresponds to [`RSA_check_key`].
-    ///
-    /// [`RSA_check_key`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_check_key.html
+    #[corresponds(RSA_check_key)]
     pub fn check_key(&self) -> Result<bool, ErrorStack> {
         unsafe {
             let result = ffi::RSA_check_key(self.as_ptr()) as i32;
@@ -281,20 +254,14 @@ where
         /// Serializes the public key into a PEM-encoded SubjectPublicKeyInfo structure.
         ///
         /// The output will have a header of `-----BEGIN PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_RSA_PUBKEY`].
-        ///
-        /// [`PEM_write_bio_RSA_PUBKEY`]: https://www.openssl.org/docs/man1.0.2/crypto/pem.html
+        #[corresponds(PEM_write_bio_RSA_PUBKEY)]
         public_key_to_pem,
         ffi::PEM_write_bio_RSA_PUBKEY
     }
 
     to_der! {
         /// Serializes the public key into a DER-encoded SubjectPublicKeyInfo structure.
-        ///
-        /// This corresponds to [`i2d_RSA_PUBKEY`].
-        ///
-        /// [`i2d_RSA_PUBKEY`]: https://www.openssl.org/docs/man1.1.0/crypto/i2d_RSA_PUBKEY.html
+        #[corresponds(i2d_RSA_PUBKEY)]
         public_key_to_der,
         ffi::i2d_RSA_PUBKEY
     }
@@ -303,29 +270,20 @@ where
         /// Serializes the public key into a PEM-encoded PKCS#1 RSAPublicKey structure.
         ///
         /// The output will have a header of `-----BEGIN RSA PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_RSAPublicKey`].
-        ///
-        /// [`PEM_write_bio_RSAPublicKey`]: https://www.openssl.org/docs/man1.0.2/crypto/pem.html
+        #[corresponds(PEM_write_bio_RSAPublicKey)]
         public_key_to_pem_pkcs1,
         ffi::PEM_write_bio_RSAPublicKey
     }
 
     to_der! {
         /// Serializes the public key into a DER-encoded PKCS#1 RSAPublicKey structure.
-        ///
-        /// This corresponds to [`i2d_RSAPublicKey`].
-        ///
-        /// [`i2d_RSAPublicKey`]: https://www.openssl.org/docs/man1.0.2/crypto/i2d_RSAPublicKey.html
+        #[corresponds(i2d_RSAPublicKey)]
         public_key_to_der_pkcs1,
         ffi::i2d_RSAPublicKey
     }
 
     /// Returns the size of the modulus in bytes.
-    ///
-    /// This corresponds to [`RSA_size`].
-    ///
-    /// [`RSA_size`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_size.html
+    #[corresponds(RSA_size)]
     pub fn size(&self) -> u32 {
         unsafe { ffi::RSA_size(self.as_ptr()) as u32 }
     }
@@ -335,6 +293,7 @@ where
     /// # Panics
     ///
     /// Panics if `to` is smaller than `self.size()`.
+    #[corresponds(RSA_public_decrypt)]
     pub fn public_decrypt(
         &self,
         from: &[u8],
@@ -361,6 +320,7 @@ where
     /// # Panics
     ///
     /// Panics if `to` is smaller than `self.size()`.
+    #[corresponds(RSA_public_encrypt)]
     pub fn public_encrypt(
         &self,
         from: &[u8],
@@ -383,10 +343,7 @@ where
     }
 
     /// Returns a reference to the modulus of the key.
-    ///
-    /// This corresponds to [`RSA_get0_key`].
-    ///
-    /// [`RSA_get0_key`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_get0_key.html
+    #[corresponds(RSA_get0_key)]
     pub fn n(&self) -> &BigNumRef {
         unsafe {
             let mut n = ptr::null();
@@ -396,10 +353,7 @@ where
     }
 
     /// Returns a reference to the public exponent of the key.
-    ///
-    /// This corresponds to [`RSA_get0_key`].
-    ///
-    /// [`RSA_get0_key`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_get0_key.html
+    #[corresponds(RSA_get0_key)]
     pub fn e(&self) -> &BigNumRef {
         unsafe {
             let mut e = ptr::null();
@@ -417,8 +371,8 @@ impl Rsa<Public> {
     ///
     /// This corresponds to [`RSA_new`] and uses [`RSA_set0_key`].
     ///
-    /// [`RSA_new`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_new.html
-    /// [`RSA_set0_key`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_set0_key.html
+    /// [`RSA_new`]: https://www.openssl.org/docs/manmaster/crypto/RSA_new.html
+    /// [`RSA_set0_key`]: https://www.openssl.org/docs/manmaster/crypto/RSA_set0_key.html
     pub fn from_public_components(n: BigNum, e: BigNum) -> Result<Rsa<Public>, ErrorStack> {
         unsafe {
             let rsa = cvt_p(ffi::RSA_new())?;
@@ -432,10 +386,7 @@ impl Rsa<Public> {
         /// Decodes a PEM-encoded SubjectPublicKeyInfo structure containing an RSA key.
         ///
         /// The input should have a header of `-----BEGIN PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_read_bio_RSA_PUBKEY`].
-        ///
-        /// [`PEM_read_bio_RSA_PUBKEY`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_read_bio_RSA_PUBKEY.html
+        #[corresponds(PEM_read_bio_RSA_PUBKEY)]
         public_key_from_pem,
         Rsa<Public>,
         ffi::PEM_read_bio_RSA_PUBKEY
@@ -445,10 +396,7 @@ impl Rsa<Public> {
         /// Decodes a PEM-encoded PKCS#1 RSAPublicKey structure.
         ///
         /// The input should have a header of `-----BEGIN RSA PUBLIC KEY-----`.
-        ///
-        /// This corresponds to [`PEM_read_bio_RSAPublicKey`].
-        ///
-        /// [`PEM_read_bio_RSAPublicKey`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_read_bio_RSAPublicKey.html
+        #[corresponds(PEM_read_bio_RSAPublicKey)]
         public_key_from_pem_pkcs1,
         Rsa<Public>,
         ffi::PEM_read_bio_RSAPublicKey
@@ -456,10 +404,7 @@ impl Rsa<Public> {
 
     from_der! {
         /// Decodes a DER-encoded SubjectPublicKeyInfo structure containing an RSA key.
-        ///
-        /// This corresponds to [`d2i_RSA_PUBKEY`].
-        ///
-        /// [`d2i_RSA_PUBKEY`]: https://www.openssl.org/docs/man1.0.2/crypto/d2i_RSA_PUBKEY.html
+        #[corresponds(d2i_RSA_PUBKEY)]
         public_key_from_der,
         Rsa<Public>,
         ffi::d2i_RSA_PUBKEY
@@ -467,10 +412,7 @@ impl Rsa<Public> {
 
     from_der! {
         /// Decodes a DER-encoded PKCS#1 RSAPublicKey structure.
-        ///
-        /// This corresponds to [`d2i_RSAPublicKey`].
-        ///
-        /// [`d2i_RSAPublicKey`]: https://www.openssl.org/docs/man1.0.2/crypto/d2i_RSA_PUBKEY.html
+        #[corresponds(d2i_RSAPublicKey)]
         public_key_from_der_pkcs1,
         Rsa<Public>,
         ffi::d2i_RSAPublicKey
@@ -489,8 +431,8 @@ impl RsaPrivateKeyBuilder {
     ///
     /// This corresponds to [`RSA_new`] and uses [`RSA_set0_key`].
     ///
-    /// [`RSA_new`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_new.html
-    /// [`RSA_set0_key`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_set0_key.html
+    /// [`RSA_new`]: https://www.openssl.org/docs/manmaster/crypto/RSA_new.html
+    /// [`RSA_set0_key`]: https://www.openssl.org/docs/manmaster/crypto/RSA_set0_key.html
     pub fn new(n: BigNum, e: BigNum, d: BigNum) -> Result<RsaPrivateKeyBuilder, ErrorStack> {
         unsafe {
             let rsa = cvt_p(ffi::RSA_new())?;
@@ -505,10 +447,7 @@ impl RsaPrivateKeyBuilder {
     /// Sets the factors of the Rsa key.
     ///
     /// `p` and `q` are the first and second factors of `n`.
-    ///
-    /// This correspond to [`RSA_set0_factors`].
-    ///
-    /// [`RSA_set0_factors`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_set0_factors.html
+    #[corresponds(RSA_set0_factors)]
     // FIXME should be infallible
     pub fn set_factors(self, p: BigNum, q: BigNum) -> Result<RsaPrivateKeyBuilder, ErrorStack> {
         unsafe {
@@ -522,10 +461,7 @@ impl RsaPrivateKeyBuilder {
     ///
     /// `dmp1`, `dmq1`, and `iqmp` are the exponents and coefficient for
     /// CRT calculations which is used to speed up RSA operations.
-    ///
-    /// This correspond to [`RSA_set0_crt_params`].
-    ///
-    /// [`RSA_set0_crt_params`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_set0_crt_params.html
+    #[corresponds(RSA_set0_crt_params)]
     // FIXME should be infallible
     pub fn set_crt_params(
         self,
@@ -576,10 +512,7 @@ impl Rsa<Private> {
     /// Generates a public/private key pair with the specified size.
     ///
     /// The public exponent will be 65537.
-    ///
-    /// This corresponds to [`RSA_generate_key_ex`].
-    ///
-    /// [`RSA_generate_key_ex`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_generate_key_ex.html
+    #[corresponds(RSA_generate_key_ex)]
     pub fn generate(bits: u32) -> Result<Rsa<Private>, ErrorStack> {
         let e = BigNum::from_u32(ffi::RSA_F4 as u32)?;
         Rsa::generate_with_e(bits, &e)
@@ -588,10 +521,7 @@ impl Rsa<Private> {
     /// Generates a public/private key pair with the specified size and a custom exponent.
     ///
     /// Unless you have specific needs and know what you're doing, use `Rsa::generate` instead.
-    ///
-    /// This corresponds to [`RSA_generate_key_ex`].
-    ///
-    /// [`RSA_generate_key_ex`]: https://www.openssl.org/docs/man1.1.0/crypto/RSA_generate_key_ex.html
+    #[corresponds(RSA_generate_key_ex)]
     pub fn generate_with_e(bits: u32, e: &BigNumRef) -> Result<Rsa<Private>, ErrorStack> {
         unsafe {
             let rsa = Rsa::from_ptr(cvt_p(ffi::RSA_new())?);
@@ -608,26 +538,17 @@ impl Rsa<Private> {
     // FIXME these need to identify input formats
     private_key_from_pem! {
         /// Deserializes a private key from a PEM-encoded PKCS#1 RSAPrivateKey structure.
-        ///
-        /// This corresponds to [`PEM_read_bio_RSAPrivateKey`].
-        ///
-        /// [`PEM_read_bio_RSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_read_bio_RSAPrivateKey.html
+        #[corresponds(PEM_read_bio_RSAPrivateKey)]
         private_key_from_pem,
 
         /// Deserializes a private key from a PEM-encoded encrypted PKCS#1 RSAPrivateKey structure.
-        ///
-        /// This corresponds to [`PEM_read_bio_RSAPrivateKey`].
-        ///
-        /// [`PEM_read_bio_RSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_read_bio_RSAPrivateKey.html
+        #[corresponds(PEM_read_bio_RSAPrivateKey)]
         private_key_from_pem_passphrase,
 
         /// Deserializes a private key from a PEM-encoded encrypted PKCS#1 RSAPrivateKey structure.
         ///
         /// The callback should fill the password into the provided buffer and return its length.
-        ///
-        /// This corresponds to [`PEM_read_bio_RSAPrivateKey`].
-        ///
-        /// [`PEM_read_bio_RSAPrivateKey`]: https://www.openssl.org/docs/man1.1.0/crypto/PEM_read_bio_RSAPrivateKey.html
+        #[corresponds(PEM_read_bio_RSAPrivateKey)]
         private_key_from_pem_callback,
         Rsa<Private>,
         ffi::PEM_read_bio_RSAPrivateKey
@@ -635,10 +556,7 @@ impl Rsa<Private> {
 
     from_der! {
         /// Decodes a DER-encoded PKCS#1 RSAPrivateKey structure.
-        ///
-        /// This corresponds to [`d2i_RSAPrivateKey`].
-        ///
-        /// [`d2i_RSAPrivateKey`]: https://www.openssl.org/docs/man1.0.2/crypto/d2i_RSA_PUBKEY.html
+        #[corresponds(d2i_RSAPrivateKey)]
         private_key_from_der,
         Rsa<Private>,
         ffi::d2i_RSAPrivateKey

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -37,6 +37,7 @@
 //! ```
 use cfg_if::cfg_if;
 use libc::c_void;
+use openssl_macros::corresponds;
 use std::mem::MaybeUninit;
 
 /// Computes the SHA1 hash of some data.
@@ -45,6 +46,7 @@ use std::mem::MaybeUninit;
 ///
 /// SHA1 is known to be insecure - it should not be used unless required for
 /// compatibility with existing systems.
+#[corresponds(SHA1)]
 #[inline]
 pub fn sha1(data: &[u8]) -> [u8; 20] {
     unsafe {
@@ -55,6 +57,7 @@ pub fn sha1(data: &[u8]) -> [u8; 20] {
 }
 
 /// Computes the SHA224 hash of some data.
+#[corresponds(SH224)]
 #[inline]
 pub fn sha224(data: &[u8]) -> [u8; 28] {
     unsafe {
@@ -65,6 +68,7 @@ pub fn sha224(data: &[u8]) -> [u8; 28] {
 }
 
 /// Computes the SHA256 hash of some data.
+#[corresponds(SHA256)]
 #[inline]
 pub fn sha256(data: &[u8]) -> [u8; 32] {
     unsafe {
@@ -75,6 +79,7 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
 }
 
 /// Computes the SHA384 hash of some data.
+#[corresponds(SHA384)]
 #[inline]
 pub fn sha384(data: &[u8]) -> [u8; 48] {
     unsafe {
@@ -85,6 +90,7 @@ pub fn sha384(data: &[u8]) -> [u8; 48] {
 }
 
 /// Computes the SHA512 hash of some data.
+#[corresponds(SHA512)]
 #[inline]
 pub fn sha512(data: &[u8]) -> [u8; 64] {
     unsafe {
@@ -114,6 +120,7 @@ cfg_if! {
 
         impl Sha1 {
             /// Creates a new hasher.
+            #[corresponds(SHA1_Init)]
             #[inline]
             pub fn new() -> Sha1 {
                 unsafe {
@@ -126,6 +133,7 @@ cfg_if! {
             /// Feeds some data into the hasher.
             ///
             /// This can be called multiple times.
+            #[corresponds(SHA1_Update)]
             #[inline]
             pub fn update(&mut self, buf: &[u8]) {
                 unsafe {
@@ -134,6 +142,7 @@ cfg_if! {
             }
 
             /// Returns the hash of the data.
+            #[corresponds(SHA1_Final)]
             #[inline]
             pub fn finish(mut self) -> [u8; 20] {
                 unsafe {
@@ -157,6 +166,7 @@ cfg_if! {
 
         impl Sha224 {
             /// Creates a new hasher.
+            #[corresponds(SHA224_Init)]
             #[inline]
             pub fn new() -> Sha224 {
                 unsafe {
@@ -169,6 +179,7 @@ cfg_if! {
             /// Feeds some data into the hasher.
             ///
             /// This can be called multiple times.
+            #[corresponds(SHA224_Update)]
             #[inline]
             pub fn update(&mut self, buf: &[u8]) {
                 unsafe {
@@ -177,6 +188,7 @@ cfg_if! {
             }
 
             /// Returns the hash of the data.
+            #[corresponds(SHA224_Final)]
             #[inline]
             pub fn finish(mut self) -> [u8; 28] {
                 unsafe {
@@ -200,6 +212,7 @@ cfg_if! {
 
         impl Sha256 {
             /// Creates a new hasher.
+            #[corresponds(SHA256_Init)]
             #[inline]
             pub fn new() -> Sha256 {
                 unsafe {
@@ -212,6 +225,7 @@ cfg_if! {
             /// Feeds some data into the hasher.
             ///
             /// This can be called multiple times.
+            #[corresponds(SHA256_Update)]
             #[inline]
             pub fn update(&mut self, buf: &[u8]) {
                 unsafe {
@@ -220,6 +234,7 @@ cfg_if! {
             }
 
             /// Returns the hash of the data.
+            #[corresponds(SHA256_Final)]
             #[inline]
             pub fn finish(mut self) -> [u8; 32] {
                 unsafe {
@@ -243,6 +258,7 @@ cfg_if! {
 
         impl Sha384 {
             /// Creates a new hasher.
+            #[corresponds(SHA384_Init)]
             #[inline]
             pub fn new() -> Sha384 {
                 unsafe {
@@ -255,6 +271,7 @@ cfg_if! {
             /// Feeds some data into the hasher.
             ///
             /// This can be called multiple times.
+            #[corresponds(SHA384_Update)]
             #[inline]
             pub fn update(&mut self, buf: &[u8]) {
                 unsafe {
@@ -263,6 +280,7 @@ cfg_if! {
             }
 
             /// Returns the hash of the data.
+            #[corresponds(SHA384_Final)]
             #[inline]
             pub fn finish(mut self) -> [u8; 48] {
                 unsafe {
@@ -286,6 +304,7 @@ cfg_if! {
 
         impl Sha512 {
             /// Creates a new hasher.
+            #[corresponds(SHA512_Init)]
             #[inline]
             pub fn new() -> Sha512 {
                 unsafe {
@@ -298,6 +317,7 @@ cfg_if! {
             /// Feeds some data into the hasher.
             ///
             /// This can be called multiple times.
+            #[corresponds(SHA512_Update)]
             #[inline]
             pub fn update(&mut self, buf: &[u8]) {
                 unsafe {
@@ -306,6 +326,7 @@ cfg_if! {
             }
 
             /// Returns the hash of the data.
+            #[corresponds(SHA512_Final)]
             #[inline]
             pub fn finish(mut self) -> [u8; 64] {
                 unsafe {

--- a/openssl/src/version.rs
+++ b/openssl/src/version.rs
@@ -12,6 +12,7 @@
 //
 
 use cfg_if::cfg_if;
+use openssl_macros::corresponds;
 use std::ffi::CStr;
 
 cfg_if! {
@@ -41,24 +42,13 @@ cfg_if! {
 /// `0x000906000 == 0.9.6 dev`
 /// `0x000906023 == 0.9.6b beta 3`
 /// `0x00090605f == 0.9.6e release`
-///
-/// Versions prior to 0.9.3 have identifiers < 0x0930. Versions between 0.9.3 and 0.9.5 had a version identifier with this interpretation:
-///
-/// `MMNNFFRBB major minor fix final beta/patch`
-///
-/// for example
-///
-/// `0x000904100 == 0.9.4 release`
-/// `0x000905000 == 0.9.5 dev`
-///
-/// Version 0.9.5a had an interim interpretation that is like the current one, except the patch level got the highest bit set, to keep continuity. The number was therefore 0x0090581f
-///
-/// The return value of this function can be compared to the macro to make sure that the correct version of the library has been loaded, especially when using DLLs on Windows systems.
+#[corresponds(OpenSSL_version_num)]
 pub fn number() -> i64 {
     unsafe { OpenSSL_version_num() as i64 }
 }
 
 /// The text variant of the version number and the release date. For example, "OpenSSL 0.9.5a 1 Apr 2000".
+#[corresponds(OpenSSL_version)]
 pub fn version() -> &'static str {
     unsafe {
         CStr::from_ptr(OpenSSL_version(OPENSSL_VERSION))
@@ -69,6 +59,7 @@ pub fn version() -> &'static str {
 
 /// The compiler flags set for the compilation process in the form "compiler: ..." if available or
 /// "compiler: information not available" otherwise.
+#[corresponds(OpenSSL_version)]
 pub fn c_flags() -> &'static str {
     unsafe {
         CStr::from_ptr(OpenSSL_version(OPENSSL_CFLAGS))
@@ -78,6 +69,7 @@ pub fn c_flags() -> &'static str {
 }
 
 /// The date of the build process in the form "built on: ..." if available or "built on: date not available" otherwise.
+#[corresponds(OpenSSL_version)]
 pub fn built_on() -> &'static str {
     unsafe {
         CStr::from_ptr(OpenSSL_version(OPENSSL_BUILT_ON))
@@ -87,6 +79,7 @@ pub fn built_on() -> &'static str {
 }
 
 /// The "Configure" target of the library build in the form "platform: ..." if available or "platform: information not available" otherwise.
+#[corresponds(OpenSSL_version)]
 pub fn platform() -> &'static str {
     unsafe {
         CStr::from_ptr(OpenSSL_version(OPENSSL_PLATFORM))
@@ -96,6 +89,7 @@ pub fn platform() -> &'static str {
 }
 
 /// The "OPENSSLDIR" setting of the library build in the form "OPENSSLDIR: "..."" if available or "OPENSSLDIR: N/A" otherwise.
+#[corresponds(OpenSSL_version)]
 pub fn dir() -> &'static str {
     unsafe {
         CStr::from_ptr(OpenSSL_version(OPENSSL_DIR))

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -35,6 +35,7 @@ use crate::stack::{Stack, StackRef, Stackable};
 use crate::string::OpensslString;
 use crate::util::{ForeignTypeExt, ForeignTypeRefExt};
 use crate::{cvt, cvt_n, cvt_p};
+use openssl_macros::corresponds;
 
 #[cfg(any(ossl102, libressl261))]
 pub mod verify;
@@ -52,22 +53,20 @@ foreign_type_and_impl_send_sync! {
     /// An `X509` certificate store context.
     pub struct X509StoreContext;
 
-    /// Reference to `X509StoreContext`.
+    /// A reference to an [`X509StoreContext`].
     pub struct X509StoreContextRef;
 }
 
 impl X509StoreContext {
     /// Returns the index which can be used to obtain a reference to the `Ssl` associated with a
     /// context.
+    #[corresponds(SSL_get_ex_data_X509_STORE_CTX_idx)]
     pub fn ssl_idx() -> Result<Index<X509StoreContext, SslRef>, ErrorStack> {
         unsafe { cvt_n(ffi::SSL_get_ex_data_X509_STORE_CTX_idx()).map(|idx| Index::from_raw(idx)) }
     }
 
     /// Creates a new `X509StoreContext` instance.
-    ///
-    /// This corresponds to [`X509_STORE_CTX_new`].
-    ///
-    /// [`X509_STORE_CTX_new`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_STORE_CTX_new.html
+    #[corresponds(X509_STORE_CTX_new)]
     pub fn new() -> Result<X509StoreContext, ErrorStack> {
         unsafe {
             ffi::init();
@@ -78,10 +77,7 @@ impl X509StoreContext {
 
 impl X509StoreContextRef {
     /// Returns application data pertaining to an `X509` store context.
-    ///
-    /// This corresponds to [`X509_STORE_CTX_get_ex_data`].
-    ///
-    /// [`X509_STORE_CTX_get_ex_data`]: https://www.openssl.org/docs/man1.0.2/crypto/X509_STORE_CTX_get_ex_data.html
+    #[corresponds(X509_STORE_CTX_get_ex_data)]
     pub fn ex_data<T>(&self, index: Index<X509StoreContext, T>) -> Option<&T> {
         unsafe {
             let data = ffi::X509_STORE_CTX_get_ex_data(self.as_ptr(), index.as_raw());
@@ -94,10 +90,7 @@ impl X509StoreContextRef {
     }
 
     /// Returns the error code of the context.
-    ///
-    /// This corresponds to [`X509_STORE_CTX_get_error`].
-    ///
-    /// [`X509_STORE_CTX_get_error`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_STORE_CTX_get_error.html
+    #[corresponds(X509_STORE_CTX_get_error)]
     pub fn error(&self) -> X509VerifyResult {
         unsafe { X509VerifyResult::from_raw(ffi::X509_STORE_CTX_get_error(self.as_ptr())) }
     }
@@ -156,19 +149,13 @@ impl X509StoreContextRef {
     /// validation error if the certificate was not valid.
     ///
     /// This will only work inside of a call to `init`.
-    ///
-    /// This corresponds to [`X509_verify_cert`].
-    ///
-    /// [`X509_verify_cert`]:  https://www.openssl.org/docs/man1.0.2/crypto/X509_verify_cert.html
+    #[corresponds(X509_verify_cert)]
     pub fn verify_cert(&mut self) -> Result<bool, ErrorStack> {
         unsafe { cvt_n(ffi::X509_verify_cert(self.as_ptr())).map(|n| n != 0) }
     }
 
     /// Set the error code of the context.
-    ///
-    /// This corresponds to [`X509_STORE_CTX_set_error`].
-    ///
-    /// [`X509_STORE_CTX_set_error`]:  https://www.openssl.org/docs/man1.1.0/crypto/X509_STORE_CTX_set_error.html
+    #[corresponds(X509_STORE_CTX_set_error)]
     pub fn set_error(&mut self, result: X509VerifyResult) {
         unsafe {
             ffi::X509_STORE_CTX_set_error(self.as_ptr(), result.as_raw());
@@ -177,10 +164,7 @@ impl X509StoreContextRef {
 
     /// Returns a reference to the certificate which caused the error or None if
     /// no certificate is relevant to the error.
-    ///
-    /// This corresponds to [`X509_STORE_CTX_get_current_cert`].
-    ///
-    /// [`X509_STORE_CTX_get_current_cert`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_STORE_CTX_get_current_cert.html
+    #[corresponds(X509_STORE_CTX_get_current_cert)]
     pub fn current_cert(&self) -> Option<&X509Ref> {
         unsafe {
             let ptr = ffi::X509_STORE_CTX_get_current_cert(self.as_ptr());
@@ -192,19 +176,13 @@ impl X509StoreContextRef {
     /// chain where the error occurred. If it is zero it occurred in the end
     /// entity certificate, one if it is the certificate which signed the end
     /// entity certificate and so on.
-    ///
-    /// This corresponds to [`X509_STORE_CTX_get_error_depth`].
-    ///
-    /// [`X509_STORE_CTX_get_error_depth`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_STORE_CTX_get_error_depth.html
+    #[corresponds(X509_STORE_CTX_get_error_depth)]
     pub fn error_depth(&self) -> u32 {
         unsafe { ffi::X509_STORE_CTX_get_error_depth(self.as_ptr()) as u32 }
     }
 
     /// Returns a reference to a complete valid `X509` certificate chain.
-    ///
-    /// This corresponds to [`X509_STORE_CTX_get0_chain`].
-    ///
-    /// [`X509_STORE_CTX_get0_chain`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_STORE_CTX_get0_chain.html
+    #[corresponds(X509_STORE_CTX_get0_chain)]
     pub fn chain(&self) -> Option<&StackRef<X509>> {
         unsafe {
             let chain = X509_STORE_CTX_get0_chain(self.as_ptr());
@@ -223,6 +201,7 @@ pub struct X509Builder(X509);
 
 impl X509Builder {
     /// Creates a new builder.
+    #[corresponds(X509_new)]
     pub fn new() -> Result<X509Builder, ErrorStack> {
         unsafe {
             ffi::init();
@@ -231,11 +210,13 @@ impl X509Builder {
     }
 
     /// Sets the notAfter constraint on the certificate.
+    #[corresponds(X509_set1_notAfter)]
     pub fn set_not_after(&mut self, not_after: &Asn1TimeRef) -> Result<(), ErrorStack> {
         unsafe { cvt(X509_set1_notAfter(self.0.as_ptr(), not_after.as_ptr())).map(|_| ()) }
     }
 
     /// Sets the notBefore constraint on the certificate.
+    #[corresponds(X509_set1_notBefore)]
     pub fn set_not_before(&mut self, not_before: &Asn1TimeRef) -> Result<(), ErrorStack> {
         unsafe { cvt(X509_set1_notBefore(self.0.as_ptr(), not_before.as_ptr())).map(|_| ()) }
     }
@@ -244,11 +225,13 @@ impl X509Builder {
     ///
     /// Note that the version is zero-indexed; that is, a certificate corresponding to version 3 of
     /// the X.509 standard should pass `2` to this method.
+    #[corresponds(X509_set_version)]
     pub fn set_version(&mut self, version: i32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::X509_set_version(self.0.as_ptr(), version.into())).map(|_| ()) }
     }
 
     /// Sets the serial number of the certificate.
+    #[corresponds(X509_set_serialNumber)]
     pub fn set_serial_number(&mut self, serial_number: &Asn1IntegerRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_set_serialNumber(
@@ -260,6 +243,7 @@ impl X509Builder {
     }
 
     /// Sets the issuer name of the certificate.
+    #[corresponds(X509_set_issuer_name)]
     pub fn set_issuer_name(&mut self, issuer_name: &X509NameRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_set_issuer_name(
@@ -288,6 +272,7 @@ impl X509Builder {
     /// let mut x509 = openssl::x509::X509::builder().unwrap();
     /// x509.set_subject_name(&x509_name).unwrap();
     /// ```
+    #[corresponds(X509_set_subject_name)]
     pub fn set_subject_name(&mut self, subject_name: &X509NameRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_set_subject_name(
@@ -299,6 +284,7 @@ impl X509Builder {
     }
 
     /// Sets the public key associated with the certificate.
+    #[corresponds(X509_set_pubkey)]
     pub fn set_pubkey<T>(&mut self, key: &PKeyRef<T>) -> Result<(), ErrorStack>
     where
         T: HasPublic,
@@ -309,6 +295,7 @@ impl X509Builder {
     /// Returns a context object which is needed to create certain X509 extension values.
     ///
     /// Set `issuer` to `None` if the certificate will be self-signed.
+    #[corresponds(X509V3_set_ctx)]
     pub fn x509v3_context<'a>(
         &'a self,
         issuer: Option<&'a X509Ref>,
@@ -348,10 +335,7 @@ impl X509Builder {
     }
 
     /// Adds an X509 extension value to the certificate.
-    ///
-    /// This corresponds to [`X509_add_ext`].
-    ///
-    /// [`X509_add_ext`]: https://www.openssl.org/docs/man1.1.0/man3/X509_get_ext.html
+    #[corresponds(X509_add_ext)]
     pub fn append_extension2(&mut self, extension: &X509ExtensionRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_add_ext(self.0.as_ptr(), extension.as_ptr(), -1))?;
@@ -360,6 +344,7 @@ impl X509Builder {
     }
 
     /// Signs the certificate with a private key.
+    #[corresponds(X509_sign)]
     pub fn sign<T>(&mut self, key: &PKeyRef<T>, hash: MessageDigest) -> Result<(), ErrorStack>
     where
         T: HasPrivate,
@@ -385,10 +370,7 @@ foreign_type_and_impl_send_sync! {
 
 impl X509Ref {
     /// Returns this certificate's subject name.
-    ///
-    /// This corresponds to [`X509_get_subject_name`].
-    ///
-    /// [`X509_get_subject_name`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_get_subject_name.html
+    #[corresponds(X509_get_subject_name)]
     pub fn subject_name(&self) -> &X509NameRef {
         unsafe {
             let name = ffi::X509_get_subject_name(self.as_ptr());
@@ -397,17 +379,13 @@ impl X509Ref {
     }
 
     /// Returns the hash of the certificates subject
-    ///
-    /// This corresponds to `X509_subject_name_hash`.
+    #[corresponds(X509_subject_name_hash)]
     pub fn subject_name_hash(&self) -> u32 {
         unsafe { ffi::X509_subject_name_hash(self.as_ptr()) as u32 }
     }
 
     /// Returns this certificate's issuer name.
-    ///
-    /// This corresponds to [`X509_get_issuer_name`].
-    ///
-    /// [`X509_get_issuer_name`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_get_subject_name.html
+    #[corresponds(X509_get_issuer_name)]
     pub fn issuer_name(&self) -> &X509NameRef {
         unsafe {
             let name = ffi::X509_get_issuer_name(self.as_ptr());
@@ -416,10 +394,7 @@ impl X509Ref {
     }
 
     /// Returns this certificate's subject alternative name entries, if they exist.
-    ///
-    /// This corresponds to [`X509_get_ext_d2i`] called with `NID_subject_alt_name`.
-    ///
-    /// [`X509_get_ext_d2i`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_get_ext_d2i.html
+    #[corresponds(X509_get_ext_d2i)]
     pub fn subject_alt_names(&self) -> Option<Stack<GeneralName>> {
         unsafe {
             let stack = ffi::X509_get_ext_d2i(
@@ -433,10 +408,7 @@ impl X509Ref {
     }
 
     /// Returns this certificate's issuer alternative name entries, if they exist.
-    ///
-    /// This corresponds to [`X509_get_ext_d2i`] called with `NID_issuer_alt_name`.
-    ///
-    /// [`X509_get_ext_d2i`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_get_ext_d2i.html
+    #[corresponds(X509_get_ext_d2i)]
     pub fn issuer_alt_names(&self) -> Option<Stack<GeneralName>> {
         unsafe {
             let stack = ffi::X509_get_ext_d2i(
@@ -451,10 +423,8 @@ impl X509Ref {
 
     /// Returns this certificate's [`authority information access`] entries, if they exist.
     ///
-    /// This corresponds to [`X509_get_ext_d2i`] called with `NID_info_access`.
-    ///
-    /// [`X509_get_ext_d2i`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_get_ext_d2i.html
     /// [`authority information access`]: https://tools.ietf.org/html/rfc5280#section-4.2.2.1
+    #[corresponds(X509_get_ext_d2i)]
     pub fn authority_info(&self) -> Option<Stack<AccessDescription>> {
         unsafe {
             let stack = ffi::X509_get_ext_d2i(
@@ -467,6 +437,7 @@ impl X509Ref {
         }
     }
 
+    #[corresponds(X509_get_pubkey)]
     pub fn public_key(&self) -> Result<PKey<Public>, ErrorStack> {
         unsafe {
             let pkey = cvt_p(ffi::X509_get_pubkey(self.as_ptr()))?;
@@ -475,10 +446,7 @@ impl X509Ref {
     }
 
     /// Returns a digest of the DER representation of the certificate.
-    ///
-    /// This corresponds to [`X509_digest`].
-    ///
-    /// [`X509_digest`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_digest.html
+    #[corresponds(X509_digest)]
     pub fn digest(&self, hash_type: MessageDigest) -> Result<DigestBytes, ErrorStack> {
         unsafe {
             let mut digest = DigestBytes {
@@ -504,6 +472,7 @@ impl X509Ref {
     }
 
     /// Returns the certificate's Not After validity period.
+    #[corresponds(X509_getm_notAfter)]
     pub fn not_after(&self) -> &Asn1TimeRef {
         unsafe {
             let date = X509_getm_notAfter(self.as_ptr());
@@ -512,6 +481,7 @@ impl X509Ref {
     }
 
     /// Returns the certificate's Not Before validity period.
+    #[corresponds(X509_getm_notBefore)]
     pub fn not_before(&self) -> &Asn1TimeRef {
         unsafe {
             let date = X509_getm_notBefore(self.as_ptr());
@@ -520,6 +490,7 @@ impl X509Ref {
     }
 
     /// Returns the certificate's signature
+    #[corresponds(X509_get0_signature)]
     pub fn signature(&self) -> &Asn1BitStringRef {
         unsafe {
             let mut signature = ptr::null();
@@ -529,6 +500,7 @@ impl X509Ref {
     }
 
     /// Returns the certificate's signature algorithm.
+    #[corresponds(X509_get0_signature)]
     pub fn signature_algorithm(&self) -> &X509AlgorithmRef {
         unsafe {
             let mut algor = ptr::null();
@@ -540,11 +512,13 @@ impl X509Ref {
 
     /// Returns the list of OCSP responder URLs specified in the certificate's Authority Information
     /// Access field.
+    #[corresponds(X509_get1_ocsp)]
     pub fn ocsp_responders(&self) -> Result<Stack<OpensslString>, ErrorStack> {
         unsafe { cvt_p(ffi::X509_get1_ocsp(self.as_ptr())).map(|p| Stack::from_ptr(p)) }
     }
 
     /// Checks that this certificate issued `subject`.
+    #[corresponds(X509_check_issued)]
     pub fn issued(&self, subject: &X509Ref) -> X509VerifyResult {
         unsafe {
             let r = ffi::X509_check_issued(self.as_ptr(), subject.as_ptr());
@@ -556,13 +530,9 @@ impl X509Ref {
     /// version 1.
     ///
     /// Note that `0` return value stands for version 1, `1` for version 2 and so on.
-    ///
-    /// This corresponds to [`X509_get_version`].
-    ///
-    /// [`X509_get_version`]: https://www.openssl.org/docs/man1.1.1/man3/X509_get_version.html
+    #[corresponds(X509_get_version)]
     #[cfg(ossl110)]
     pub fn version(&self) -> i32 {
-        // Covered with `x509_ref_version()`, `x509_ref_version_no_version_set()` tests
         unsafe { ffi::X509_get_version(self.as_ptr()) as i32 }
     }
 
@@ -572,10 +542,7 @@ impl X509Ref {
     /// are performed.
     ///
     /// Returns `true` if verification succeeds.
-    ///
-    /// This corresponds to [`X509_verify"].
-    ///
-    /// [`X509_verify`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_verify.html
+    #[corresponds(X509_verify)]
     pub fn verify<T>(&self, key: &PKeyRef<T>) -> Result<bool, ErrorStack>
     where
         T: HasPublic,
@@ -584,10 +551,7 @@ impl X509Ref {
     }
 
     /// Returns this certificate's serial number.
-    ///
-    /// This corresponds to [`X509_get_serialNumber`].
-    ///
-    /// [`X509_get_serialNumber`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_get_serialNumber.html
+    #[corresponds(X509_get_serialNumber)]
     pub fn serial_number(&self) -> &Asn1IntegerRef {
         unsafe {
             let r = ffi::X509_get_serialNumber(self.as_ptr());
@@ -599,20 +563,14 @@ impl X509Ref {
         /// Serializes the certificate into a PEM-encoded X509 structure.
         ///
         /// The output will have a header of `-----BEGIN CERTIFICATE-----`.
-        ///
-        /// This corresponds to [`PEM_write_bio_X509`].
-        ///
-        /// [`PEM_write_bio_X509`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_write_bio_X509.html
+        #[corresponds(PEM_write_bio_X509)]
         to_pem,
         ffi::PEM_write_bio_X509
     }
 
     to_der! {
         /// Serializes the certificate into a DER-encoded X509 structure.
-        ///
-        /// This corresponds to [`i2d_X509`].
-        ///
-        /// [`i2d_X509`]: https://www.openssl.org/docs/man1.1.0/crypto/i2d_X509.html
+        #[corresponds(i2d_X509)]
         to_der,
         ffi::i2d_X509
     }
@@ -639,10 +597,7 @@ impl X509 {
         /// Deserializes a PEM-encoded X509 structure.
         ///
         /// The input should have a header of `-----BEGIN CERTIFICATE-----`.
-        ///
-        /// This corresponds to [`PEM_read_bio_X509`].
-        ///
-        /// [`PEM_read_bio_X509`]: https://www.openssl.org/docs/man1.0.2/crypto/PEM_read_bio_X509.html
+        #[corresponds(PEM_read_bio_X509)]
         from_pem,
         X509,
         ffi::PEM_read_bio_X509
@@ -650,16 +605,14 @@ impl X509 {
 
     from_der! {
         /// Deserializes a DER-encoded X509 structure.
-        ///
-        /// This corresponds to [`d2i_X509`].
-        ///
-        /// [`d2i_X509`]: https://www.openssl.org/docs/manmaster/man3/d2i_X509.html
+        #[corresponds(d2i_X509)]
         from_der,
         X509,
         ffi::d2i_X509
     }
 
     /// Deserializes a list of PEM-formatted certificates.
+    #[corresponds(PEM_read_bio_X509)]
     pub fn stack_from_pem(pem: &[u8]) -> Result<Vec<X509>, ErrorStack> {
         unsafe {
             ffi::init();

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -5,6 +5,7 @@ use std::net::IpAddr;
 
 use crate::cvt;
 use crate::error::ErrorStack;
+use openssl_macros::corresponds;
 
 bitflags! {
     /// Flags used to check an `X509` certificate.
@@ -70,10 +71,7 @@ foreign_type_and_impl_send_sync! {
 
 impl X509VerifyParamRef {
     /// Set the host flags.
-    ///
-    /// This corresponds to [`X509_VERIFY_PARAM_set_hostflags`].
-    ///
-    /// [`X509_VERIFY_PARAM_set_hostflags`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_VERIFY_PARAM_set_hostflags.html
+    #[corresponds(X509_VERIFY_PARAM_set_hostflags)]
     pub fn set_hostflags(&mut self, hostflags: X509CheckFlags) {
         unsafe {
             ffi::X509_VERIFY_PARAM_set_hostflags(self.as_ptr(), hostflags.bits);
@@ -81,19 +79,13 @@ impl X509VerifyParamRef {
     }
 
     /// Set verification flags.
-    ///
-    /// This corresponds to [`X509_VERIFY_PARAM_set_flags`].
-    ///
-    /// [`X509_VERIFY_PARAM_set_flags`]: https://www.openssl.org/docs/man1.0.2/crypto/X509_VERIFY_PARAM_set_flags.html
+    #[corresponds(X509_VERIFY_PARAM_set_flags)]
     pub fn set_flags(&mut self, flags: X509VerifyFlags) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::X509_VERIFY_PARAM_set_flags(self.as_ptr(), flags.bits)).map(|_| ()) }
     }
 
     /// Clear verification flags.
-    ///
-    /// This corresponds to [`X509_VERIFY_PARAM_clear_flags`].
-    ///
-    /// [`X509_VERIFY_PARAM_clear_flags`]: https://www.openssl.org/docs/man1.0.2/crypto/X509_VERIFY_PARAM_clear_flags.html
+    #[corresponds(X509_VERIFY_PARAM_clear_flags)]
     pub fn clear_flags(&mut self, flags: X509VerifyFlags) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_VERIFY_PARAM_clear_flags(
@@ -105,20 +97,14 @@ impl X509VerifyParamRef {
     }
 
     /// Gets verification flags.
-    ///
-    /// This corresponds to [`X509_VERIFY_PARAM_get_flags`].
-    ///
-    /// [`X509_VERIFY_PARAM_get_flags`]: https://www.openssl.org/docs/man1.0.2/crypto/X509_VERIFY_PARAM_get_flags.html
+    #[corresponds(X509_VERIFY_PARAM_get_flags)]
     pub fn flags(&mut self) -> X509VerifyFlags {
         let bits = unsafe { ffi::X509_VERIFY_PARAM_get_flags(self.as_ptr()) };
         X509VerifyFlags { bits }
     }
 
     /// Set the expected DNS hostname.
-    ///
-    /// This corresponds to [`X509_VERIFY_PARAM_set1_host`].
-    ///
-    /// [`X509_VERIFY_PARAM_set1_host`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_VERIFY_PARAM_set1_host.html
+    #[corresponds(X509_VERIFY_PARAM_set1_host)]
     pub fn set_host(&mut self, host: &str) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_VERIFY_PARAM_set1_host(
@@ -131,10 +117,7 @@ impl X509VerifyParamRef {
     }
 
     /// Set the expected IPv4 or IPv6 address.
-    ///
-    /// This corresponds to [`X509_VERIFY_PARAM_set1_ip`].
-    ///
-    /// [`X509_VERIFY_PARAM_set1_ip`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_VERIFY_PARAM_set1_ip.html
+    #[corresponds(X509_VERIFY_PARAM_set1_ip)]
     pub fn set_ip(&mut self, ip: IpAddr) -> Result<(), ErrorStack> {
         unsafe {
             let mut buf = [0; 16];


### PR DESCRIPTION
This both makes it easier to add these references and also adds a rustdoc alias so you can search rust-openssl's docs for the raw OpenSSL function and see what the binding is.