### PR TITLE
Asn1Type completed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target/
 Cargo.lock
 .idea/
 *.iml
+*.tmp
 .vscode/

--- a/openssl-sys/src/handwritten/asn1.rs
+++ b/openssl-sys/src/handwritten/asn1.rs
@@ -14,6 +14,40 @@ extern "C" {
 
 stack!(stack_st_ASN1_OBJECT);
 
+#[repr(C)]
+pub struct ASN1_TYPE {
+    pub type_: c_int,
+    pub value: ASN1_TYPE_value,
+}
+#[repr(C)]
+pub union ASN1_TYPE_value {
+    pub ptr: *mut c_char,
+    pub boolean: ASN1_BOOLEAN,
+    pub asn1_string: *mut ASN1_STRING,
+    pub object: *mut ASN1_OBJECT,
+    pub integer: *mut ASN1_INTEGER,
+    pub enumerated: *mut ASN1_ENUMERATED,
+    pub bit_string: *mut ASN1_BIT_STRING,
+    pub octet_string: *mut ASN1_OCTET_STRING,
+    pub printablestring: *mut ASN1_PRINTABLESTRING,
+    pub t61string: *mut ASN1_T61STRING,
+    pub ia5string: *mut ASN1_IA5STRING,
+    pub generalstring: *mut ASN1_GENERALSTRING,
+    pub bmpstring: *mut ASN1_BMPSTRING,
+    pub universalstring: *mut ASN1_UNIVERSALSTRING,
+    pub utctime: *mut ASN1_UTCTIME,
+    pub generalizedtime: *mut ASN1_GENERALIZEDTIME,
+    pub visiblestring: *mut ASN1_VISIBLESTRING,
+    pub utf8string: *mut ASN1_UTF8STRING,
+    /*
+     * set and sequence are left complete and still contain the set or
+     * sequence bytes
+     */
+    pub set: *mut ASN1_STRING,
+    pub sequence: *mut ASN1_STRING,
+    pub asn1_value: *mut ASN1_VALUE,
+}
+
 extern "C" {
     pub fn ASN1_STRING_type_new(ty: c_int) -> *mut ASN1_STRING;
     #[cfg(any(ossl110, libressl273))]
@@ -51,6 +85,10 @@ extern "C" {
     pub fn ASN1_TIME_set_string(s: *mut ASN1_TIME, str: *const c_char) -> c_int;
     #[cfg(ossl111)]
     pub fn ASN1_TIME_set_string_X509(s: *mut ASN1_TIME, str: *const c_char) -> c_int;
+
+    pub fn ASN1_TYPE_free(x: *mut ASN1_TYPE);
+
+    pub fn ASN1_generate_v3(str: *const c_char, cnf: *mut X509V3_CTX) -> *mut ASN1_TYPE;
 }
 
 const_ptr_api! {

--- a/openssl-sys/src/handwritten/types.rs
+++ b/openssl-sys/src/handwritten/types.rs
@@ -3,14 +3,26 @@ use libc::*;
 #[allow(unused_imports)]
 use *;
 
+#[derive(Copy, Clone)]
+pub enum ASN1_BOOLEAN {}
+pub enum ASN1_ENUMERATED {}
 pub enum ASN1_INTEGER {}
 pub enum ASN1_GENERALIZEDTIME {}
 pub enum ASN1_STRING {}
 pub enum ASN1_BIT_STRING {}
 pub enum ASN1_TIME {}
-pub enum ASN1_TYPE {}
 pub enum ASN1_OBJECT {}
 pub enum ASN1_OCTET_STRING {}
+pub enum ASN1_PRINTABLESTRING {}
+pub enum ASN1_T61STRING {}
+pub enum ASN1_IA5STRING {}
+pub enum ASN1_GENERALSTRING {}
+pub enum ASN1_BMPSTRING {}
+pub enum ASN1_UNIVERSALSTRING {}
+pub enum ASN1_UTCTIME {}
+pub enum ASN1_VISIBLESTRING {}
+pub enum ASN1_UTF8STRING {}
+pub enum ASN1_VALUE {}
 
 pub enum bio_st {} // FIXME remove
 cfg_if! {

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -25,6 +25,7 @@ bitflags = "1.0"
 cfg-if = "1.0"
 foreign-types = "0.3.1"
 libc = "0.2"
+num_enum = "0.5"
 once_cell = "1.5.2"
 
 openssl-macros = { path = "../openssl-macros" }

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -895,6 +895,19 @@ mod tests {
         }
     }
 
+    // Check (deprecated) `pub const Asn1Type::...` et al.
+    #[test]
+    fn asn1_type_type_compatibility() {
+        let null = null_mut();
+        unsafe {
+            // Create an ASN.1 type object
+            let s = CString::new("UTF8String:Hällö Test").unwrap();
+            let at: Asn1Type = cvt_p(ffi::ASN1_generate_v3(s.as_ptr(), null))
+                .map(|p| Asn1Type::from_ptr(p)).unwrap();
+            assert_eq!(at.typ().unwrap(), Asn1Type::UTF8STRING);
+        }
+    }
+
     #[test]
     fn asn1_string_from_asn1_type() {
         let null = null_mut();

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -190,6 +190,39 @@ foreign_type_and_impl_send_sync! {
     pub struct Asn1TypeRef;
 }
 
+#[allow(missing_docs)] // no need to document the constants
+#[deprecated(note = "Use Asn1TagValue instead")]
+impl Asn1Type {
+    pub const EOC: Asn1TagValue = Asn1TagValue::Eoc;
+    pub const BOOLEAN: Asn1TagValue = Asn1TagValue::Boolean;
+    pub const INTEGER: Asn1TagValue = Asn1TagValue::Integer;
+    pub const BIT_STRING: Asn1TagValue = Asn1TagValue::BitString;
+    pub const OCTET_STRING: Asn1TagValue = Asn1TagValue::OctetString;
+    pub const NULL: Asn1TagValue = Asn1TagValue::Null;
+    pub const OBJECT: Asn1TagValue = Asn1TagValue::Object;
+    pub const OBJECT_DESCRIPTOR: Asn1TagValue = Asn1TagValue::ObjectDescriptor;
+    pub const EXTERNAL: Asn1TagValue = Asn1TagValue::External;
+    pub const REAL: Asn1TagValue = Asn1TagValue::Real;
+    pub const ENUMERATED: Asn1TagValue = Asn1TagValue::Enumerated;
+    pub const UTF8STRING: Asn1TagValue = Asn1TagValue::Utf8String;
+    pub const SEQUENCE: Asn1TagValue = Asn1TagValue::Sequence;
+    pub const SET: Asn1TagValue = Asn1TagValue::Set;
+    pub const NUMERICSTRING: Asn1TagValue = Asn1TagValue::NumericString;
+    pub const PRINTABLESTRING: Asn1TagValue = Asn1TagValue::PrintableString;
+    pub const T61STRING: Asn1TagValue = Asn1TagValue::T61String;
+    pub const TELETEXSTRING: Asn1TagValue = Asn1TagValue::T61String;
+    pub const VIDEOTEXSTRING: Asn1TagValue = Asn1TagValue::VideotexString;
+    pub const IA5STRING: Asn1TagValue = Asn1TagValue::Ia5String;
+    pub const UTCTIME: Asn1TagValue = Asn1TagValue::UtcTime;
+    pub const GENERALIZEDTIME: Asn1TagValue = Asn1TagValue::GeneralizedTime;
+    pub const GRAPHICSTRING: Asn1TagValue = Asn1TagValue::GraphicString;
+    pub const ISO64STRING: Asn1TagValue = Asn1TagValue::VisibleString;
+    pub const VISIBLESTRING: Asn1TagValue = Asn1TagValue::VisibleString;
+    pub const GENERALSTRING: Asn1TagValue = Asn1TagValue::GeneralString;
+    pub const UNIVERSALSTRING: Asn1TagValue = Asn1TagValue::UniversalString;
+    pub const BMPSTRING: Asn1TagValue = Asn1TagValue::BmpString;
+}
+
 impl Asn1Type {
     /// The type of the value, the Asn1Type contains.
     pub fn typ(&self) -> Result<Asn1TagValue, Asn1Error> {

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -533,23 +533,30 @@ impl fmt::Debug for Asn1StringRef {
 impl FromAsn1Type<Asn1StringRef> for Asn1StringRef {
     fn from_asn1type(ty: &Asn1Type) -> Result<&Asn1StringRef, Asn1Error> {
         unsafe {
+            unsafe fn from_asn1type_ptr(ty: &Asn1Type) -> &Asn1StringRef {
+                Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)
+            }
             match ty.typ()? {
-                Asn1TagValue::BitString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::BmpString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::Enumerated => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::GeneralString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::GraphicString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::Ia5String => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::Integer => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::NumericString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::OctetString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::PrintableString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::T61String => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::UniversalString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::Utf8String => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::VideotexString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                Asn1TagValue::VisibleString => Ok(Asn1StringRef::from_const_ptr((*ty.0).value.asn1_string as *const ffi::ASN1_STRING)),
-                _ => Err(Asn1Error { message: String::from("Not a string type. Conversion not supported.") }),
+                Asn1TagValue::BitString => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::BmpString => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::Enumerated => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::GeneralString => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::GeneralizedTime => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::GraphicString => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::Ia5String => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::Integer => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::NumericString => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::OctetString => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::PrintableString => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::T61String => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::UniversalString => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::UtcTime => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::Utf8String => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::VideotexString => Ok(from_asn1type_ptr(&ty)),
+                Asn1TagValue::VisibleString => Ok(from_asn1type_ptr(&ty)),
+                _ => Err(Asn1Error {
+                    message: String::from("Not a string type. Conversion not supported.")
+                }),
             }
         }
     }

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -20,9 +20,7 @@ use std::ptr;
 use std::slice;
 use std::str;
 
-use crate::asn1::{
-    Asn1BitStringRef, Asn1IntegerRef, Asn1ObjectRef, Asn1StringRef, Asn1TimeRef, Asn1Type,
-};
+use crate::asn1::{Asn1BitStringRef, Asn1IntegerRef, Asn1ObjectRef, Asn1StringRef, Asn1TagValue, Asn1TimeRef};
 use crate::bio::MemBioSlice;
 use crate::conf::ConfRef;
 use crate::error::ErrorStack;
@@ -812,7 +810,7 @@ impl X509NameBuilder {
         &mut self,
         field: &str,
         value: &str,
-        ty: Asn1Type,
+        ty: Asn1TagValue,
     ) -> Result<(), ErrorStack> {
         unsafe {
             let field = CString::new(field).unwrap();
@@ -820,7 +818,7 @@ impl X509NameBuilder {
             cvt(ffi::X509_NAME_add_entry_by_txt(
                 self.0.as_ptr(),
                 field.as_ptr() as *mut _,
-                ty.as_raw(),
+                ty as c_int,
                 value.as_ptr(),
                 value.len() as c_int,
                 -1,
@@ -860,14 +858,14 @@ impl X509NameBuilder {
         &mut self,
         field: Nid,
         value: &str,
-        ty: Asn1Type,
+        ty: Asn1TagValue,
     ) -> Result<(), ErrorStack> {
         unsafe {
             assert!(value.len() <= c_int::max_value() as usize);
             cvt(ffi::X509_NAME_add_entry_by_NID(
                 self.0.as_ptr(),
                 field.as_raw(),
-                ty.as_raw(),
+                ty as c_int,
                 value.as_ptr() as *mut _,
                 value.len() as c_int,
                 -1,

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -105,7 +105,9 @@ fn main() {
             || s.starts_with("CRYPTO_EX_")
     });
     cfg.skip_struct(|s| {
-        s == "ProbeResult" || s == "X509_OBJECT_data" // inline union
+        s == "ProbeResult" ||
+        s == "X509_OBJECT_data" || // inline union
+        s == "ASN1_TYPE_value"
     });
     cfg.skip_fn(move |s| {
         s == "CRYPTO_memcmp" ||                 // uses volatile
@@ -125,7 +127,8 @@ fn main() {
     cfg.skip_field_type(|s, field| {
         (s == "EVP_PKEY" && field == "pkey") ||      // union
             (s == "GENERAL_NAME" && field == "d") || // union
-            (s == "X509_OBJECT" && field == "data") // union
+            (s == "X509_OBJECT" && field == "data") || // union
+            (s == "ASN1_TYPE" && field == "value") // union
     });
     cfg.skip_signededness(|s| {
         s.ends_with("_cb")


### PR DESCRIPTION
With this PR `Asn1Type` will represent the complete OpenSSL `ASN1_TYPE` including the `union value` part.

**Important:** this introduces a small incompatibility, as the former `Asn1Type` was implemented as `struct Asn1Type(c_int) {}` and now it is

```rust
pub struct ASN1_TYPE {
    pub type_: c_int,
    pub value: ASN1_TYPE_value,
}
```

See also the changes in ...