### PR TITLE
Some miscellaneous documentation fixes

### DIFF
--- a/openssl/src/aes.rs
+++ b/openssl/src/aes.rs
@@ -13,7 +13,7 @@
 //! [`aes_ige`]: fn.aes_ige.html
 //!
 //! The [`symm`] module should be used in preference to this module in most cases.
-//! The IGE block cypher is a non-traditional cipher mode.  More traditional AES
+//! The IGE block cipher is a non-traditional cipher mode.  More traditional AES
 //! encryption methods are found in the [`Crypter`] and [`Cipher`] structs.
 //!
 //! [`symm`]: ../symm/index.html

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 
-//! Defines the format of certificiates
+//! Defines the format of certificates
 //!
 //! This module is used by [`x509`] and other certificate building functions
 //! to describe time, strings, and objects.

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -230,7 +230,7 @@ impl CipherCtxRef {
 
     /// Initializes the context to perform envelope decryption.
     ///
-    /// Normally thisis called once with all of the arguments present. However, this process may be split up by first
+    /// Normally this is called once with all of the arguments present. However, this process may be split up by first
     /// providing the cipher alone and then after providing the rest of the arguments in a second call.
     ///
     /// # Panics

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -68,7 +68,7 @@ foreign_type_and_impl_send_sync! {
 }
 
 impl CmsContentInfoRef {
-    /// Given the sender's private key, `pkey` and the recipient's certificiate, `cert`,
+    /// Given the sender's private key, `pkey` and the recipient's certificate, `cert`,
     /// decrypt the data in `self`.
     #[corresponds(CMS_decrypt)]
     pub fn decrypt<T>(&self, pkey: &PKeyRef<T>, cert: &X509) -> Result<Vec<u8>, ErrorStack>

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -83,7 +83,7 @@ where
     T: HasPublic,
 {
     to_pem! {
-        /// Serialies the public key into a PEM-encoded SubjectPublicKeyInfo structure.
+        /// Serializes the public key into a PEM-encoded SubjectPublicKeyInfo structure.
         ///
         /// The output will have a header of `-----BEGIN PUBLIC KEY-----`.
         #[corresponds(PEM_write_bio_DSA_PUBKEY)]

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -1,16 +1,16 @@
 //! Elliptic Curve
 //!
-//! Cryptology relies on the difficulty of solving mathematical problems, such as the factor
+//! Cryptography relies on the difficulty of solving mathematical problems, such as the factor
 //! of large integers composed of two large prime numbers and the discrete logarithm of a
-//! random eliptic curve.  This module provides low-level features of the latter.
+//! random elliptic curve.  This module provides low-level features of the latter.
 //! Elliptic Curve protocols can provide the same security with smaller keys.
 //!
 //! There are 2 forms of elliptic curves, `Fp` and `F2^m`.  These curves use irreducible
-//! trinomial or pentanomial .  Being a generic interface to a wide range of algorithms,
-//! the cuves are generally referenced by [`EcGroup`].  There are many built in groups
+//! trinomial or pentanomial.  Being a generic interface to a wide range of algorithms,
+//! the curves are generally referenced by [`EcGroup`].  There are many built-in groups
 //! found in [`Nid`].
 //!
-//! OpenSSL Wiki explains the fields and curves in detail at [Eliptic Curve Cryptography].
+//! OpenSSL Wiki explains the fields and curves in detail at [Elliptic Curve Cryptography].
 //!
 //! [`EcGroup`]: struct.EcGroup.html
 //! [`Nid`]: ../nid/struct.Nid.html
@@ -454,7 +454,7 @@ impl EcPointRef {
         }
     }
 
-    /// Place affine coordinates of a curve over a prime field in the provided
+    /// Places affine coordinates of a curve over a prime field in the provided
     /// `x` and `y` `BigNum`s
     #[corresponds(EC_POINT_get_affine_coordinates_GFp)]
     pub fn affine_coordinates_gfp(
@@ -476,7 +476,7 @@ impl EcPointRef {
         }
     }
 
-    /// Place affine coordinates of a curve over a binary field in the provided
+    /// Places affine coordinates of a curve over a binary field in the provided
     /// `x` and `y` `BigNum`s
     #[corresponds(EC_POINT_get_affine_coordinates_GF2m)]
     #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
@@ -613,7 +613,7 @@ where
     }
 
     to_pem! {
-        /// Serialies the public key into a PEM-encoded SubjectPublicKeyInfo structure.
+        /// Serializes the public key into a PEM-encoded SubjectPublicKeyInfo structure.
         ///
         /// The output will have a header of `-----BEGIN PUBLIC KEY-----`.
         #[corresponds(PEM_write_bio_EC_PUBKEY)]

--- a/openssl/src/pkcs7.rs
+++ b/openssl/src/pkcs7.rs
@@ -298,13 +298,13 @@ mod tests {
         let mut certs = Stack::new().unwrap();
         certs.push(cert.clone()).unwrap();
         let message: String = String::from("foo");
-        let cypher = Cipher::des_ede3_cbc();
+        let cipher = Cipher::des_ede3_cbc();
         let flags = Pkcs7Flags::STREAM;
         let pkey = include_bytes!("../test/key.pem");
         let pkey = PKey::private_key_from_pem(pkey).unwrap();
 
         let pkcs7 =
-            Pkcs7::encrypt(&certs, message.as_bytes(), cypher, flags).expect("should succeed");
+            Pkcs7::encrypt(&certs, message.as_bytes(), cipher, flags).expect("should succeed");
 
         let encrypted = pkcs7
             .to_smime(message.as_bytes(), flags)

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -564,7 +564,7 @@ impl PKey<Private> {
     }
 
     /// Deserializes a DER-formatted PKCS#8 private key, using a callback to retrieve the password
-    /// if the key is encrpyted.
+    /// if the key is encrypted.
     ///
     /// The callback should copy the password into the provided buffer and return the number of
     /// bytes written.

--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -271,7 +271,7 @@ where
 
     /// Signs the contents of `data`.
     ///
-    /// If `sig` is set to `None`, an upper bound on the number of bytes required for the output buffere will be
+    /// If `sig` is set to `None`, an upper bound on the number of bytes required for the output buffer will be
     /// returned.
     ///
     /// # Note

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -41,9 +41,11 @@ use openssl_macros::corresponds;
 use std::mem::MaybeUninit;
 
 /// Computes the SHA1 hash of some data.
-#[deprecated(
-    note = "SHA1 is known to be insecure - it should not be used unless required for compatibility with existing systems."
-)]
+///
+/// # Warning
+///
+/// SHA1 is known to be insecure - it should not be used unless required for
+/// compatibility with existing systems.
 #[corresponds(SHA1)]
 #[inline]
 pub fn sha1(data: &[u8]) -> [u8; 20] {
@@ -101,7 +103,11 @@ pub fn sha512(data: &[u8]) -> [u8; 64] {
 cfg_if! {
     if #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))] {
         /// An object which calculates a SHA1 hash of some data.
-        #[deprecated(note = "SHA1 is known to be insecure - it should not be used unless required for compatibility with existing systems.")]
+        ///
+        /// # Warning
+        ///
+        /// SHA1 is known to be insecure - it should not be used unless required for
+        /// compatibility with existing systems.
         #[derive(Clone)]
         pub struct Sha1(ffi::SHA_CTX);
 

--- a/openssl/src/sha.rs
+++ b/openssl/src/sha.rs
@@ -41,11 +41,9 @@ use openssl_macros::corresponds;
 use std::mem::MaybeUninit;
 
 /// Computes the SHA1 hash of some data.
-///
-/// # Warning
-///
-/// SHA1 is known to be insecure - it should not be used unless required for
-/// compatibility with existing systems.
+#[deprecated(
+    note = "SHA1 is known to be insecure - it should not be used unless required for compatibility with existing systems."
+)]
 #[corresponds(SHA1)]
 #[inline]
 pub fn sha1(data: &[u8]) -> [u8; 20] {
@@ -103,11 +101,7 @@ pub fn sha512(data: &[u8]) -> [u8; 64] {
 cfg_if! {
     if #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))] {
         /// An object which calculates a SHA1 hash of some data.
-        ///
-        /// # Warning
-        ///
-        /// SHA1 is known to be insecure - it should not be used unless required for
-        /// compatibility with existing systems.
+        #[deprecated(note = "SHA1 is known to be insecure - it should not be used unless required for compatibility with existing systems.")]
         #[derive(Clone)]
         pub struct Sha1(ffi::SHA_CTX);
 

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -343,10 +343,10 @@ impl<'a> Signer<'a> {
         Ok(buf)
     }
 
-    /// Signs the data in data_buf and writes the signature into the buffer sig_buf, returning the
+    /// Signs the data in `data_buf` and writes the signature into the buffer `sig_buf`, returning the
     /// number of bytes written.
     ///
-    /// For PureEdDSA (Ed25519 and Ed448 keys) this is the only way to sign data.
+    /// For PureEdDSA (Ed25519 and Ed448 keys), this is the only way to sign data.
     ///
     /// This method will fail if the buffer is not large enough for the signature. Use the `len`
     /// method to get an upper bound on the required size.
@@ -583,7 +583,7 @@ impl<'a> Verifier<'a> {
         }
     }
 
-    /// Determines if the data given in buf matches the provided signature.
+    /// Determines if the data given in `buf` matches the provided signature.
     ///
     /// OpenSSL documentation at [`EVP_DigestVerify`].
     ///

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -21,7 +21,7 @@ pub struct StreamState<S> {
     pub dtls_mtu_size: c_long,
 }
 
-/// Safe wrapper for BIO_METHOD
+/// Safe wrapper for `BIO_METHOD`
 pub struct BioMethod(BIO_METHOD);
 
 impl BioMethod {

--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -55,7 +55,7 @@ fn ctx(method: SslMethod) -> Result<SslContextBuilder, ErrorStack> {
 /// OpenSSL's default configuration is highly insecure. This connector manages the OpenSSL
 /// structures, configuring cipher suites, session options, hostname verification, and more.
 ///
-/// OpenSSL's built in hostname verification is used when linking against OpenSSL 1.0.2 or 1.1.0,
+/// OpenSSL's built-in hostname verification is used when linking against OpenSSL 1.0.2 or 1.1.0,
 /// and a custom implementation is used when linking against OpenSSL 1.0.1.
 #[derive(Clone, Debug)]
 pub struct SslConnector(SslContext);

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -172,6 +172,7 @@ bitflags! {
 
         /// Allow legacy insecure renegotiation with servers or clients that do not support secure
         /// renegotiation.
+        #[deprecated(note = "This is insecure and should not be used unless required for compatibility with existing systems.")]
         const ALLOW_UNSAFE_LEGACY_RENEGOTIATION =
             ffi::SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION;
 
@@ -270,7 +271,7 @@ bitflags! {
         const ENABLE_PARTIAL_WRITE = ffi::SSL_MODE_ENABLE_PARTIAL_WRITE;
 
         /// Disables a check that the data buffer has not moved between calls when operating in a
-        /// nonblocking context.
+        /// non-blocking context.
         const ACCEPT_MOVING_WRITE_BUFFER = ffi::SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER;
 
         /// Enables automatic retries after TLS session events such as renegotiations or heartbeats.
@@ -1015,7 +1016,7 @@ impl SslContextBuilder {
     ///
     /// The `set_cipher_list` method controls the cipher suites for protocols before TLSv1.3.
     ///
-    /// The format consists of TLSv1.3 ciphersuite names separated by `:` characters in order of
+    /// The format consists of TLSv1.3 cipher suite names separated by `:` characters in order of
     /// preference.
     ///
     /// Requires OpenSSL 1.1.1 or newer.
@@ -1256,7 +1257,7 @@ impl SslContextBuilder {
     /// `Ok(false)` indicates that the OCSP status is invalid and the handshake should be
     /// terminated.
     ///
-    /// On the server side, this callback is resopnsible for setting the OCSP status response to be
+    /// On the server side, this callback is responsible for setting the OCSP status response to be
     /// returned to clients. The status may be set with the `SslRef::set_ocsp_status` method. A
     /// response of `Ok(true)` indicates that the OCSP status should be returned to the client, and
     /// `Ok(false)` indicates that the status should not be returned to the client.
@@ -2643,9 +2644,9 @@ impl SslRef {
         }
     }
 
-    /// Copies the client_random value sent by the client in the TLS handshake into a buffer.
+    /// Copies the `client_random` value sent by the client in the TLS handshake into a buffer.
     ///
-    /// Returns the number of bytes copied, or if the buffer is empty, the size of the client_random
+    /// Returns the number of bytes copied, or if the buffer is empty, the size of the `client_random`
     /// value.
     ///
     /// Requires OpenSSL 1.1.0 or newer.
@@ -2657,9 +2658,9 @@ impl SslRef {
         }
     }
 
-    /// Copies the server_random value sent by the server in the TLS handshake into a buffer.
+    /// Copies the `server_random` value sent by the server in the TLS handshake into a buffer.
     ///
-    /// Returns the number of bytes copied, or if the buffer is empty, the size of the server_random
+    /// Returns the number of bytes copied, or if the buffer is empty, the size of the `server_random`
     /// value.
     ///
     /// Requires OpenSSL 1.1.0 or newer.
@@ -3257,7 +3258,7 @@ impl<S: Read + Write> SslStream<S> {
 
     /// Like `read`, but returns an `ssl::Error` rather than an `io::Error`.
     ///
-    /// It is particularly useful with a nonblocking socket, where the error value will identify if
+    /// It is particularly useful with a non-blocking socket, where the error value will identify if
     /// OpenSSL is waiting on read or write readiness.
     #[corresponds(SSL_read)]
     pub fn ssl_read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
@@ -3280,7 +3281,7 @@ impl<S: Read + Write> SslStream<S> {
 
     /// Like `write`, but returns an `ssl::Error` rather than an `io::Error`.
     ///
-    /// It is particularly useful with a nonblocking socket, where the error value will identify if
+    /// It is particularly useful with a non-blocking socket, where the error value will identify if
     /// OpenSSL is waiting on read or write readiness.
     #[corresponds(SSL_write)]
     pub fn ssl_write(&mut self, buf: &[u8]) -> Result<usize, Error> {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -172,7 +172,6 @@ bitflags! {
 
         /// Allow legacy insecure renegotiation with servers or clients that do not support secure
         /// renegotiation.
-        #[deprecated(note = "This is insecure and should not be used unless required for compatibility with existing systems.")]
         const ALLOW_UNSAFE_LEGACY_RENEGOTIATION =
             ffi::SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION;
 

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -572,7 +572,7 @@ impl Crypter {
 /// and initialization vector `iv`. Padding is enabled.
 ///
 /// This is a convenient interface to `Crypter` to encrypt all data in one go.  To encrypt a stream
-/// of data increamentally , use `Crypter` instead.
+/// of data incrementally , use `Crypter` instead.
 ///
 /// # Examples
 ///
@@ -611,7 +611,7 @@ pub fn encrypt(
 /// and initialization vector `iv`. Padding is enabled.
 ///
 /// This is a convenient interface to `Crypter` to decrypt all data in one go.  To decrypt a  stream
-/// of data increamentally , use `Crypter` instead.
+/// of data incrementally , use `Crypter` instead.
 ///
 /// # Examples
 ///

--- a/openssl/src/x509/extension.rs
+++ b/openssl/src/x509/extension.rs
@@ -57,7 +57,7 @@ impl BasicConstraints {
         self
     }
 
-    /// Sets the pathlen to an optional non-negative value. The pathlen is the
+    /// Sets the `pathlen` to an optional non-negative value. The `pathlen` is the
     /// maximum number of CAs that can appear below this one in a chain.
     pub fn pathlen(&mut self, pathlen: u32) -> &mut BasicConstraints {
         self.pathlen = Some(pathlen);

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1323,7 +1323,7 @@ impl X509VerifyResult {
         }
     }
 
-    /// Successful peer certifiate verification.
+    /// Successful peer certificate verification.
     pub const OK: X509VerifyResult = X509VerifyResult(ffi::X509_V_OK);
     /// Application verification failure.
     pub const APPLICATION_VERIFICATION: X509VerifyResult =


### PR DESCRIPTION
Mostly fixing typos, uncommon spellings, etc. ~I also marked some insecure items as `deprecated`.~

Feel free to pick and choose which edits you think are useful ~(e.g., you may not want to be in the business of deciding which features should be `deprecated` or not)~.

- [ ] Do any of these changes need to be upstreamed to [`openssl`](https://github.com/openssl/openssl) itself (i.e., are they generated from `openssl`'s comments)?