### PR TITLE
Add `BigNum::copy_from_slice`

### DIFF
--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -1070,7 +1070,7 @@ impl BigNum {
     pub fn from_slice(n: &[u8]) -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
-            assert!(n.len() <= c_int::max_value() as usize);
+            assert!(n.len() <= LenType::max_value() as usize);
 
             cvt_p(ffi::BN_bin2bn(
                 n.as_ptr(),

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -1080,6 +1080,30 @@ impl BigNum {
             .map(|p| BigNum::from_ptr(p))
         }
     }
+
+    /// Copies data from a slice overwriting what was in the BigNum.
+    ///
+    /// This function can be used to copy data from a slice to a
+    /// [secure BigNum][`BigNum::new_secure`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use openssl::bn::BigNum;
+    /// let mut bignum = BigNum::new().unwrap();
+    /// bignum.copy_from_slice(&[0x12, 0x00, 0x34]).unwrap();
+    ///
+    /// assert_eq!(bignum, BigNum::from_u32(0x120034).unwrap());
+    /// ```
+    #[corresponds(BN_bin2bn)]
+    pub fn copy_from_slice(&mut self, n: &[u8]) -> Result<(), ErrorStack> {
+        unsafe {
+            assert!(n.len() <= LenType::max_value() as usize);
+
+            cvt_p(ffi::BN_bin2bn(n.as_ptr(), n.len() as LenType, self.0))?;
+            Ok(())
+        }
+    }
 }
 
 impl fmt::Debug for BigNumRef {


### PR DESCRIPTION
Unfortunately `BigNum::from_slice` always creates a new BigNum and cannot be used to initialize an already existing BigNum thus it is not possible to have a secure BigNum initialized from a slice.
    
This patch adds the function for overwriting existing BigNum with given slice bytes. Thus the BigNum can be created using `BigNum::new_secure` and then overwritten using `BigNum::copy_from_slice`.