### PR TITLE
Improve fmt::Display impl for Error

### DIFF
--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -315,8 +315,8 @@ impl fmt::Display for Error {
         }
         write!(fmt, "in file '{}:{}' ", self.file(), self.line())?;
         match self.library() {
-            Some(l) => write!(fmt, "in library '{}' ", l),
-            None => write!(fmt, "in library 'Unknown' "),
+            Some(l) => write!(fmt, "in library '{}'", l),
+            None => write!(fmt, "in library 'Unknown'"),
         }
     }
 }

--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -298,26 +298,26 @@ impl fmt::Debug for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "error:{:08X}", self.code())?;
-        match self.library() {
-            Some(l) => write!(fmt, ":{}", l)?,
-            None => write!(fmt, ":lib({})", ffi::ERR_GET_LIB(self.code()))?,
-        }
-        match self.function() {
-            Some(f) => write!(fmt, ":{}", f)?,
-            None => write!(fmt, ":func({})", ffi::ERR_GET_FUNC(self.code()))?,
-        }
+        write!(fmt, "error 0x{:08X} ", self.code())?;
         match self.reason() {
-            Some(r) => write!(fmt, ":{}", r)?,
-            None => write!(fmt, ":reason({})", ffi::ERR_GET_REASON(self.code()))?,
+            Some(r) => write!(fmt, "'{}", r)?,
+            None => write!(fmt, "'Unknown'")?,
         }
-        write!(
-            fmt,
-            ":{}:{}:{}",
-            self.file(),
-            self.line(),
-            self.data().unwrap_or("")
-        )
+        if let Some(data) = self.data() {
+            write!(fmt, ": {}' ", data)?;
+        } else {
+            write!(fmt, "' ")?;
+        }
+        write!(fmt, "occurred in ")?;
+        match self.function() {
+            Some(f) => write!(fmt, "function '{}' ", f)?,
+            None => write!(fmt, "function 'Unknown' ")?,
+        }
+        write!(fmt, "in file '{}:{}' ", self.file(), self.line())?;
+        match self.library() {
+            Some(l) => write!(fmt, "in library '{}' ", l),
+            None => write!(fmt, "in library 'Unknown' "),
+        }
     }
 }
 


### PR DESCRIPTION
Resolves point 2 in https://github.com/sfackler/rust-openssl/issues/1715

A bit of bikeshedding is welcome but this change is already a lot more readable than the previous implementation.

## Example 1
An error in the old format:
`error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1919:`

That same error with the new format:
`error 0x1416F086 'certificate verify failed' occurred in function 'tls_process_server_certificate' in file 'ssl/statem/statem_clnt.c:1919' in library 'SSL routines'`

## Example 2
If we had a working data implementation (point 3 in https://github.com/sfackler/rust-openssl/issues/1715 ) the previous example would look like this.

An error in the old format:
`error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1919:DATA_HERE`

That same error with the new format:
`error 0x1416F086 'certificate verify failed: DATA_HERE' occurred in function 'tls_process_server_certificate' in file 'ssl/statem/statem_clnt.c:1919' in library 'SSL routines'`