### PR TITLE
Recognize LibreSSL 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,11 @@ jobs:
               library:
                 name: libressl
                 version: 3.5.2
+            - target: x86_64-unknown-linux-gnu
+              bindgen: false
+              library:
+                name: libressl
+                version: 3.6.0
           exclude:
             - library:
                 name: boringssl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
               bindgen: false
               library:
                 name: libressl
-                version: 3.5.2
+                version: 3.5.3
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -280,6 +280,7 @@ See rust-openssl documentation for more information:
             (3, 4, 0) => ('3', '4', '0'),
             (3, 4, _) => ('3', '4', 'x'),
             (3, 5, _) => ('3', '5', 'x'),
+            (3, 6, _) => ('3', '6', 'x'),
             _ => version_error(),
         };
 
@@ -322,7 +323,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3.0.0), or LibreSSL 2.5
-through 3.5, but a different version of OpenSSL was found. The build is now aborting
+through 3.6, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "


### PR DESCRIPTION
This is a minimal patch to make openssl-sys work on OpenBSD-current (soon to be 7.2).  LibreSSL has already been versioned there as 3.6.0, although the portable version is not yet released (portable LibreSSL releases are synchronized with OpenBSD releases).  When the portable release is done, I guess there will be more changes needed for finding the correct library on e.g. Linux.