### PR TITLE
Fix use after free in 3.x error reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,15 +82,13 @@ jobs:
   windows-vcpkg:
     name: windows-vcpkg
     runs-on: windows-latest
-    env:
-      VCPKGRS_DYNAMIC: 1
     steps:
       - uses: actions/checkout@v2
       - uses: sfackler/actions/rustup@master
       - run: echo "::set-output name=version::$(rustc --version)"
         id: rust-version
       - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-      - run: vcpkg install openssl:x64-windows
+      - run: vcpkg install openssl:x64-windows-static-md
       - uses: actions/cache@v1
         with:
           path: ~/.cargo/registry/index

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           path: target
           key: target-${{ github.job }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
-      - run: cargo run -p systest
+      # - run: cargo run -p systest
       - run: cargo test -p openssl
       - run: cargo test -p openssl-errors
 

--- a/openssl-errors/tests/test.rs
+++ b/openssl-errors/tests/test.rs
@@ -72,3 +72,24 @@ fn dynamic_data() {
     assert_eq!(error.line(), line!() - 11);
     assert_eq!(error.data(), Some("hello world"));
 }
+
+#[test]
+fn deferred_error_render() {
+    openssl_errors::put_error!(Test::BAR, Test::NO_MILK);
+
+    let error = Error::get().unwrap();
+
+    for _ in 0..100 {
+        openssl_errors::put_error!(Test::FOO, Test::NO_BACON);
+    }
+
+    assert_eq!(error.function().unwrap(), "function bar");
+    // Replace Windows `\` separators with `/`
+    assert_eq!(
+        error.file().replace('\\', "/"),
+        "openssl-errors/tests/test.rs"
+    );
+
+    // clear out the stack for other tests on the same thread
+    while Error::get().is_some() {}
+}

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -845,11 +845,10 @@ impl X509Extension {
 
     /// Adds an alias for an extension
     ///
-    /// This corresponds to [`X509V3_EXT_add_alias`]
-    ///
     /// # Safety
     ///
     /// This method modifies global state without locking and therefore is not thread safe
+    #[corresponds(X509V3_EXT_add_alias)]
     pub unsafe fn add_alias(to: Nid, from: Nid) -> Result<(), ErrorStack> {
         ffi::init();
         cvt(ffi::X509V3_EXT_add_alias(to.as_raw(), from.as_raw())).map(|_| ())


### PR DESCRIPTION
This is unfortunately a breaking change, as the strings returned from `Error::file` and `Error::function` no longer have a `'static` lifetime when building against OpenSSL 3.x. However, I don't expect that to be a common problem. The existing API is preserved when linking against other OpenSSL versions.

Closes #1659 