### PR TITLE
Added `.to-text()` for `X509Req`.

### DIFF
--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -636,4 +636,5 @@ extern "C" {
 
 extern "C" {
     pub fn X509_print(bio: *mut BIO, x509: *mut X509) -> c_int;
+    pub fn X509_REQ_print(bio: *mut BIO, req: *mut X509_REQ) -> c_int;
 }

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1310,6 +1310,13 @@ impl X509ReqRef {
         ffi::i2d_X509_REQ
     }
 
+    to_pem! {
+        /// Converts the request to human readable text.
+        #[corresponds(X509_Req_print)]
+        to_text,
+        ffi::X509_REQ_print
+    }
+
     /// Returns the numerical value of the version field of the certificate request.
     ///
     /// This corresponds to [`X509_REQ_get_version`]

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -502,3 +502,28 @@ fn test_convert_to_text() {
         );
     }
 }
+
+#[test]
+fn test_convert_req_to_text() {
+    let csr = include_bytes!("../../test/csr.pem");
+    let csr = X509Req::from_pem(csr).unwrap();
+
+    const SUBSTRINGS: &[&str] = &[
+        "Certificate Request:\n",
+        "Version: 1",
+        "Subject: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd, CN=foobar.com\n",
+        "Subject Public Key Info:",
+        "Signature Algorithm:",
+    ];
+
+    let text = String::from_utf8(csr.to_text().unwrap()).unwrap();
+
+    for substring in SUBSTRINGS {
+        assert!(
+            text.contains(substring),
+            "{:?} not found inside {}",
+            substring,
+            text
+        );
+    }
+}

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -510,7 +510,7 @@ fn test_convert_req_to_text() {
 
     const SUBSTRINGS: &[&str] = &[
         "Certificate Request:\n",
-        "Version: 1",
+        "Version:",
         "Subject: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd, CN=foobar.com\n",
         "Subject Public Key Info:",
         "Signature Algorithm:",

--- a/openssl/test/csr.pem
+++ b/openssl/test/csr.pem
@@ -1,0 +1,62 @@
+Certificate Request:
+    Data:
+        Version: 1 (0x0)
+        Subject: C = AU, ST = Some-State, O = Internet Widgits Pty Ltd, CN = foobar.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:a8:f4:25:8c:44:b3:17:a3:50:85:fe:23:91:87:
+                    d0:78:36:1b:49:17:ff:2d:47:d3:e5:1b:de:6c:36:
+                    fc:96:b9:04:3f:f2:37:de:bf:ef:33:12:ba:65:c5:
+                    f2:e4:b7:4a:49:a9:ca:22:64:6f:20:f4:d5:34:91:
+                    4e:a8:e5:3f:bf:d5:08:19:72:50:80:a1:96:92:d0:
+                    9a:b1:9a:8a:36:62:4f:f5:42:c8:f5:ea:99:cc:05:
+                    cd:74:b9:20:e4:e9:5f:5a:25:25:f5:bc:ac:0e:35:
+                    53:52:c2:21:c0:d4:c8:57:fa:2e:d6:7f:bf:ca:d2:
+                    78:aa:fa:4e:e1:3a:48:65:78:59:16:81:9b:54:ab:
+                    8d:60:5e:1d:55:7c:eb:a0:91:ae:d4:92:d6:27:93:
+                    d9:ab:05:b0:0c:8e:66:a5:a1:93:67:da:93:0c:01:
+                    0c:55:83:84:e1:88:b9:b7:ce:fb:96:aa:f5:c0:49:
+                    6c:d4:65:ce:c8:01:dd:46:6c:de:00:b4:3b:a1:b3:
+                    6e:76:7a:a1:3d:13:88:93:1e:4e:c5:d7:8c:00:4b:
+                    52:56:aa:fe:ba:ea:14:5e:18:7a:e6:64:91:b1:d3:
+                    14:13:33:db:cf:0f:51:cd:e6:dd:94:dc:a4:df:84:
+                    ef:e6:4e:50:14:59:5c:a0:f6:d0:ad:3b:36:e8:2a:
+                    0b:35
+                Exponent: 65537 (0x10001)
+        Attributes:
+            a0:00
+    Signature Algorithm: sha256WithRSAEncryption
+         95:26:e1:84:56:e7:80:da:2c:a4:c0:b5:85:43:61:85:34:84:
+         37:83:c0:bc:cf:70:20:89:46:ce:3d:7e:23:8a:40:a4:a5:fa:
+         c5:e3:3d:ee:e5:05:16:58:93:f9:6c:f3:86:ee:99:cc:e1:04:
+         5c:68:99:da:66:72:a1:95:31:cd:13:6f:a5:6f:fc:a9:ec:75:
+         6a:f7:e5:cf:0e:7b:5f:2f:db:8d:45:e6:66:52:12:1d:c9:ac:
+         3a:86:35:bd:1f:7b:6e:b5:e1:f3:4f:80:6a:06:73:1c:a0:0d:
+         a3:63:b6:40:76:25:b0:e9:96:33:7a:9d:18:7e:5e:93:c0:47:
+         d7:0b:da:b3:03:17:94:d0:0c:78:18:f3:0e:cd:3c:f7:e8:25:
+         08:c2:13:0a:af:1e:5c:48:5f:17:41:b2:2d:d2:0f:37:2e:b3:
+         10:fd:2b:c0:77:e1:17:8a:57:0c:95:5e:c8:03:eb:63:14:2e:
+         46:fd:1e:14:13:9f:38:c1:2f:e9:9b:47:c3:60:a9:d7:6e:a3:
+         d0:af:0b:6f:df:6e:37:f6:d9:a0:1b:dd:1f:a5:a5:33:89:1f:
+         a5:a3:44:14:91:83:c3:c8:b2:6e:fb:3f:f1:6d:d2:51:21:f7:
+         98:20:0a:40:75:a5:60:c3:59:53:08:62:3d:39:e8:83:55:90:
+         1a:bf:51:57
+-----BEGIN CERTIFICATE REQUEST-----
+MIICnzCCAYcCAQAwWjELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUx
+ITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDETMBEGA1UEAwwKZm9v
+YmFyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKj0JYxEsxej
+UIX+I5GH0Hg2G0kX/y1H0+Ub3mw2/Ja5BD/yN96/7zMSumXF8uS3SkmpyiJkbyD0
+1TSRTqjlP7/VCBlyUIChlpLQmrGaijZiT/VCyPXqmcwFzXS5IOTpX1olJfW8rA41
+U1LCIcDUyFf6LtZ/v8rSeKr6TuE6SGV4WRaBm1SrjWBeHVV866CRrtSS1ieT2asF
+sAyOZqWhk2fakwwBDFWDhOGIubfO+5aq9cBJbNRlzsgB3UZs3gC0O6GzbnZ6oT0T
+iJMeTsXXjABLUlaq/rrqFF4YeuZkkbHTFBMz288PUc3m3ZTcpN+E7+ZOUBRZXKD2
+0K07NugqCzUCAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IBAQCVJuGEVueA2iykwLWF
+Q2GFNIQ3g8C8z3AgiUbOPX4jikCkpfrF4z3u5QUWWJP5bPOG7pnM4QRcaJnaZnKh
+lTHNE2+lb/yp7HVq9+XPDntfL9uNReZmUhIdyaw6hjW9H3tuteHzT4BqBnMcoA2j
+Y7ZAdiWw6ZYzep0Yfl6TwEfXC9qzAxeU0Ax4GPMOzTz36CUIwhMKrx5cSF8XQbIt
+0g83LrMQ/SvAd+EXilcMlV7IA+tjFC5G/R4UE584wS/pm0fDYKnXbqPQrwtv3243
+9tmgG90fpaUziR+lo0QUkYPDyLJu+z/xbdJRIfeYIApAdaVgw1lTCGI9OeiDVZAa
+v1FX
+-----END CERTIFICATE REQUEST-----


### PR DESCRIPTION
Added `.to_text()` for `X509Req`, which provides human readable representation of CSR's as in
```
openssl req -in csr.pem -text -noout
```