### PR TITLE
Fix up LibreSSL bits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,12 +178,22 @@ jobs:
               bindgen: true
               library:
                 name: libressl
+                version: 3.4.3
+            - target: x86_64-unknown-linux-gnu
+              bindgen: true
+              library:
+                name: libressl
                 version: 3.5.2
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:
                 name: libressl
                 version: 2.5.5
+            - target: x86_64-unknown-linux-gnu
+              bindgen: false
+              library:
+                name: libressl
+                version: 3.4.3
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:

--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -7,6 +7,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x2_05_01_00_0 {
             cfgs.push("libressl251");
         }
+        if libressl_version >= 0x2_05_02_00_0 {
+            cfgs.push("libressl252");
+        }
         if libressl_version >= 0x2_06_01_00_0 {
             cfgs.push("libressl261");
         }

--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -34,6 +34,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x3_03_02_00_0 {
             cfgs.push("libressl332");
         }
+        if libressl_version >= 0x3_04_00_00_0 {
+            cfgs.push("libressl340");
+        }
         if libressl_version >= 0x3_05_00_00_0 {
             cfgs.push("libressl350");
         }

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -439,6 +439,8 @@ cfg_if! {
         extern "C" {
             pub fn SSL_CTX_set_min_proto_version(ctx: *mut ::SSL_CTX, version: u16) -> c_int;
             pub fn SSL_CTX_set_max_proto_version(ctx: *mut ::SSL_CTX, version: u16) -> c_int;
+            pub fn SSL_set_min_proto_version(s: *mut SSL, version: u16) -> c_int;
+            pub fn SSL_set_max_proto_version(s: *mut SSL, version: u16) -> c_int;
         }
     }
 }
@@ -448,6 +450,8 @@ cfg_if! {
         extern "C" {
             pub fn SSL_CTX_get_min_proto_version(ctx: *mut ::SSL_CTX) -> c_int;
             pub fn SSL_CTX_get_max_proto_version(ctx: *mut ::SSL_CTX) -> c_int;
+            pub fn SSL_get_min_proto_version(s: *mut SSL) -> c_int;
+            pub fn SSL_get_max_proto_version(s: *mut SSL) -> c_int;
         }
     }
 }
@@ -482,9 +486,9 @@ extern "C" {
     pub fn SSL_set_bio(ssl: *mut SSL, rbio: *mut BIO, wbio: *mut BIO);
     pub fn SSL_get_rbio(ssl: *const SSL) -> *mut BIO;
     pub fn SSL_get_wbio(ssl: *const SSL) -> *mut BIO;
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_CTX_set_ciphersuites(ctx: *mut SSL_CTX, str: *const c_char) -> c_int;
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_set_ciphersuites(ssl: *mut ::SSL, str: *const c_char) -> c_int;
     pub fn SSL_set_verify(
         ssl: *mut SSL,
@@ -518,12 +522,12 @@ extern "C" {
 
     pub fn SSL_SESSION_get_time(s: *const SSL_SESSION) -> c_long;
     pub fn SSL_SESSION_get_timeout(s: *const SSL_SESSION) -> c_long;
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl270))]
     pub fn SSL_SESSION_get_protocol_version(s: *const SSL_SESSION) -> c_int;
 
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_SESSION_set_max_early_data(ctx: *mut SSL_SESSION, max_early_data: u32) -> c_int;
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_SESSION_get_max_early_data(ctx: *const SSL_SESSION) -> u32;
 
     pub fn SSL_SESSION_get_id(s: *const SSL_SESSION, len: *mut c_uint) -> *const c_uchar;
@@ -560,7 +564,7 @@ extern "C" {
     );
     pub fn SSL_CTX_set_verify_depth(ctx: *mut SSL_CTX, depth: c_int);
 
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_CTX_set_post_handshake_auth(ctx: *mut SSL_CTX, val: c_int);
 
     pub fn SSL_CTX_check_private_key(ctx: *const SSL_CTX) -> c_int;
