### PR TITLE
openss-sys: define X509_V_ERR_INVALID_CA errno for openssl v3

### DIFF
--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -97,6 +97,8 @@ cfg_if! {
         pub const X509_V_ERR_PROXY_SUBJECT_NAME_VIOLATION: c_int = 67;
     }
 }
+#[cfg(ossl300)]
+pub const X509_V_ERR_INVALID_CA: c_int = 79;
 
 #[cfg(not(ossl110))]
 pub const X509_V_FLAG_CB_ISSUER_CHECK: c_ulong = 0x1;


### PR DESCRIPTION
From https://github.com/sfackler/rust-openssl/issues/1647