### PR TITLE
Add Clone implementation for SslContextBuilder

### DIFF
--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -662,6 +662,7 @@ pub fn select_next_proto<'a>(server: &[u8], client: &'a [u8]) -> Option<&'a [u8]
 }
 
 /// A builder for `SslContext`s.
+#[derive(Clone)]
 pub struct SslContextBuilder(SslContext);
 
 impl SslContextBuilder {


### PR DESCRIPTION
I needed to clone `SslContextBuilder` before calling `build()` as it will consume the builder object. Need to keep the prepared state of the builder to easily make some changes and build another `SslContext` object.