### PR TITLE
Add NID constants for Brainpool curves

### DIFF
--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -94,6 +94,12 @@ pub const NID_sect409k1: c_int = 731;
 pub const NID_sect409r1: c_int = 732;
 pub const NID_sect571k1: c_int = 733;
 pub const NID_sect571r1: c_int = 734;
+#[cfg(ossl110)]
+pub const NID_brainpoolP256r1: c_int = 927;
+#[cfg(ossl110)]
+pub const NID_brainpoolP384r1: c_int = 931;
+#[cfg(ossl110)]
+pub const NID_brainpoolP512r1: c_int = 933;
 pub const NID_wap_wsg_idm_ecid_wtls1: c_int = 735;
 pub const NID_wap_wsg_idm_ecid_wtls3: c_int = 736;
 pub const NID_wap_wsg_idm_ecid_wtls4: c_int = 737;

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -215,6 +215,12 @@ impl Nid {
     pub const SECT409R1: Nid = Nid(ffi::NID_sect409r1);
     pub const SECT571K1: Nid = Nid(ffi::NID_sect571k1);
     pub const SECT571R1: Nid = Nid(ffi::NID_sect571r1);
+    #[cfg(ossl110)]
+    pub const BRAINPOOL_P256R1: Nid = Nid(ffi::NID_brainpoolP256r1);
+    #[cfg(ossl110)]
+    pub const BRAINPOOL_P384R1: Nid = Nid(ffi::NID_brainpoolP384r1);
+    #[cfg(ossl110)]
+    pub const BRAINPOOL_P512R1: Nid = Nid(ffi::NID_brainpoolP512r1);
     pub const WAP_WSG_IDM_ECID_WTLS1: Nid = Nid(ffi::NID_wap_wsg_idm_ecid_wtls1);
     pub const WAP_WSG_IDM_ECID_WTLS3: Nid = Nid(ffi::NID_wap_wsg_idm_ecid_wtls3);
     pub const WAP_WSG_IDM_ECID_WTLS4: Nid = Nid(ffi::NID_wap_wsg_idm_ecid_wtls4);

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -55,6 +55,7 @@ fn main() {
         .header("openssl/x509v3.h")
         .header("openssl/safestack.h")
         .header("openssl/hmac.h")
+        .header("openssl/obj_mac.h")
         .header("openssl/ssl.h")
         .header("openssl/err.h")
         .header("openssl/rand.h")


### PR DESCRIPTION
Brainpool curves are used by European government organizations that are suspicious of the NIST curves. Brainpool curves are very similar to NIST curves with one critical difference: the parameters to Brainpool are [nothing-up-my-sleeve numbers][0].

The actual values of the NID constants have been taken from the [OpenSSL source code][1].

[0]: https://github.com/veorq/numsgen#seeds

[1]: https://github.com/openssl/openssl/blob/4e6647506331fc3b3ef5b23e5dbe188279ddd575/include/openssl/obj_mac.h#L4759