### PR TITLE
Expose EVP_PKEY_security_bits for LibreSSL 3.6.0 and later

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -43,6 +43,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x3_05_00_00_0 {
             cfgs.push("libressl350");
         }
+        if libressl_version >= 0x3_06_00_00_0 {
+            cfgs.push("libressl360");
+        }
         if libressl_version >= 0x3_07_00_00_0 {
             cfgs.push("libressl370");
         }

--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -427,7 +427,7 @@ cfg_if! {
         const_ptr_api! {
             extern "C" {
                 pub fn EVP_PKEY_bits(key: #[const_ptr_if(any(ossl110, libressl280))] EVP_PKEY) -> c_int;
-                #[cfg(ossl110)]
+                #[cfg(any(ossl110, libressl360))]
                 pub fn EVP_PKEY_security_bits(pkey: #[const_ptr_if(any(ossl110, libressl280))] EVP_PKEY) -> c_int;
             }
         }

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -233,7 +233,7 @@ where
     ///
     ///Bits of security is defined in NIST SP800-57.
     #[corresponds(EVP_PKEY_security_bits)]
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     pub fn security_bits(&self) -> u32 {
         unsafe { ffi::EVP_PKEY_security_bits(self.as_ptr()) as u32 }
     }
@@ -1028,7 +1028,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     fn test_security_bits() {
         let group = crate::ec::EcGroup::from_curve_name(crate::nid::Nid::SECP521R1).unwrap();
         let ec_key = EcKey::generate(&group).unwrap();


### PR DESCRIPTION
Follow-up to #1753 