### PR TITLE
LibreSSL 3.6.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
               bindgen: true
               library:
                 name: libressl
-                version: 3.6.0
+                version: 3.6.1
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:
@@ -198,7 +198,7 @@ jobs:
               bindgen: false
               library:
                 name: libressl
-                version: 3.6.0
+                version: 3.6.1
           exclude:
             - library:
                 name: boringssl

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -281,6 +281,7 @@ See rust-openssl documentation for more information:
             (3, 4, _) => ('3', '4', 'x'),
             (3, 5, _) => ('3', '5', 'x'),
             (3, 6, 0) => ('3', '6', '0'),
+            (3, 6, _) => ('3', '6', 'x'),
             _ => version_error(),
         };
 
@@ -323,7 +324,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3.0.0), or LibreSSL 2.5
-through 3.6.0, but a different version of OpenSSL was found. The build is now aborting
+through 3.6.x, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "


### PR DESCRIPTION
The 3.6 series is declared stable with 3.6.1.