### PR TITLE
[openssl-sys] adding no-bundle option to openssl

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -364,11 +364,16 @@ fn parse_new_version(version: &str) -> u64 {
 /// statically or dynamically.
 fn determine_mode(libdirs: &[PathBuf], libs: &[&str]) -> &'static str {
     // First see if a mode was explicitly requested
-    let kind = env("OPENSSL_STATIC");
-    match kind.as_ref().and_then(|s| s.to_str()) {
+    let _static = env("OPENSSL_STATIC");
+    match _static.as_ref().and_then(|s| s.to_str()) {
         Some("0") => return "dylib",
         Some(_) => return "static",
         None => {}
+    }
+    let _static_nobundle = env("OPENSSL_STATIC_NOBUNDLE");
+    match _static_nobundle.as_ref().and_then(|s| s.to_str()) {
+        Some("0") | None => {}
+        Some(_) => return "static-nobundle",
     }
 
     // Next, see what files we actually have to link against, and see what our


### PR DESCRIPTION
Definining ``OPENSSL_STATIC_NOBUNDLE=1`` environment variable, so
openssl libraries are linked via ``static-nobundle`` options.
See
https://github.com/rust-lang/rfcs/blob/master/text/1717-dllimport.md#unbundled-static-libs-optional





##### Some more context:
I am trying to build a static library 
```toml
[lib]
crate-type = ["staticlib"]
```

that includes openssl as a dependency.
This rust-based static library (let's call it ``librust.a`` for the sake of the explanation) is part of a bigger project that includes some C/C++ code as well, which itself uses openssl.
The problem I am having is at the linking phase where, linking the C++ code against both  ``libopenssl.a`` and ``librust.a``, gives me an error of ``duplicate symbol`` as all the openssl symbols are present in both static libraries.

This change would allow me to leave all the openssl symbols within ``librust.a`` as undefined, and let the linker solve them at the very final phase where the project-wide library is built and all symbols resolved.