### PR TITLE
Added missing NIDs for SHA3 hashes

### DIFF
--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -958,3 +958,15 @@ pub const NID_sm4_cfb8: c_int = 978;
 pub const NID_sm4_ctr: c_int = 1139;
 #[cfg(libressl291)]
 pub const NID_sm4_ctr: c_int = 979;
+#[cfg(ossl111)]
+pub const NID_sha3_224: c_int = 1096;
+#[cfg(ossl111)]
+pub const NID_sha3_256: c_int = 1097;
+#[cfg(ossl111)]
+pub const NID_sha3_384: c_int = 1098;
+#[cfg(ossl111)]
+pub const NID_sha3_512: c_int = 1099;
+#[cfg(ossl111)]
+pub const NID_shake128: c_int = 1100;
+#[cfg(ossl111)]
+pub const NID_shake256: c_int = 1101;

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -480,6 +480,7 @@ mod tests {
 
         assert_eq!(MessageDigest::md5().block_size(), 64);
         assert_eq!(MessageDigest::md5().size(), 16);
+        assert_eq!(MessageDigest::md5().type_().as_raw(), Nid::MD5.as_raw());
     }
 
     #[test]
@@ -542,6 +543,7 @@ mod tests {
 
         assert_eq!(MessageDigest::sha1().block_size(), 64);
         assert_eq!(MessageDigest::sha1().size(), 20);
+        assert_eq!(MessageDigest::sha1().type_().as_raw(), Nid::SHA1.as_raw());
     }
 
     #[test]
@@ -557,6 +559,30 @@ mod tests {
 
         assert_eq!(MessageDigest::sha256().block_size(), 64);
         assert_eq!(MessageDigest::sha256().size(), 32);
+        assert_eq!(
+            MessageDigest::sha256().type_().as_raw(),
+            Nid::SHA256.as_raw()
+        );
+    }
+
+    #[test]
+    fn test_sha512() {
+        let tests = [(
+            "737465766566696e647365766572797468696e67",
+            "ba61d1f1af0f2dd80729f6cc900f19c0966bd38ba5c75e4471ef11b771dfe7551afab7fcbd300fdc4418f2\
+            b07a028fcd99e7b6446a566f2d9bcd7c604a1ea801",
+        )];
+
+        for test in tests.iter() {
+            hash_test(MessageDigest::sha512(), test);
+        }
+
+        assert_eq!(MessageDigest::sha512().block_size(), 128);
+        assert_eq!(MessageDigest::sha512().size(), 64);
+        assert_eq!(
+            MessageDigest::sha512().type_().as_raw(),
+            Nid::SHA512.as_raw()
+        );
     }
 
     #[cfg(ossl111)]
@@ -573,6 +599,10 @@ mod tests {
 
         assert_eq!(MessageDigest::sha3_224().block_size(), 144);
         assert_eq!(MessageDigest::sha3_224().size(), 28);
+        assert_eq!(
+            MessageDigest::sha3_224().type_().as_raw(),
+            Nid::SHA3_224.as_raw()
+        );
     }
 
     #[cfg(ossl111)]
@@ -589,6 +619,10 @@ mod tests {
 
         assert_eq!(MessageDigest::sha3_256().block_size(), 136);
         assert_eq!(MessageDigest::sha3_256().size(), 32);
+        assert_eq!(
+            MessageDigest::sha3_256().type_().as_raw(),
+            Nid::SHA3_256.as_raw()
+        );
     }
 
     #[cfg(ossl111)]
@@ -605,6 +639,10 @@ mod tests {
 
         assert_eq!(MessageDigest::sha3_384().block_size(), 104);
         assert_eq!(MessageDigest::sha3_384().size(), 48);
+        assert_eq!(
+            MessageDigest::sha3_384().type_().as_raw(),
+            Nid::SHA3_384.as_raw()
+        );
     }
 
     #[cfg(ossl111)]
@@ -621,6 +659,10 @@ mod tests {
 
         assert_eq!(MessageDigest::sha3_512().block_size(), 72);
         assert_eq!(MessageDigest::sha3_512().size(), 64);
+        assert_eq!(
+            MessageDigest::sha3_512().type_().as_raw(),
+            Nid::SHA3_512.as_raw()
+        );
     }
 
     #[cfg(ossl111)]
@@ -637,6 +679,10 @@ mod tests {
 
         assert_eq!(MessageDigest::shake_128().block_size(), 168);
         assert_eq!(MessageDigest::shake_128().size(), 16);
+        assert_eq!(
+            MessageDigest::shake_128().type_().as_raw(),
+            Nid::SHAKE128.as_raw()
+        );
     }
 
     #[cfg(ossl111)]
