### PR TITLE
Add SslOptions::PRIORITIZE_CHACHA

### DIFF
--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -109,6 +109,8 @@ cfg_if! {
 
 #[cfg(ossl111)]
 pub const SSL_OP_ENABLE_MIDDLEBOX_COMPAT: ssl_op_type!() = 0x00100000;
+#[cfg(ossl111)]
+pub const SSL_OP_PRIORITIZE_CHACHA: ssl_op_type!() = 0x00200000;
 
 pub const SSL_OP_CIPHER_SERVER_PREFERENCE: ssl_op_type!() = 0x00400000;
 cfg_if! {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -256,6 +256,20 @@ bitflags! {
         /// may have this disabled by default.
         #[cfg(ossl111)]
         const ENABLE_MIDDLEBOX_COMPAT = ffi::SSL_OP_ENABLE_MIDDLEBOX_COMPAT;
+
+        /// Prioritize ChaCha ciphers when preferred by clients.
+        ///
+        /// Temporarily reprioritize ChaCha20-Poly1305 ciphers to the top of the server cipher list
+        /// if a ChaCha20-Poly1305 cipher is at the top of the client cipher list. This helps those
+        /// clients (e.g. mobile) use ChaCha20-Poly1305 if that cipher is anywhere in the server
+        /// cipher list; but still allows other clients to use AES and other ciphers.
+        ///
+        /// Requires enable [`SslOptions::CIPHER_SERVER_PREFERENCE`].
+        /// Requires OpenSSL 1.1.1 or newer.
+        ///
+        /// [`SslOptions::CIPHER_SERVER_PREFERENCE`]: struct.SslOptions.html#associatedconstant.CIPHER_SERVER_PREFERENCE
+        #[cfg(ossl111)]
+        const PRIORITIZE_CHACHA = ffi::SSL_OP_PRIORITIZE_CHACHA;
     }
 }
 


### PR DESCRIPTION
This option can improve performance on clients without AES hardware acceleration.

The `SSL_OP_PRIORITIZE_CHACHA` added in OpenSSL 1.1.1, see [SSL_CTX_set_options](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_options.html#HISTORY).