@@ -626,7 +630,7 @@ extern "C" {
     pub fn SSL_connect(ssl: *mut SSL) -> c_int;
     pub fn SSL_read(ssl: *mut SSL, buf: *mut c_void, num: c_int) -> c_int;
     pub fn SSL_peek(ssl: *mut SSL, buf: *mut c_void, num: c_int) -> c_int;
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_read_early_data(
         s: *mut ::SSL,
         buf: *mut c_void,
@@ -637,7 +641,7 @@ extern "C" {
 
 extern "C" {
     pub fn SSL_write(ssl: *mut SSL, buf: *const c_void, num: c_int) -> c_int;
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_write_early_data(
         s: *mut SSL,
         buf: *const c_void,
@@ -699,7 +703,6 @@ extern "C" {
 
     pub fn SSL_CTX_set_client_CA_list(ctx: *mut SSL_CTX, list: *mut stack_st_X509_NAME);
 
-    #[cfg(not(libressl))]
     pub fn SSL_CTX_add_client_CA(ctx: *mut SSL_CTX, cacert: *mut X509) -> c_int;
 
     pub fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> c_int;
@@ -738,9 +741,9 @@ const_ptr_api! {
 }
 
 extern "C" {
-    #[cfg(ossl102)]
+    #[cfg(any(ossl102, libressl270))]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
-    #[cfg(ossl102)]
+    #[cfg(any(ossl102, libressl340))]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
 
     pub fn SSL_set_shutdown(ss: *mut SSL, mode: c_int);
@@ -754,9 +757,9 @@ extern "C" {
     #[cfg(ossl110)]
     pub fn SSL_get0_verified_chain(ssl: *const SSL) -> *mut stack_st_X509;
 
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl270))]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut c_uchar, len: size_t) -> size_t;
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl270))]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut c_uchar, len: size_t) -> size_t;
     #[cfg(any(ossl110, libressl273))]
     pub fn SSL_SESSION_get_master_key(
@@ -863,9 +866,9 @@ extern "C" {
 }
 
 extern "C" {
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl270))]
     pub fn SSL_CIPHER_get_cipher_nid(c: *const SSL_CIPHER) -> c_int;
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl270))]
     pub fn SSL_CIPHER_get_digest_nid(c: *const SSL_CIPHER) -> c_int;
 }
 

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -411,13 +411,13 @@ extern "C" {
     #[cfg(ossl111)]
     pub fn SSL_CTX_set_keylog_callback(ctx: *mut SSL_CTX, cb: SSL_CTX_keylog_cb_func);
 
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_CTX_set_max_early_data(ctx: *mut SSL_CTX, max_early_data: u32) -> c_int;
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_CTX_get_max_early_data(ctx: *const SSL_CTX) -> u32;
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_set_max_early_data(ctx: *mut SSL, max_early_data: u32) -> c_int;
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn SSL_get_max_early_data(ctx: *const SSL) -> u32;
 
     pub fn SSL_get_finished(s: *const SSL, buf: *mut c_void, count: size_t) -> size_t;

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -139,7 +139,7 @@ cfg_if! {
         pub const SSL_OP_NO_DTLSv1_2: ssl_op_type!() = 0x80000000;
     }
 }
-#[cfg(ossl111)]
+#[cfg(any(ossl111, libressl340))]
 pub const SSL_OP_NO_TLSv1_3: ssl_op_type!() = 0x20000000;
 
 #[cfg(ossl110h)]

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -3,7 +3,7 @@ use std::ptr;
 
 use *;
 
-#[cfg(not(any(libressl, ossl110)))]
+#[cfg(not(ossl110))]
 pub const SSL_MAX_KRB5_PRINCIPAL_LENGTH: c_int = 256;
 
 #[cfg(not(ossl110))]
@@ -11,7 +11,7 @@ pub const SSL_MAX_SSL_SESSION_ID_LENGTH: c_int = 32;
 #[cfg(not(ossl110))]
 pub const SSL_MAX_SID_CTX_LENGTH: c_int = 32;
 
-#[cfg(not(any(libressl, ossl110)))]
+#[cfg(not(ossl110))]
 pub const SSL_MAX_KEY_ARG_LENGTH: c_int = 8;
 #[cfg(not(ossl110))]
 pub const SSL_MAX_MASTER_KEY_LENGTH: c_int = 48;

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -337,7 +337,7 @@ pub const SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP: c_int = 71;
 #[cfg(any(libressl, all(ossl101, not(ossl110))))]
 pub const SSL_CTRL_CLEAR_OPTIONS: c_int = 77;
 pub const SSL_CTRL_GET_EXTRA_CHAIN_CERTS: c_int = 82;
-#[cfg(ossl111)]
+#[cfg(any(ossl111, libressl252))]
 pub const SSL_CTRL_SET_GROUPS_LIST: c_int = 92;
 #[cfg(any(libressl, all(ossl102, not(ossl110))))]
 pub const SSL_CTRL_SET_ECDH_AUTO: c_int = 94;
