### PR TITLE
Mark Openssl 3 deprecated functions

### DIFF
--- a/openssl-sys/src/handwritten/aes.rs
+++ b/openssl-sys/src/handwritten/aes.rs
@@ -12,6 +12,7 @@ extern "C" {
     pub fn AES_set_encrypt_key(userKey: *const c_uchar, bits: c_int, key: *mut AES_KEY) -> c_int;
     pub fn AES_set_decrypt_key(userKey: *const c_uchar, bits: c_int, key: *mut AES_KEY) -> c_int;
 
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     pub fn AES_ige_encrypt(
         in_: *const c_uchar,
         out: *mut c_uchar,

--- a/openssl-sys/src/handwritten/bn.rs
+++ b/openssl-sys/src/handwritten/bn.rs
@@ -7,8 +7,10 @@ extern "C" {
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
     pub fn BN_rand(r: *mut BIGNUM, bits: c_int, top: c_int, bottom: c_int) -> c_int;
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     pub fn BN_pseudo_rand(r: *mut BIGNUM, bits: c_int, top: c_int, bottom: c_int) -> c_int;
     pub fn BN_rand_range(r: *mut BIGNUM, range: *const BIGNUM) -> c_int;
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     pub fn BN_pseudo_rand_range(r: *mut BIGNUM, range: *const BIGNUM) -> c_int;
     pub fn BN_new() -> *mut BIGNUM;
     #[cfg(ossl110)]
@@ -122,12 +124,14 @@ extern "C" {
         rem: *const BIGNUM,
         cb: *mut BN_GENCB,
     ) -> c_int;
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     pub fn BN_is_prime_ex(
         p: *const BIGNUM,
         checks: c_int,
         ctx: *mut BN_CTX,
         cb: *mut BN_GENCB,
     ) -> c_int;
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     pub fn BN_is_prime_fasttest_ex(
         p: *const BIGNUM,
         checks: c_int,

--- a/openssl/src/aes.rs
+++ b/openssl/src/aes.rs
@@ -23,7 +23,7 @@
 //! # Examples
 
 #![cfg_attr(
-    not(boringssl),
+    all(not(boringssl), not(osslconf = "OPENSSL_NO_DEPRECATED_3_0")),
     doc = r#"\
 ## AES IGE
 ```rust
@@ -156,6 +156,7 @@ impl AesKey {
 /// Panics if `in_` is not the same length as `out`, if that length is not a multiple of 16, or if
 /// `iv` is not at least 32 bytes.
 #[cfg(not(boringssl))]
+#[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
 #[corresponds(AES_ige_encrypt)]
 pub fn aes_ige(in_: &[u8], out: &mut [u8], key: &AesKey, iv: &mut [u8], mode: Mode) {
     unsafe {
@@ -268,6 +269,7 @@ mod test {
     // From https://www.mgp25.com/AESIGE/
     #[test]
     #[cfg(not(boringssl))]
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     fn ige_vector_1() {
         let raw_key = "000102030405060708090A0B0C0D0E0F";
         let raw_iv = "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F";

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -217,6 +217,7 @@ impl BigNumRef {
     }
 
     /// The cryptographically weak counterpart to `rand_in_range`.
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     #[corresponds(BN_pseudo_rand_range)]
     pub fn pseudo_rand_range(&self, rnd: &mut BigNumRef) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::BN_pseudo_rand_range(rnd.as_ptr(), self.as_ptr())).map(|_| ()) }
@@ -385,6 +386,7 @@ impl BigNumRef {
     }
 
     /// The cryptographically weak counterpart to `rand`.  Not suitable for key generation.
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     #[corresponds(BN_pseudo_rand)]
     #[allow(clippy::useless_conversion)]
     pub fn pseudo_rand(&mut self, bits: i32, msb: MsbOption, odd: bool) -> Result<(), ErrorStack> {
@@ -722,6 +724,7 @@ impl BigNumRef {
     /// # Return Value
     ///
     /// Returns `true` if `self` is prime with an error probability of less than `0.25 ^ checks`.
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     #[corresponds(BN_is_prime_ex)]
     #[allow(clippy::useless_conversion)]
     pub fn is_prime(&self, checks: i32, ctx: &mut BigNumContextRef) -> Result<bool, ErrorStack> {
@@ -745,6 +748,7 @@ impl BigNumRef {
     /// # Return Value
     ///
     /// Returns `true` if `self` is prime with an error probability of less than `0.25 ^ checks`.
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     #[corresponds(BN_is_prime_fasttest_ex)]
     #[allow(clippy::useless_conversion)]
     pub fn is_prime_fasttest(
@@ -1388,6 +1392,7 @@ mod tests {
         assert_eq!(a, &(&a << 1) >> 1);
     }
 
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     #[test]
     fn test_rand_range() {
         let range = BigNum::from_u32(909_829_283).unwrap();
@@ -1396,6 +1401,7 @@ mod tests {
         assert!(result >= BigNum::from_u32(0).unwrap() && result < range);
     }
 
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     #[test]
     fn test_pseudo_rand_range() {
         let range = BigNum::from_u32(909_829_283).unwrap();
@@ -1404,6 +1410,7 @@ mod tests {
         assert!(result >= BigNum::from_u32(0).unwrap() && result < range);
     }
 
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     #[test]
     fn test_prime_numbers() {
         let a = BigNum::from_u32(19_029_017).unwrap();


### PR DESCRIPTION
Solve #1745 
mark this functions as OPENSSL_NO_DEPRECATED_3_0
```rust
openssl::aes::aes_ige
openssl::bn::BigNumRef::pseudo_rand_range
openssl::bn::BigNumRef::pseudo_rand
openssl::bn::BigNumRef::is_prime
openssl::bn::BigNumRef::is_prime_fasttest
```