### PR TITLE
openssl: set ossl110h cfg

### DIFF
--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -32,6 +32,9 @@ fn main() {
         if version >= 0x1_01_00_07_0 {
             println!("cargo:rustc-cfg=ossl110g");
         }
+        if version >= 0x1_01_00_08_0 {
+            println!("cargo:rustc-cfg=ossl110h");
+        }
         if version >= 0x1_01_01_00_0 {
             println!("cargo:rustc-cfg=ossl111");
         }


### PR DESCRIPTION
this is used as conditional guard for disabling renegotiation via
SslOptions.

Fixes: 9189b6732646e2af9d0847ef4230aec1d1e61730

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>