### PR TITLE
brew: prefer to install openssl@3

### DIFF
--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! ```not_rust
 //! # macOS (Homebrew)
-//! $ brew install openssl@1.1
+//! $ brew install openssl@3
 //!
 //! # macOS (MacPorts)
 //! $ sudo port install openssl


### PR DESCRIPTION
Since both `openssl@3` and `openssl@1.1` are supported, it would be good to recommend to use `openssl@3`.

https://github.com/sfackler/rust-openssl/blob/8621407a3268071e30312dfe40098b574554ea1f/openssl-sys/build/find_normal.rs#L36