### PR TITLE
Downgrade our vendored OpenSSL version back to 1.1.1

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2"
 
 [build-dependencies]
 cc = "1.0"
-openssl-src = { version = "300", optional = true }
+openssl-src = { version = "111", optional = true }
 pkg-config = "0.3.9"
 autocfg = "1.0"
 


### PR DESCRIPTION
3.0.0 unfortunately seems to have shipped with several major performance regressions. It seems best to temporarily revert the version used by the `vendored` feature back to 1.1.1 for now. Hopefully an upcoming 3.x.x release will fix the performance issues, at which point we'll switch back.