@@ -653,6 +699,10 @@ mod tests {
 
         assert_eq!(MessageDigest::shake_256().block_size(), 136);
         assert_eq!(MessageDigest::shake_256().size(), 32);
+        assert_eq!(
+            MessageDigest::shake_256().type_().as_raw(),
+            Nid::SHAKE256.as_raw()
+        );
     }
 
     #[test]
@@ -668,6 +718,10 @@ mod tests {
 
         assert_eq!(MessageDigest::ripemd160().block_size(), 64);
         assert_eq!(MessageDigest::ripemd160().size(), 20);
+        assert_eq!(
+            MessageDigest::ripemd160().type_().as_raw(),
+            Nid::RIPEMD160.as_raw()
+        );
     }
 
     #[cfg(all(any(ossl111, libressl291), not(osslconf = "OPENSSL_NO_SM3")))]
@@ -684,6 +738,7 @@ mod tests {
 
         assert_eq!(MessageDigest::sm3().block_size(), 64);
         assert_eq!(MessageDigest::sm3().size(), 32);
+        assert_eq!(MessageDigest::sm3().type_().as_raw(), Nid::SM3.as_raw());
     }
 
     #[test]

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -1066,6 +1066,20 @@ impl Nid {
     pub const AES_128_CBC_HMAC_SHA1: Nid = Nid(ffi::NID_aes_128_cbc_hmac_sha1);
     pub const AES_192_CBC_HMAC_SHA1: Nid = Nid(ffi::NID_aes_192_cbc_hmac_sha1);
     pub const AES_256_CBC_HMAC_SHA1: Nid = Nid(ffi::NID_aes_256_cbc_hmac_sha1);
+    #[cfg(any(ossl111, libressl291))]
+    pub const SM3: Nid = Nid(ffi::NID_sm3);
+    #[cfg(ossl111)]
+    pub const SHA3_224: Nid = Nid(ffi::NID_sha3_224);
+    #[cfg(ossl111)]
+    pub const SHA3_256: Nid = Nid(ffi::NID_sha3_256);
+    #[cfg(ossl111)]
+    pub const SHA3_384: Nid = Nid(ffi::NID_sha3_384);
+    #[cfg(ossl111)]
+    pub const SHA3_512: Nid = Nid(ffi::NID_sha3_512);
+    #[cfg(ossl111)]
+    pub const SHAKE128: Nid = Nid(ffi::NID_shake128);
+    #[cfg(ossl111)]
+    pub const SHAKE256: Nid = Nid(ffi::NID_shake256);
 }
 
 #[cfg(test)]

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -228,7 +228,7 @@ impl X509Builder {
     /// the X.509 standard should pass `2` to this method.
     #[corresponds(X509_set_version)]
     pub fn set_version(&mut self, version: i32) -> Result<(), ErrorStack> {
-        unsafe { cvt(ffi::X509_set_version(self.0.as_ptr(), version.into())).map(|_| ()) }
+        unsafe { cvt(ffi::X509_set_version(self.0.as_ptr(), version as c_long)).map(|_| ()) }
     }
 
     /// Sets the serial number of the certificate.
@@ -1147,7 +1147,7 @@ impl X509ReqBuilder {
     ///
     ///[`X509_REQ_set_version`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_REQ_set_version.html
     pub fn set_version(&mut self, version: i32) -> Result<(), ErrorStack> {
-        unsafe { cvt(ffi::X509_REQ_set_version(self.0.as_ptr(), version.into())).map(|_| ()) }
+        unsafe { cvt(ffi::X509_REQ_set_version(self.0.as_ptr(), version as c_long)).map(|_| ()) }
     }
 
     /// Set the issuer name.

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1147,7 +1147,13 @@ impl X509ReqBuilder {
     ///
     ///[`X509_REQ_set_version`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_REQ_set_version.html
     pub fn set_version(&mut self, version: i32) -> Result<(), ErrorStack> {
-        unsafe { cvt(ffi::X509_REQ_set_version(self.0.as_ptr(), version as c_long)).map(|_| ()) }
+        unsafe {
+            cvt(ffi::X509_REQ_set_version(
+                self.0.as_ptr(),
+                version as c_long,
+            ))
+            .map(|_| ())
+        }
     }
 
     /// Set the issuer name.


### PR DESCRIPTION
The `Nid`s for SHA3 hash algorithm were missing. I added them, as SHA3 is already supported in `MessageDigest`. Also added `Nid` checks in the tests to make sure, that the NIDs set by OpenSSL match the constants defined by rust-openssl.