### PR TITLE
Add X509*_cmp/_dup methods to openssl-sys

### DIFF
--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -236,6 +236,8 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn i2d_X509_CRL(x: #[const_ptr_if(ossl300)] X509_CRL, buf: *mut *mut u8) -> c_int;
+        #[cfg(any(ossl110, libressl270))]
+        pub fn X509_CRL_dup(x: #[const_ptr_if(ossl300)] X509_CRL) -> *mut X509_CRL;
     }
 }
 
@@ -258,6 +260,9 @@ const_ptr_api! {
             palg: *mut #[const_ptr_if(any(ossl110, libressl273))] X509_ALGOR,
             x: *const X509,
         );
+
+        #[cfg(any(ossl110, libressl270))]
+        pub fn X509_REQ_dup(x: #[const_ptr_if(ossl300)] X509_REQ) -> *mut X509_REQ;
     }
 }
 extern "C" {
@@ -277,6 +282,10 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn i2d_X509(x: #[const_ptr_if(ossl300)] X509, buf: *mut *mut u8) -> c_int;
+        #[cfg(any(ossl110, libressl270))]
+        pub fn X509_NAME_dup(x: #[const_ptr_if(ossl300)] X509_NAME) -> *mut X509_NAME;
+        #[cfg(any(ossl110, libressl270))]
+        pub fn X509_dup(x: #[const_ptr_if(ossl300)] X509) -> *mut X509;
     }
 }
 extern "C" {
@@ -613,4 +622,14 @@ extern "C" {
     pub fn X509_get_default_cert_file() -> *const c_char;
     pub fn X509_get_default_cert_dir_env() -> *const c_char;
     pub fn X509_get_default_cert_dir() -> *const c_char;
+}
+
+extern "C" {
+    pub fn X509_cmp(a: *const X509, b: *const X509) -> c_int;
+    pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> c_int;
+    pub fn X509_issuer_and_serial_cmp(a: *const X509, b: *const X509) -> c_int;
+    pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> c_int;
+    pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> c_int;
+    pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> c_int;
+    pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> c_int;
 }


### PR DESCRIPTION
The cmp methods are a bit of a pain to actually use, in OpenSSL 1.1.1 they're documented to return a positive number when larger, 0 if equal and negative when smaller, and -2 if there's an error. However, I'm pretty sure -2 also means smaller in some situations so I've got no idea what you do if it actually ever returns -2.

I have not verified the `#[cfg(any(ossl110, libressl270))]` or the `#[const_ptr_if(ossl300)]`, because I haven't been able to work out how, however it does match what's already there for `X509_REVOKED_dup` and I see no reason for the other dups to diverge from that.

The compare methods appear to have existed since OpenSSL 1.0.0 and LibreSSL 2.0.0.