@@ -347,13 +347,13 @@ pub const SSL_CTRL_SET_SIGALGS_LIST: c_int = 98;
 pub const SSL_CTRL_SET_VERIFY_CERT_STORE: c_int = 106;
 #[cfg(ossl110)]
 pub const SSL_CTRL_GET_EXTMS_SUPPORT: c_int = 122;
-#[cfg(ossl110)]
+#[cfg(any(ossl110, libressl261))]
 pub const SSL_CTRL_SET_MIN_PROTO_VERSION: c_int = 123;
-#[cfg(ossl110)]
+#[cfg(any(ossl110, libressl261))]
 pub const SSL_CTRL_SET_MAX_PROTO_VERSION: c_int = 124;
-#[cfg(ossl110g)]
+#[cfg(any(ossl110g, libressl270))]
 pub const SSL_CTRL_GET_MIN_PROTO_VERSION: c_int = 130;
-#[cfg(ossl110g)]
+#[cfg(any(ossl110g, libressl270))]
 pub const SSL_CTRL_GET_MAX_PROTO_VERSION: c_int = 131;
 
 pub unsafe fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *mut DH) -> c_long {
@@ -388,14 +388,21 @@ pub unsafe fn SSL_CTX_set0_verify_cert_store(ctx: *mut SSL_CTX, st: *mut X509_ST
     SSL_CTX_ctrl(ctx, SSL_CTRL_SET_VERIFY_CERT_STORE, 0, st as *mut c_void)
 }
 
-#[cfg(ossl111)]
-pub unsafe fn SSL_CTX_set1_groups_list(ctx: *mut SSL_CTX, s: *const c_char) -> c_long {
-    SSL_CTX_ctrl(
-        ctx,
-        SSL_CTRL_SET_GROUPS_LIST,
-        0,
-        s as *const c_void as *mut c_void,
-    )
+cfg_if! {
+    if #[cfg(ossl111)] {
+        pub unsafe fn SSL_CTX_set1_groups_list(ctx: *mut SSL_CTX, s: *const c_char) -> c_long {
+            SSL_CTX_ctrl(
+                ctx,
+                SSL_CTRL_SET_GROUPS_LIST,
+                0,
+                s as *const c_void as *mut c_void,
+            )
+        }
+    } else if #[cfg(libressl251)] {
+        extern "C" {
+            pub fn SSL_CTX_set1_groups_list(ctx: *mut SSL_CTX, s: *const c_char) -> c_int;
+        }
+    }
 }
 
 #[cfg(ossl102)]
@@ -418,7 +425,7 @@ pub unsafe fn SSL_CTX_set_ecdh_auto(ctx: *mut SSL_CTX, onoff: c_int) -> c_int {
     ) as c_int
 }
 
-#[cfg(any(libress, all(ossl102, not(ossl110))))]
+#[cfg(any(libressl, all(ossl102, not(ossl110))))]
 pub unsafe fn SSL_set_ecdh_auto(ssl: *mut ::SSL, onoff: c_int) -> c_int {
     SSL_ctrl(
         ssl,
@@ -447,6 +454,24 @@ cfg_if! {
                 ptr::null_mut(),
             ) as c_int
         }
+
+        pub unsafe fn SSL_set_min_proto_version(s: *mut SSL, version: c_int) -> c_int {
+            SSL_ctrl(
+                s,
+                SSL_CTRL_SET_MIN_PROTO_VERSION,
+                version as c_long,
+                ptr::null_mut(),
+            ) as c_int
+        }
+
+        pub unsafe fn SSL_set_max_proto_version(s: *mut SSL, version: c_int) -> c_int {
+            SSL_ctrl(
+                s,
+                SSL_CTRL_SET_MAX_PROTO_VERSION,
+                version as c_long,
+                ptr::null_mut(),
+            ) as c_int
+        }
     }
 }
 
@@ -459,37 +484,13 @@ cfg_if! {
         pub unsafe fn SSL_CTX_get_max_proto_version(ctx: *mut SSL_CTX) -> c_int {
             SSL_CTX_ctrl(ctx, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, ptr::null_mut()) as c_int
         }
+        pub unsafe fn SSL_get_min_proto_version(s: *mut SSL) -> c_int {
+            SSL_ctrl(s, SSL_CTRL_GET_MIN_PROTO_VERSION, 0, ptr::null_mut()) as c_int
+        }
+        pub unsafe fn SSL_get_max_proto_version(s: *mut SSL) -> c_int {
+            SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, ptr::null_mut()) as c_int
+        }
     }
