### PR TITLE
LibreSSL 3.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,11 @@ jobs:
               library:
                 name: libressl
                 version: 3.5.2
+            - target: x86_64-unknown-linux-gnu
+              bindgen: false
+              library:
+                name: libressl
+                version: 3.6.0
           exclude:
             - library:
                 name: boringssl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,11 +180,6 @@ jobs:
               bindgen: true
               library:
                 name: libressl
-                version: 3.4.3
-            - target: x86_64-unknown-linux-gnu
-              bindgen: true
-              library:
-                name: libressl
                 version: 3.5.3
             - target: x86_64-unknown-linux-gnu
               bindgen: true
@@ -196,11 +191,6 @@ jobs:
               library:
                 name: libressl
                 version: 2.5.5
-            - target: x86_64-unknown-linux-gnu
-              bindgen: false
-              library:
-                name: libressl
-                version: 3.4.3
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,12 @@ jobs:
               bindgen: true
               library:
                 name: libressl
-                version: 3.5.2
+                version: 3.5.3
+            - target: x86_64-unknown-linux-gnu
+              bindgen: true
+              library:
+                name: libressl
+                version: 3.6.0
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
               bindgen: false
               library:
                 name: libressl
-                version: 3.5.2
+                version: 3.5.3
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -280,7 +280,7 @@ See rust-openssl documentation for more information:
             (3, 4, 0) => ('3', '4', '0'),
             (3, 4, _) => ('3', '4', 'x'),
             (3, 5, _) => ('3', '5', 'x'),
-            (3, 6, _) => ('3', '6', 'x'),
+            (3, 6, 0) => ('3', '6', '0'),
             _ => version_error(),
         };
 
@@ -323,7 +323,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3.0.0), or LibreSSL 2.5
-through 3.6, but a different version of OpenSSL was found. The build is now aborting
+through 3.6.0, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -280,6 +280,7 @@ See rust-openssl documentation for more information:
             (3, 4, 0) => ('3', '4', '0'),
             (3, 4, _) => ('3', '4', 'x'),
             (3, 5, _) => ('3', '5', 'x'),
+            (3, 6, _) => ('3', '6', 'x'),
             _ => version_error(),
         };
 
@@ -322,7 +323,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3.0.0), or LibreSSL 2.5
-through 3.5, but a different version of OpenSSL was found. The build is now aborting
+through 3.6, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -94,5 +94,13 @@ fn main() {
         if version >= 0x3_05_00_00_0 {
             println!("cargo:rustc-cfg=libressl350");
         }
+
+        if version >= 0x3_06_00_00_0 {
+            println!("cargo:rustc-cfg=libressl360");
+        }
+
+        if version >= 0x3_06_01_00_0 {
+            println!("cargo:rustc-cfg=libressl361");
+        }
     }
 }

--- a/openssl/src/pkcs7.rs
+++ b/openssl/src/pkcs7.rs
@@ -361,7 +361,9 @@ mod tests {
         assert_eq!(content.expect("should be non-empty"), message.as_bytes());
     }
 
+    /// https://marc.info/?l=openbsd-cvs&m=166602943014106&w=2
     #[test]
+    #[cfg_attr(all(libressl360, not(libressl361)), ignore)]
     fn sign_verify_test_normal() {
         let cert = include_bytes!("../test/cert.pem");
         let cert = X509::from_pem(cert).unwrap();
@@ -397,7 +399,9 @@ mod tests {
         assert!(content.is_none());
     }
 
+    /// https://marc.info/?l=openbsd-cvs&m=166602943014106&w=2
     #[test]
+    #[cfg_attr(all(libressl360, not(libressl361)), ignore)]
     fn signers() {
         let cert = include_bytes!("../test/cert.pem");
         let cert = X509::from_pem(cert).unwrap();


### PR DESCRIPTION
Limit to 3.6.0 only, as the 3.6 series is still considered developmental. Pet CI, add 3.6.0 and 3.6.1 definitions in `openssl` and use them to ignore two failing PKCS#7 tests due to a bug. Incorporates #1695.

There have been some API additions and removals for 3.6.0 but nothing concerning what we implement/expose.