### PR TITLE
WIP: Add is_ca method to X509 struct

### DIFF
--- a/openssl-sys/src/handwritten/x509v3.rs
+++ b/openssl-sys/src/handwritten/x509v3.rs
@@ -20,6 +20,16 @@ extern "C" {
 }
 
 #[repr(C)]
+pub struct BASIC_CONSTRAINTS {
+    pub ca: c_int,
+    pub pathlen: *mut ASN1_INTEGER,
+}
+
+extern "C" {
+    pub fn BASIC_CONSTRAINTS_free(bc: *mut BASIC_CONSTRAINTS);
+}
+
+#[repr(C)]
 pub struct AUTHORITY_KEYID {
     pub keyid: *mut ASN1_OCTET_STRING,
     pub issuer: *mut stack_st_GENERAL_NAME,


### PR DESCRIPTION
This adds the ability to tell the difference between CA certificates and leaf certificates by exposing the `is_ca` method on `X509` structs. 
I've marked this as an WIP PR since I am unsure about the implementation as is and I would appreciate your feedback.

The current implementation introduces a new `BasicConstraints` type that has nothing to do with the existing `x509::extension::BasicConstraints` type. This seems wrong, but I am unsure how to combine those types in an idiomatic way.

I will add more documentation after an initial review.

