### PR TITLE
Custom ECC curve support

### DIFF
--- a/openssl-sys/src/handwritten/ec.rs
+++ b/openssl-sys/src/handwritten/ec.rs
@@ -35,6 +35,13 @@ extern "C" {
 
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 
+    pub fn EC_GROUP_set_generator(
+        group: *mut EC_GROUP,
+        generator: *const EC_POINT,
+        order: *const BIGNUM,
+        cofactor: *const BIGNUM,
+    ) -> c_int;
+
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> c_int;
 
     pub fn EC_GROUP_set_asn1_flag(key: *mut EC_GROUP, flag: c_int);
@@ -106,6 +113,14 @@ extern "C" {
         p: *const EC_POINT,
         x: *mut BIGNUM,
         y: *mut BIGNUM,
+        ctx: *mut BN_CTX,
+    ) -> c_int;
+
+    pub fn EC_POINT_set_affine_coordinates_GFp(
+        group: *const EC_GROUP,
+        p: *mut EC_POINT,
+        x: *const BIGNUM,
+        y: *const BIGNUM,
         ctx: *mut BN_CTX,
     ) -> c_int;
 

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -133,7 +133,6 @@ impl EcGroup {
         ctx: &mut BigNumContextRef,
     ) -> Result<EcGroup, ErrorStack> {
         unsafe {
-            init();
             cvt_p(ffi::EC_GROUP_new_curve_GFp(
                 p.as_ptr(),
                 a.as_ptr(),
@@ -237,7 +236,7 @@ impl EcGroupRef {
     /// Sets the generator point for the given curve
     #[corresponds(EC_GROUP_set_generator)]
     pub fn set_generator(
-        &self,
+        &mut self,
         generator: EcPoint,
         order: BigNum,
         cofactor: BigNum,
@@ -519,7 +518,7 @@ impl EcPointRef {
     /// `x` and `y` `BigNum`s
     #[corresponds(EC_POINT_set_affine_coordinates_GFp)]
     pub fn set_affine_coordinates_gfp(
-        &self,
+        &mut self,
         group: &EcGroupRef,
         x: &BigNumRef,
         y: &BigNumRef,


### PR DESCRIPTION
## Overview
Expose a few OpenSSL FFI to enable specifying custom ECC curves and update `EcGroup` and `EcPoint` to take advantage of them.

## Changes
 * [x] FFI to expose `EC_GROUP_set_generator` and `EC_POINT_set_affine_coordinates_GFp`
 * [x] Enable creation of `EcGroup` with `from_components(p, a, b)`
 * [x] Enable setting `EcGroup` generator through `set_generator`
 * [x] Enable setting `EcPoint` coordinates through `set_affine_coordinates_gfp`
 * [x] Unit tests for above