-}
-
-#[cfg(ossl110)]
-pub unsafe fn SSL_set_min_proto_version(s: *mut SSL, version: c_int) -> c_int {
-    SSL_ctrl(
-        s,
-        SSL_CTRL_SET_MIN_PROTO_VERSION,
-        version as c_long,
-        ptr::null_mut(),
-    ) as c_int
-}
-
-#[cfg(ossl110)]
-pub unsafe fn SSL_set_max_proto_version(s: *mut SSL, version: c_int) -> c_int {
-    SSL_ctrl(
-        s,
-        SSL_CTRL_SET_MAX_PROTO_VERSION,
-        version as c_long,
-        ptr::null_mut(),
-    ) as c_int
-}
-
-#[cfg(ossl110g)]
-pub unsafe fn SSL_get_min_proto_version(s: *mut SSL) -> c_int {
-    SSL_ctrl(s, SSL_CTRL_GET_MIN_PROTO_VERSION, 0, ptr::null_mut()) as c_int
-}
-
-#[cfg(ossl110g)]
-pub unsafe fn SSL_get_max_proto_version(s: *mut SSL) -> c_int {
-    SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, ptr::null_mut()) as c_int
 }
 
 #[cfg(ossl111)]
@@ -499,11 +500,11 @@ pub const SSL_CLIENT_HELLO_ERROR: c_int = 0;
 #[cfg(ossl111)]
 pub const SSL_CLIENT_HELLO_RETRY: c_int = -1;
 
-#[cfg(ossl111)]
+#[cfg(any(ossl111, libressl340))]
 pub const SSL_READ_EARLY_DATA_ERROR: c_int = 0;
-#[cfg(ossl111)]
+#[cfg(any(ossl111, libressl340))]
 pub const SSL_READ_EARLY_DATA_SUCCESS: c_int = 1;
