### PR TITLE
Add feature `vendored-engine` for engine support in openssl-src

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -15,6 +15,7 @@ build = "build/main.rs"
 
 [features]
 vendored = ['openssl-src']
+vendored-engine = ['openssl-src']
 
 [dependencies]
 libc = "0.2"

--- a/openssl-sys/build/find_vendored.rs
+++ b/openssl-sys/build/find_vendored.rs
@@ -2,7 +2,12 @@ use openssl_src;
 use std::path::PathBuf;
 
 pub fn get_openssl(_target: &str) -> (Vec<PathBuf>, PathBuf) {
-    let artifacts = openssl_src::Build::new().build();
+    let mut builder = openssl_src::Build::new();
+
+    #[cfg(feature = "vendored-engine")]
+    builder = builder.force_engine();
+
+    let artifacts = builder.build();
     println!("cargo:vendored=1");
     println!(
         "cargo:root={}",

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -4,7 +4,7 @@ extern crate autocfg;
 #[cfg(feature = "bindgen")]
 extern crate bindgen;
 extern crate cc;
-#[cfg(feature = "vendored")]
+#[cfg(any(feature = "vendored", feature = "vendored-engine"))]
 extern crate openssl_src;
 extern crate pkg_config;
 #[cfg(target_env = "msvc")]
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 mod cfgs;
 
 mod find_normal;
-#[cfg(feature = "vendored")]
+#[cfg(any(feature = "vendored", feature = "vendored-engine"))]
 mod find_vendored;
 #[cfg(feature = "bindgen")]
 mod run_bindgen;
@@ -49,7 +49,7 @@ fn env(name: &str) -> Option<OsString> {
 }
 
 fn find_openssl(target: &str) -> (Vec<PathBuf>, PathBuf) {
-    #[cfg(feature = "vendored")]
+    #[cfg(any(feature = "vendored", feature = "vendored-engine"))]
     {
         // vendor if the feature is present, unless
         // OPENSSL_NO_VENDOR exists and isn't `0`


### PR DESCRIPTION
NOTE this change depends on the following PR being merged into `openssl-src` : https://github.com/alexcrichton/openssl-src-rs/pull/150 , and thus CI will fail until that is made available. Posting this PR in anticipation of that for visibility.

One of our project dependency crates added a hard dependency on the openssl Engine module.

This created a problem when cross compiling with musl due to the disabling of the Engine module by openssl-src for the musl target.

By adding the option to enable Engine support in openssl-src , and adding this feature flag to openssl-sys to make use of that option, together this would unblock us .