### PR TITLE
Add SSL_get_psk_identity

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -384,6 +384,8 @@ extern "C" {
             extern "C" fn(*mut SSL, *const c_char, *mut c_uchar, c_uint) -> c_uint,
         >,
     );
+    pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const c_char;
+    pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const c_char;
 }
 
 extern "C" {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3007,6 +3007,36 @@ impl SslRef {
     pub fn set_mtu(&mut self, mtu: u32) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::SSL_set_mtu(self.as_ptr(), mtu as c_long) as c_int).map(|_| ()) }
     }
+
+    /// Returns the PSK identity hint used during connection setup.
+    ///
+    /// May return `None` if no PSK identity hint was used during the connection setup.
+    #[corresponds(SSL_get_psk_identity_hint)]
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+    pub fn psk_identity_hint(&self) -> Option<&[u8]> {
+        unsafe {
+            let ptr = ffi::SSL_get_psk_identity_hint(self.as_ptr());
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_bytes())
+            }
+        }
+    }
+
+    /// Returns the PSK identity used during connection setup.
+    #[corresponds(SSL_get_psk_identity)]
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+    pub fn psk_identity(&self) -> Option<&[u8]> {
+        unsafe {
+            let ptr = ffi::SSL_get_psk_identity(self.as_ptr());
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_bytes())
+            }
+        }
+    }
 }
 
 /// An SSL stream midway through the handshake process.


### PR DESCRIPTION
This adds the functions described here: https://www.openssl.org/docs/man1.0.2/man3/SSL_get_psk_identity.html

This is useful for extracting the PSK identity from the callback in `SslContextBuilder::set_psk_client_callback`.