-#[cfg(ossl111)]
+#[cfg(any(ossl111, libressl340))]
 pub const SSL_READ_EARLY_DATA_FINISH: c_int = 2;
 
 cfg_if! {

--- a/openssl-sys/src/tls1.rs
+++ b/openssl-sys/src/tls1.rs
@@ -7,7 +7,7 @@ use *;
 pub const TLS1_VERSION: c_int = 0x301;
 pub const TLS1_1_VERSION: c_int = 0x302;
 pub const TLS1_2_VERSION: c_int = 0x303;
-#[cfg(ossl111)]
+#[cfg(any(ossl111, libressl340))]
 pub const TLS1_3_VERSION: c_int = 0x304;
 
 pub const TLS1_AD_DECODE_ERROR: c_int = 50;

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -46,6 +46,10 @@ fn main() {
     if let Ok(version) = env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER") {
         let version = u64::from_str_radix(&version, 16).unwrap();
 
+        if version >= 0x2_05_01_00_0 {
+            println!("cargo:rustc-cfg=libressl251");
+        }
+
         if version >= 0x2_06_01_00_0 {
             println!("cargo:rustc-cfg=libressl261");
         }

--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -4,6 +4,8 @@ use std::ops::{Deref, DerefMut};
 
 use crate::dh::Dh;
 use crate::error::ErrorStack;
+#[cfg(libressl340)]
+use crate::ssl::SslVersion;
 use crate::ssl::{
     HandshakeError, Ssl, SslContext, SslContextBuilder, SslContextRef, SslMethod, SslMode,
     SslOptions, SslRef, SslStream, SslVerifyMode,
@@ -253,7 +255,10 @@ impl SslAcceptor {
     #[cfg(any(ossl111, libressl340))]
     pub fn mozilla_modern_v5(method: SslMethod) -> Result<SslAcceptorBuilder, ErrorStack> {
         let mut ctx = ctx(method)?;
+        #[cfg(ossl111)]
         ctx.set_options(SslOptions::NO_SSL_MASK & !SslOptions::NO_TLSV1_3);
+        #[cfg(libressl340)]
+        ctx.set_min_proto_version(Some(SslVersion::TLS1_3))?;
         ctx.set_ciphersuites(
             "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256",
         )?;

--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 
 use crate::dh::Dh;
 use crate::error::ErrorStack;
-#[cfg(libressl340)]
+#[cfg(any(ossl111, libressl340))]
 use crate::ssl::SslVersion;
 use crate::ssl::{
     HandshakeError, Ssl, SslContext, SslContextBuilder, SslContextRef, SslMethod, SslMode,
@@ -255,9 +255,6 @@ impl SslAcceptor {
     #[cfg(any(ossl111, libressl340))]
     pub fn mozilla_modern_v5(method: SslMethod) -> Result<SslAcceptorBuilder, ErrorStack> {
         let mut ctx = ctx(method)?;
-        #[cfg(ossl111)]
-        ctx.set_options(SslOptions::NO_SSL_MASK & !SslOptions::NO_TLSV1_3);
-        #[cfg(libressl340)]
         ctx.set_min_proto_version(Some(SslVersion::TLS1_3))?;
         ctx.set_ciphersuites(
             "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256",

--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -235,7 +235,7 @@ impl SslAcceptor {
              ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:\
              DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
         )?;
-        #[cfg(ossl111)]
+        #[cfg(any(ossl111, libressl340))]
         ctx.set_ciphersuites(
             "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256",
         )?;
@@ -247,10 +247,10 @@ impl SslAcceptor {
     /// This corresponds to the modern configuration of version 5 of Mozilla's server side TLS recommendations.
     /// See its [documentation][docs] for more details on specifics.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     ///
     /// [docs]: https://wiki.mozilla.org/Security/Server_Side_TLS
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn mozilla_modern_v5(method: SslMethod) -> Result<SslAcceptorBuilder, ErrorStack> {
         let mut ctx = ctx(method)?;
         ctx.set_options(SslOptions::NO_SSL_MASK & !SslOptions::NO_TLSV1_3);
@@ -271,7 +271,7 @@ impl SslAcceptor {
     pub fn mozilla_intermediate(method: SslMethod) -> Result<SslAcceptorBuilder, ErrorStack> {
         let mut ctx = ctx(method)?;
         ctx.set_options(SslOptions::CIPHER_SERVER_PREFERENCE);
-        #[cfg(ossl111)]
+        #[cfg(any(ossl111, libressl340))]
         ctx.set_options(SslOptions::NO_TLSV1_3);
         let dh = Dh::params_from_pem(FFDHE_2048.as_bytes())?;
         ctx.set_tmp_dh(&dh)?;
@@ -301,7 +301,7 @@ impl SslAcceptor {
         ctx.set_options(
             SslOptions::CIPHER_SERVER_PREFERENCE | SslOptions::NO_TLSV1 | SslOptions::NO_TLSV1_1,
         );
-        #[cfg(ossl111)]
+        #[cfg(any(ossl111, libressl340))]
         ctx.set_options(SslOptions::NO_TLSV1_3);
         setup_curves(&mut ctx)?;
         ctx.set_cipher_list(

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -65,7 +65,7 @@ use crate::error::ErrorStack;
 use crate::ex_data::Index;
 #[cfg(ossl111)]
 use crate::hash::MessageDigest;
-#[cfg(ossl110)]
+#[cfg(any(ossl110, libressl270))]
 use crate::nid::Nid;
 use crate::pkey::{HasPrivate, PKeyRef, Params, Private};
 use crate::srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
@@ -210,8 +210,8 @@ bitflags! {
 
         /// Disables the use of TLSv1.3.
         ///
-        /// Requires OpenSSL 1.1.1 or newer.
-        #[cfg(ossl111)]
+        /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
+        #[cfg(any(ossl111, libressl340))]
         const NO_TLSV1_3 = ffi::SSL_OP_NO_TLSv1_3;
 
         /// Disables the use of DTLSv1.0
@@ -876,7 +876,6 @@ impl SslContextBuilder {
     /// Add the provided CA certificate to the list sent by the server to the client when
     /// requesting client-side TLS authentication.
     #[corresponds(SSL_CTX_add_client_CA)]
-    #[cfg(not(libressl))]
     pub fn add_client_ca(&mut self, cacert: &X509Ref) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::SSL_CTX_add_client_CA(self.as_ptr(), cacert.as_ptr())).map(|_| ()) }
     }
@@ -1018,9 +1017,9 @@ impl SslContextBuilder {
     /// The format consists of TLSv1.3 cipher suite names separated by `:` characters in order of
     /// preference.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[corresponds(SSL_CTX_set_ciphersuites)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn set_ciphersuites(&mut self, cipher_list: &str) -> Result<(), ErrorStack> {
         let cipher_list = CString::new(cipher_list).unwrap();
         unsafe {
@@ -1565,9 +1564,9 @@ impl SslContextBuilder {
     ///
     /// Defaults to 0.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[corresponds(SSL_CTX_set_max_early_data)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn set_max_early_data(&mut self, bytes: u32) -> Result<(), ErrorStack> {
         if unsafe { ffi::SSL_CTX_set_max_early_data(self.as_ptr(), bytes) } == 1 {
             Ok(())
@@ -1622,9 +1621,9 @@ impl SslContextBuilder {
 
     /// Sets the context's supported elliptic curve groups.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 2.5.1 or newer.
     #[corresponds(SSL_CTX_set1_groups_list)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl251))]
     pub fn set_groups_list(&mut self, groups: &str) -> Result<(), ErrorStack> {
         let groups = CString::new(groups).unwrap();
         unsafe {
@@ -1719,9 +1718,9 @@ impl SslContext {
 impl SslContextRef {
     /// Returns the certificate associated with this `SslContext`, if present.
     ///
-    /// Requires OpenSSL 1.0.2 or newer.
+    /// Requires OpenSSL 1.0.2 or LibreSSL 2.7.0 or newer.
     #[corresponds(SSL_CTX_get0_certificate)]
-    #[cfg(any(ossl102, ossl110))]
+    #[cfg(any(ossl102, libressl270))]
     pub fn certificate(&self) -> Option<&X509Ref> {
         unsafe {
             let ptr = ffi::SSL_CTX_get0_certificate(self.as_ptr());
@@ -1731,9 +1730,9 @@ impl SslContextRef {
 
     /// Returns the private key associated with this `SslContext`, if present.
     ///
-    /// Requires OpenSSL 1.0.2 or newer.
+    /// Requires OpenSSL 1.0.2 or LibreSSL 3.4.0 or newer.
     #[corresponds(SSL_CTX_get0_privatekey)]
-    #[cfg(any(ossl102, ossl110))]
+    #[cfg(any(ossl102, libressl340))]
     pub fn private_key(&self) -> Option<&PKeyRef<Private>> {
         unsafe {
             let ptr = ffi::SSL_CTX_get0_privatekey(self.as_ptr());
@@ -1772,9 +1771,9 @@ impl SslContextRef {
 
     /// Gets the maximum amount of early data that will be accepted on incoming connections.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[corresponds(SSL_CTX_get_max_early_data)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn max_early_data(&self) -> u32 {
         unsafe { ffi::SSL_CTX_get_max_early_data(self.as_ptr()) }
     }
@@ -1954,9 +1953,9 @@ impl SslCipherRef {
 
     /// Returns the NID corresponding to the cipher.
     ///
-    /// Requires OpenSSL 1.1.0 or newer.
+    /// Requires OpenSSL 1.1.0 or LibreSSL 2.7.0 or newer.
     #[corresponds(SSL_CIPHER_get_cipher_nid)]
-    #[cfg(any(ossl110))]
+    #[cfg(any(ossl110, libressl270))]
     pub fn cipher_nid(&self) -> Option<Nid> {
         let n = unsafe { ffi::SSL_CIPHER_get_cipher_nid(self.as_ptr()) };
         if n == 0 {
@@ -2036,9 +2035,9 @@ impl SslSessionRef {
 
     /// Gets the maximum amount of early data that can be sent on this session.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[corresponds(SSL_SESSION_get_max_early_data)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn max_early_data(&self) -> u32 {
         unsafe { ffi::SSL_SESSION_get_max_early_data(self.as_ptr()) }
     }
@@ -2061,9 +2060,9 @@ impl SslSessionRef {
 
     /// Returns the session's TLS protocol version.
     ///
-    /// Requires OpenSSL 1.1.0 or newer.
+    /// Requires OpenSSL 1.1.0 or LibreSSL 2.7.0 or newer.
     #[corresponds(SSL_SESSION_get_protocol_version)]
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl270))]
     pub fn protocol_version(&self) -> SslVersion {
         unsafe {
             let version = ffi::SSL_SESSION_get_protocol_version(self.as_ptr());
@@ -2316,11 +2315,11 @@ impl SslRef {
 
     /// Like [`SslContextBuilder::set_ecdh_auto`].
     ///
-    /// Requires OpenSSL 1.0.2.
+    /// Requires OpenSSL 1.0.2 or LibreSSL.
     ///
     /// [`SslContextBuilder::set_tmp_ecdh`]: struct.SslContextBuilder.html#method.set_tmp_ecdh
     #[corresponds(SSL_set_ecdh_auto)]
-    #[cfg(all(ossl102, not(ossl110)))]
+    #[cfg(any(all(ossl102, not(ossl110)), libressl))]
     pub fn set_ecdh_auto(&mut self, onoff: bool) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::SSL_set_ecdh_auto(self.as_ptr(), onoff as c_int)).map(|_| ()) }
     }
@@ -2648,9 +2647,9 @@ impl SslRef {
     /// Returns the number of bytes copied, or if the buffer is empty, the size of the `client_random`
     /// value.
     ///
-    /// Requires OpenSSL 1.1.0 or newer.
+    /// Requires OpenSSL 1.1.0 or LibreSSL 2.7.0 or newer.
     #[corresponds(SSL_get_client_random)]
-    #[cfg(any(ossl110))]
+    #[cfg(any(ossl110, libressl270))]
     pub fn client_random(&self, buf: &mut [u8]) -> usize {
         unsafe {
             ffi::SSL_get_client_random(self.as_ptr(), buf.as_mut_ptr() as *mut c_uchar, buf.len())
@@ -2662,9 +2661,9 @@ impl SslRef {
     /// Returns the number of bytes copied, or if the buffer is empty, the size of the `server_random`
     /// value.
     ///
-    /// Requires OpenSSL 1.1.0 or newer.
+    /// Requires OpenSSL 1.1.0 or LibreSSL 2.7.0 or newer.
     #[corresponds(SSL_get_server_random)]
-    #[cfg(any(ossl110))]
+    #[cfg(any(ossl110, libressl270))]
     pub fn server_random(&self, buf: &mut [u8]) -> usize {
         unsafe {
             ffi::SSL_get_server_random(self.as_ptr(), buf.as_mut_ptr() as *mut c_uchar, buf.len())
@@ -2850,9 +2849,9 @@ impl SslRef {
 
     /// Sets the maximum amount of early data that will be accepted on this connection.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[corresponds(SSL_set_max_early_data)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn set_max_early_data(&mut self, bytes: u32) -> Result<(), ErrorStack> {
         if unsafe { ffi::SSL_set_max_early_data(self.as_ptr(), bytes) } == 1 {
             Ok(())
@@ -2863,9 +2862,9 @@ impl SslRef {
 
     /// Gets the maximum amount of early data that can be sent on this connection.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[corresponds(SSL_get_max_early_data)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn max_early_data(&self) -> u32 {
         unsafe { ffi::SSL_get_max_early_data(self.as_ptr()) }
     }
@@ -3143,9 +3142,9 @@ impl<S: Read + Write> SslStream<S> {
     ///
     /// Returns `Ok(0)` if all early data has been read.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[corresponds(SSL_read_early_data)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn read_early_data(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         let mut read = 0;
         let ret = unsafe {
@@ -3169,9 +3168,9 @@ impl<S: Read + Write> SslStream<S> {
     /// Useful for reducing latency, but vulnerable to replay attacks. Call
     /// [`SslRef::set_connect_state`] first.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[corresponds(SSL_write_early_data)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn write_early_data(&mut self, buf: &[u8]) -> Result<usize, Error> {
         let mut written = 0;
         let ret = unsafe {
@@ -3587,12 +3586,12 @@ where
     ///
     /// Returns `Ok(0)` if all early data has been read.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     ///
     /// This corresponds to [`SSL_read_early_data`].
     ///
     /// [`SSL_read_early_data`]: https://www.openssl.org/docs/manmaster/man3/SSL_read_early_data.html
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn read_early_data(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         self.inner.read_early_data(buf)
     }
@@ -3602,12 +3601,12 @@ where
     /// Useful for reducing latency, but vulnerable to replay attacks. Call
     /// `set_connect_state` first.
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     ///
     /// This corresponds to [`SSL_write_early_data`].
     ///
     /// [`SSL_write_early_data`]: https://www.openssl.org/docs/manmaster/man3/SSL_write_early_data.html
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     pub fn write_early_data(&mut self, buf: &[u8]) -> Result<usize, Error> {
         self.inner.write_early_data(buf)
     }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -611,8 +611,8 @@ impl SslVersion {
 
     /// TLSv1.3
     ///
-    /// Requires OpenSSL 1.1.1 or newer.
-    #[cfg(ossl111)]
+    /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
+    #[cfg(any(ossl111, libressl340))]
     pub const TLS1_3: SslVersion = SslVersion(ffi::TLS1_3_VERSION);
 }
 

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -790,7 +790,7 @@ fn connector_client_server_mozilla_intermediate_v5() {
 }
 
 #[test]
-#[cfg(ossl111)]
+#[cfg(any(ossl111, libressl340))]
 fn connector_client_server_mozilla_modern_v5() {
     test_mozilla_server(SslAcceptor::mozilla_modern_v5);
 }

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -903,7 +903,7 @@ fn tmp_dh_callback_ssl() {
 
     let mut client = server.client();
     // TLS 1.3 has no DH suites, so make sure we don't pick that version
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     client.ctx().set_options(super::SslOptions::NO_TLSV1_3);
     client.ctx().set_cipher_list("EDH").unwrap();
     client.connect();

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -853,7 +853,7 @@ fn tmp_dh_callback() {
 
     let mut client = server.client();
     // TLS 1.3 has no DH suites, so make sure we don't pick that version
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl340))]
     client.ctx().set_options(super::SslOptions::NO_TLSV1_3);
     client.ctx().set_cipher_list("EDH").unwrap();
     client.connect();

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -944,8 +944,9 @@ fn idle_session() {
     assert!(ssl.session().is_none());
 }
 
+/// possible LibreSSL bug since 3.2.1
 #[test]
-#[cfg_attr(all(libressl321, not(libressl340)), ignore)]
+#[cfg_attr(libressl321, ignore)]
 fn active_session() {
     let server = Server::builder().build();
 
@@ -1000,8 +1001,9 @@ fn status_callbacks() {
     assert!(CALLED_BACK_CLIENT.load(Ordering::SeqCst));
 }
 
+/// possible LibreSSL bug since 3.2.1
 #[test]
-#[cfg_attr(all(libressl321, not(libressl340)), ignore)]
+#[cfg_attr(libressl321, ignore)]
 fn new_session_callback() {
     static CALLED_BACK: AtomicBool = AtomicBool::new(false);
 
@@ -1024,8 +1026,9 @@ fn new_session_callback() {
     assert!(CALLED_BACK.load(Ordering::SeqCst));
 }
 
+/// possible LibreSSL bug since 3.2.1
 #[test]
-#[cfg_attr(all(libressl321, not(libressl340)), ignore)]
+#[cfg_attr(libressl321, ignore)]
 fn new_session_callback_swapped_ctx() {
     static CALLED_BACK: AtomicBool = AtomicBool::new(false);
 

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -550,7 +550,7 @@ fn read_panic() {
 }
 
 #[test]
-#[cfg_attr(libressl321, ignore)]
+#[cfg_attr(all(libressl321, not(libressl340)), ignore)]
 #[should_panic(expected = "blammo")]
 fn flush_panic() {
     struct ExplodingStream(TcpStream);
@@ -838,7 +838,7 @@ fn cert_store() {
 }
 
 #[test]
-#[cfg_attr(libressl321, ignore)]
+#[cfg_attr(all(libressl321, not(libressl340)), ignore)]
 fn tmp_dh_callback() {
     static CALLED_BACK: AtomicBool = AtomicBool::new(false);
 
@@ -886,7 +886,7 @@ fn tmp_ecdh_callback() {
 }
 
 #[test]
-#[cfg_attr(libressl321, ignore)]
+#[cfg_attr(all(libressl321, not(libressl340)), ignore)]
 fn tmp_dh_callback_ssl() {
     static CALLED_BACK: AtomicBool = AtomicBool::new(false);
 
@@ -945,7 +945,7 @@ fn idle_session() {
 }
 
 #[test]
-#[cfg_attr(libressl321, ignore)]
+#[cfg_attr(all(libressl321, not(libressl340)), ignore)]
 fn active_session() {
     let server = Server::builder().build();
 
@@ -1001,7 +1001,7 @@ fn status_callbacks() {
 }
 
 #[test]
-#[cfg_attr(libressl321, ignore)]
+#[cfg_attr(all(libressl321, not(libressl340)), ignore)]
 fn new_session_callback() {
     static CALLED_BACK: AtomicBool = AtomicBool::new(false);
 
@@ -1025,7 +1025,7 @@ fn new_session_callback() {
 }
 
 #[test]
-#[cfg_attr(libressl321, ignore)]
+#[cfg_attr(all(libressl321, not(libressl340)), ignore)]
 fn new_session_callback_swapped_ctx() {
     static CALLED_BACK: AtomicBool = AtomicBool::new(false);
 


### PR DESCRIPTION
Rebased on #1628

Expose stuff introduced since the 3.4 cycle and fix some before then. Re-add 3.4 to CI to verify, also since it is not yet considered EOL.

I'm inclined to re-ignore the three tests that continue to fail. May be LibreSSL bugs rather than anything on our end.