### PR TITLE
Add `try_cmp` function to `X509NameRef`s

### DIFF
--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use crate::asn1::Asn1Time;
 use crate::bn::{BigNum, MsbOption};
 use crate::hash::MessageDigest;
@@ -526,4 +528,15 @@ fn test_convert_req_to_text() {
             text
         );
     }
+}
+
+#[test]
+fn test_name_cmp() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+
+    let subject = cert.subject_name();
+    let issuer = cert.issuer_name();
+    assert_eq!(Ordering::Equal, subject.try_cmp(subject).unwrap());
+    assert_eq!(Ordering::Greater, subject.try_cmp(issuer).unwrap());
 }


### PR DESCRIPTION
Fixes #1641.

This adds a `X509NameRef::try_cmp(&self, other: &X509NameRef) -> Result<Ordering, ErrorStack>` function that is sensible on OpenSSL 3.0.0 and up but can occasionally return a spurious less than in older versions. I believe that spurious failure can only occur if a memory allocation fails so is vanishingly unlikely (or at least is unlikely to occur on a system that isn't about to fall over anyway).