### PR TITLE
Add message digest block size accessor

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -34,6 +34,11 @@ pub unsafe fn EVP_get_digestbynid(type_: c_int) -> *const EVP_MD {
 cfg_if! {
     if #[cfg(ossl300)] {
         #[inline]
+        pub unsafe fn EVP_MD_block_size(md: *const EVP_MD) -> c_int {
+            EVP_MD_get_block_size(md)
+        }
+
+        #[inline]
         pub unsafe fn EVP_MD_size(md: *const EVP_MD) -> c_int {
             EVP_MD_get_size(md)
         }

--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -4,6 +4,7 @@ use *;
 cfg_if! {
     if #[cfg(ossl300)] {
         extern "C" {
+            pub fn EVP_MD_get_block_size(md: *const EVP_MD) -> c_int;
             pub fn EVP_MD_get_size(md: *const EVP_MD) -> c_int;
             pub fn EVP_MD_get_type(md: *const EVP_MD) -> c_int;
 
@@ -26,6 +27,7 @@ cfg_if! {
         }
     } else {
         extern "C" {
+            pub fn EVP_MD_block_size(md: *const EVP_MD) -> c_int;
             pub fn EVP_MD_size(md: *const EVP_MD) -> c_int;
             pub fn EVP_MD_type(md: *const EVP_MD) -> c_int;
 

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -138,6 +138,12 @@ impl MessageDigest {
         self.0
     }
 
+    /// The block size of the digest in bytes.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn block_size(&self) -> usize {
+        unsafe { ffi::EVP_MD_block_size(self.0) as usize }
+    }
+
     /// The size of the digest in bytes.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn size(&self) -> usize {
@@ -471,6 +477,9 @@ mod tests {
         for test in MD5_TESTS.iter() {
             hash_test(MessageDigest::md5(), test);
         }
+
+        assert_eq!(MessageDigest::md5().block_size(), 64);
+        assert_eq!(MessageDigest::md5().size(), 16);
     }
 
     #[test]
@@ -530,6 +539,9 @@ mod tests {
         for test in tests.iter() {
             hash_test(MessageDigest::sha1(), test);
         }
+
+        assert_eq!(MessageDigest::sha1().block_size(), 64);
+        assert_eq!(MessageDigest::sha1().size(), 20);
     }
 
     #[test]
@@ -542,6 +554,9 @@ mod tests {
         for test in tests.iter() {
             hash_test(MessageDigest::sha256(), test);
         }
+
+        assert_eq!(MessageDigest::sha256().block_size(), 64);
+        assert_eq!(MessageDigest::sha256().size(), 32);
     }
 
     #[cfg(ossl111)]
@@ -555,6 +570,9 @@ mod tests {
         for test in tests.iter() {
             hash_test(MessageDigest::sha3_224(), test);
         }
+
+        assert_eq!(MessageDigest::sha3_224().block_size(), 144);
+        assert_eq!(MessageDigest::sha3_224().size(), 28);
     }
 
     #[cfg(ossl111)]
@@ -568,6 +586,9 @@ mod tests {
         for test in tests.iter() {
             hash_test(MessageDigest::sha3_256(), test);
         }
+
+        assert_eq!(MessageDigest::sha3_256().block_size(), 136);
+        assert_eq!(MessageDigest::sha3_256().size(), 32);
     }
 
     #[cfg(ossl111)]
@@ -581,6 +602,9 @@ mod tests {
         for test in tests.iter() {
             hash_test(MessageDigest::sha3_384(), test);
         }
+
+        assert_eq!(MessageDigest::sha3_384().block_size(), 104);
+        assert_eq!(MessageDigest::sha3_384().size(), 48);
     }
 
     #[cfg(ossl111)]
@@ -594,6 +618,9 @@ mod tests {
         for test in tests.iter() {
             hash_test(MessageDigest::sha3_512(), test);
         }
+
+        assert_eq!(MessageDigest::sha3_512().block_size(), 72);
+        assert_eq!(MessageDigest::sha3_512().size(), 64);
     }
 
     #[cfg(ossl111)]
@@ -607,6 +634,9 @@ mod tests {
         for test in tests.iter() {
             hash_xof_test(MessageDigest::shake_128(), test);
         }
+
+        assert_eq!(MessageDigest::shake_128().block_size(), 168);
+        assert_eq!(MessageDigest::shake_128().size(), 16);
     }
 
     #[cfg(ossl111)]
@@ -620,6 +650,9 @@ mod tests {
         for test in tests.iter() {
             hash_xof_test(MessageDigest::shake_256(), test);
         }
+
+        assert_eq!(MessageDigest::shake_256().block_size(), 136);
+        assert_eq!(MessageDigest::shake_256().size(), 32);
     }
 
     #[test]
@@ -632,6 +665,9 @@ mod tests {
         for test in tests.iter() {
             hash_test(MessageDigest::ripemd160(), test);
         }
+
+        assert_eq!(MessageDigest::ripemd160().block_size(), 64);
+        assert_eq!(MessageDigest::ripemd160().size(), 20);
     }
 
     #[cfg(all(any(ossl111, libressl291), not(osslconf = "OPENSSL_NO_SM3")))]
@@ -645,6 +681,9 @@ mod tests {
         for test in tests.iter() {
             hash_test(MessageDigest::sm3(), test);
         }
+
+        assert_eq!(MessageDigest::sm3().block_size(), 64);
+        assert_eq!(MessageDigest::sm3().size(), 32);
     }
 
     #[test]

--- a/openssl/src/md.rs
+++ b/openssl/src/md.rs
@@ -207,6 +207,13 @@ unsafe impl Sync for MdRef {}
 unsafe impl Send for MdRef {}
 
 impl MdRef {
+    /// Returns the block size of the digest in bytes.
+    #[corresponds(EVP_MD_block_size)]
+    #[inline]
+    pub fn block_size(&self) -> usize {
+        unsafe { ffi::EVP_MD_block_size(self.as_ptr()) as usize }
+    }
+
     /// Returns the size of the digest in bytes.
     #[corresponds(EVP_MD_size)]
     #[inline]


### PR DESCRIPTION
As well as the digest size, we sometimes need to know the block size used by the message digest algorithm. Expose the openssl function for this in the message digest related APIs of the create.