### PR TITLE
Fix supported OpenSSL versions

### DIFF
--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -1,7 +1,7 @@
 //! Bindings to OpenSSL
 //!
 //! This crate provides a safe interface to the popular OpenSSL cryptography library. OpenSSL versions 1.0.1 through
-//! 1.1.1 and LibreSSL versions 2.5 through 3.4.1 are supported.
+//! 3.x.x and LibreSSL versions 2.5 through 3.4.1 are supported.
 //!
 //! # Building
 //!


### PR DESCRIPTION
`openssl-sys` does support OpenSSL version 3. Update the documentation to reflect that.

Closes https://github.com/sfackler/rust-openssl/issues/1693