### PR TITLE
X509_PURPOSE

### DIFF
--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -645,3 +645,22 @@ extern "C" {
     pub fn X509_print(bio: *mut BIO, x509: *mut X509) -> c_int;
     pub fn X509_REQ_print(bio: *mut BIO, req: *mut X509_REQ) -> c_int;
 }
+
+#[repr(C)]
+pub struct X509_PURPOSE {
+    pub purpose: c_int,
+    pub trust: c_int, // Default trust ID
+    pub flags: c_int,
+    pub check_purpose:
+        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
+    pub name: *mut c_char,
+    pub sname: *mut c_char,
+    pub usr_data: *mut c_void,
+}
+
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
+        pub fn X509_PURPOSE_get0(idx: c_int) -> *mut X509_PURPOSE;
+    }
+}

--- a/openssl-sys/src/handwritten/x509_vfy.rs
+++ b/openssl-sys/src/handwritten/x509_vfy.rs
@@ -4,6 +4,18 @@ use *;
 #[cfg(any(libressl, all(ossl102, not(ossl110))))]
 pub enum X509_VERIFY_PARAM_ID {}
 
+#[repr(C)]
+pub struct X509_PURPOSE {
+    pub purpose: c_int,
+    pub trust: c_int, // Default trust ID
+    pub flags: c_int,
+    pub check_purpose:
+        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
+    pub name: *mut c_char,
+    pub sname: *mut c_char,
+    pub usr_data: *mut c_void,
+}
+
 extern "C" {
     #[cfg(ossl110)]
     pub fn X509_LOOKUP_meth_free(method: *mut X509_LOOKUP_METHOD);
@@ -48,6 +60,9 @@ extern "C" {
 
     pub fn X509_STORE_set_default_paths(store: *mut X509_STORE) -> c_int;
     pub fn X509_STORE_set_flags(store: *mut X509_STORE, flags: c_ulong) -> c_int;
+    pub fn X509_STORE_set_purpose(ctx: *mut X509_STORE, purpose: c_int) -> c_int;
+    pub fn X509_STORE_set_trust(ctx: *mut X509_STORE, trust: c_int) -> c_int;
+
 }
 
 const_ptr_api! {
@@ -126,4 +141,11 @@ extern "C" {
     pub fn X509_VERIFY_PARAM_get_auth_level(param: *const X509_VERIFY_PARAM) -> c_int;
     #[cfg(ossl102)]
     pub fn X509_VERIFY_PARAM_set_purpose(param: *mut X509_VERIFY_PARAM, purpose: c_int) -> c_int;
+}
+
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
+        pub fn X509_PURPOSE_get0(idx: c_int) -> *mut X509_PURPOSE;
+    }
 }

--- a/openssl-sys/src/handwritten/x509_vfy.rs
+++ b/openssl-sys/src/handwritten/x509_vfy.rs
@@ -4,18 +4,6 @@ use *;
 #[cfg(any(libressl, all(ossl102, not(ossl110))))]
 pub enum X509_VERIFY_PARAM_ID {}
 
-#[repr(C)]
-pub struct X509_PURPOSE {
-    pub purpose: c_int,
-    pub trust: c_int, // Default trust ID
-    pub flags: c_int,
-    pub check_purpose:
-        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
-    pub name: *mut c_char,
-    pub sname: *mut c_char,
-    pub usr_data: *mut c_void,
-}
-
 extern "C" {
     #[cfg(ossl110)]
     pub fn X509_LOOKUP_meth_free(method: *mut X509_LOOKUP_METHOD);
@@ -141,11 +129,4 @@ extern "C" {
     pub fn X509_VERIFY_PARAM_get_auth_level(param: *const X509_VERIFY_PARAM) -> c_int;
     #[cfg(ossl102)]
     pub fn X509_VERIFY_PARAM_set_purpose(param: *mut X509_VERIFY_PARAM, purpose: c_int) -> c_int;
-}
-
-const_ptr_api! {
-    extern "C" {
-        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
-        pub fn X509_PURPOSE_get0(idx: c_int) -> *mut X509_PURPOSE;
-    }
 }

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -147,26 +147,3 @@ pub unsafe fn X509_LOOKUP_add_dir(
         std::ptr::null_mut(),
     )
 }
-
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SSL_CLIENT: c_int = 1;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SSL_SERVER: c_int = 2;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_NS_SSL_SERVER: c_int = 3;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SMIME_SIGN: c_int = 4;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SMIME_ENCRYPT: c_int = 5;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_CRL_SIGN: c_int = 6;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_ANY: c_int = 7;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_OCSP_HELPER: c_int = 8;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_TIMESTAMP_SIGN: c_int = 9;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_MIN: c_int = 1;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_MAX: c_int = 9;

--- a/openssl-sys/src/x509v3.rs
+++ b/openssl-sys/src/x509v3.rs
@@ -58,25 +58,15 @@ pub const EXFLAG_FRESHEST: u32 = 0x1000;
 #[cfg(any(ossl102, libressl261))]
 pub const EXFLAG_SS: u32 = 0x2000;
 
-#[cfg(not(boringssl))]
 pub const X509v3_KU_DIGITAL_SIGNATURE: u32 = 0x0080;
-#[cfg(not(boringssl))]
 pub const X509v3_KU_NON_REPUDIATION: u32 = 0x0040;
-#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_ENCIPHERMENT: u32 = 0x0020;
-#[cfg(not(boringssl))]
 pub const X509v3_KU_DATA_ENCIPHERMENT: u32 = 0x0010;
-#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_AGREEMENT: u32 = 0x0008;
-#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_CERT_SIGN: u32 = 0x0004;
-#[cfg(not(boringssl))]
 pub const X509v3_KU_CRL_SIGN: u32 = 0x0002;
-#[cfg(not(boringssl))]
 pub const X509v3_KU_ENCIPHER_ONLY: u32 = 0x0001;
-#[cfg(not(boringssl))]
 pub const X509v3_KU_DECIPHER_ONLY: u32 = 0x8000;
-#[cfg(not(boringssl))]
 pub const X509v3_KU_UNDEF: u32 = 0xffff;
 
 pub const XKU_SSL_SERVER: u32 = 0x1;

--- a/openssl-sys/src/x509v3.rs
+++ b/openssl-sys/src/x509v3.rs
@@ -58,15 +58,25 @@ pub const EXFLAG_FRESHEST: u32 = 0x1000;
 #[cfg(any(ossl102, libressl261))]
 pub const EXFLAG_SS: u32 = 0x2000;
 
+#[cfg(not(boringssl))]
 pub const X509v3_KU_DIGITAL_SIGNATURE: u32 = 0x0080;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_NON_REPUDIATION: u32 = 0x0040;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_ENCIPHERMENT: u32 = 0x0020;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_DATA_ENCIPHERMENT: u32 = 0x0010;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_AGREEMENT: u32 = 0x0008;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_CERT_SIGN: u32 = 0x0004;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_CRL_SIGN: u32 = 0x0002;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_ENCIPHER_ONLY: u32 = 0x0001;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_DECIPHER_ONLY: u32 = 0x8000;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_UNDEF: u32 = 0xffff;
 
 pub const XKU_SSL_SERVER: u32 = 0x1;
@@ -79,3 +89,15 @@ pub const XKU_TIMESTAMP: u32 = 0x40;
 pub const XKU_DVCS: u32 = 0x80;
 #[cfg(ossl110)]
 pub const XKU_ANYEKU: u32 = 0x100;
+
+pub const X509_PURPOSE_SSL_CLIENT: c_int = 1;
+pub const X509_PURPOSE_SSL_SERVER: c_int = 2;
+pub const X509_PURPOSE_NS_SSL_SERVER: c_int = 3;
+pub const X509_PURPOSE_SMIME_SIGN: c_int = 4;
+pub const X509_PURPOSE_SMIME_ENCRYPT: c_int = 5;
+pub const X509_PURPOSE_CRL_SIGN: c_int = 6;
+pub const X509_PURPOSE_ANY: c_int = 7;
+pub const X509_PURPOSE_OCSP_HELPER: c_int = 8;
+pub const X509_PURPOSE_TIMESTAMP_SIGN: c_int = 9;
+pub const X509_PURPOSE_MIN: c_int = 1;
+pub const X509_PURPOSE_MAX: c_int = 9;

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -8,7 +8,7 @@
 //! the secure protocol for browsing the web.
 
 use cfg_if::cfg_if;
-use foreign_types::{ForeignType, ForeignTypeRef};
+use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::{c_int, c_long, c_uint};
 use std::cmp::{self, Ordering};
 use std::error::Error;
@@ -1740,7 +1740,8 @@ cfg_if! {
     }
 }
 
-pub struct X509PurposeId(i32);
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct X509PurposeId(c_int);
 
 impl X509PurposeId {
     pub const SSL_CLIENT: X509PurposeId = X509PurposeId(ffi::X509_PURPOSE_SSL_CLIENT);
@@ -1753,31 +1754,24 @@ impl X509PurposeId {
     pub const OCSP_HELPER: X509PurposeId = X509PurposeId(ffi::X509_PURPOSE_OCSP_HELPER);
     pub const TIMESTAMP_SIGN: X509PurposeId = X509PurposeId(ffi::X509_PURPOSE_TIMESTAMP_SIGN);
 
-    pub fn value(&self) -> i32 {
+    /// Constructs an `X509PurposeId` from a raw OpenSSL value.
+    pub fn from_raw(id: c_int) -> Self { X509PurposeId(id) }
+
+    /// Returns the raw OpenSSL value represented by this type.
+    pub fn as_raw(&self) -> c_int {
         self.0
     }
 }
 
-impl From<i32> for X509PurposeId {
-    fn from(id: i32) -> Self {
-        X509PurposeId(id)
-    }
-}
+/// A reference to an [`X509_PURPOSE`].
+pub struct X509PurposeRef(Opaque);
 
-/// fake free method, since X509_PURPOSE is static
-unsafe fn no_free_purpose(_purps: *mut ffi::X509_PURPOSE) {}
-
-foreign_type_and_impl_send_sync! {
+/// Implements a wrapper type for the static `X509_PURPOSE` table in OpenSSL.
+impl ForeignTypeRef for X509PurposeRef {
     type CType = ffi::X509_PURPOSE;
-    fn drop = no_free_purpose;
-
-    /// Adjust parameters associated with certificate verification.
-    pub struct X509Purpose;
-    /// Reference to `X509Purpose`.
-    pub struct X509PurposeRef;
 }
 
-impl X509Purpose {
+impl X509PurposeRef {
     /// Get the internal table index of an X509_PURPOSE for a given short name. Valid short
     /// names include
     ///  - "sslclient",
@@ -1789,9 +1783,9 @@ impl X509Purpose {
     ///  - "any",
     ///  - "ocsphelper",
     ///  - "timestampsign"
-    /// The index can be used with `X509Purpose::from_idx()` to get the purpose.
+    /// The index can be used with `X509PurposeRef::from_idx()` to get the purpose.
     #[allow(clippy::unnecessary_cast)]
-    pub fn get_by_sname(sname: &str) -> Result<i32, ErrorStack> {
+    pub fn get_by_sname(sname: &str) -> Result<c_int, ErrorStack> {
         unsafe {
             let sname = CString::new(sname).unwrap();
             cfg_if! {
@@ -1801,22 +1795,19 @@ impl X509Purpose {
                     let purpose = cvt_n(ffi::X509_PURPOSE_get_by_sname(sname.as_ptr() as *mut _))?;
                 }
             }
-            Ok(purpose as i32)
+            Ok(purpose)
         }
     }
-
     /// Get an `X509PurposeRef` for a given index value. The index can be obtained from e.g.
-    /// `X509Purpose::get_by_sname()`.
+    /// `X509PurposeRef::get_by_sname()`.
     #[corresponds(X509_PURPOSE_get0)]
-    pub fn from_idx(idx: i32) -> Result<&'static X509PurposeRef, ErrorStack> {
+    pub fn from_idx(idx: c_int) -> Result<&'static X509PurposeRef, ErrorStack> {
         unsafe {
             let ptr = cvt_p(ffi::X509_PURPOSE_get0(idx))?;
             Ok(X509PurposeRef::from_ptr(ptr))
         }
     }
-}
 
-impl X509PurposeRef {
     /// Get the purpose value from an X509Purpose structure. This value is one of
     /// - `X509_PURPOSE_SSL_CLIENT`
     /// - `X509_PURPOSE_SSL_SERVER`
@@ -1830,7 +1821,7 @@ impl X509PurposeRef {
     pub fn purpose(&self) -> X509PurposeId {
         unsafe {
             let x509_purpose: *mut ffi::X509_PURPOSE = self.as_ptr();
-            X509PurposeId::from((*x509_purpose).purpose)
+            X509PurposeId::from_raw((*x509_purpose).purpose)
         }
     }
 }

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1755,7 +1755,9 @@ impl X509PurposeId {
     pub const TIMESTAMP_SIGN: X509PurposeId = X509PurposeId(ffi::X509_PURPOSE_TIMESTAMP_SIGN);
 
     /// Constructs an `X509PurposeId` from a raw OpenSSL value.
-    pub fn from_raw(id: c_int) -> Self { X509PurposeId(id) }
+    pub fn from_raw(id: c_int) -> Self {
+        X509PurposeId(id)
+    }
 
     /// Returns the raw OpenSSL value represented by this type.
     pub fn as_raw(&self) -> c_int {

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -129,13 +129,7 @@ impl X509StoreBuilderRef {
     /// The purpose value can be obtained by `X509PurposeRef::get_by_sname()`
     #[corresponds(X509_STORE_set_purpose)]
     pub fn set_purpose(&mut self, purpose: X509PurposeId) -> Result<(), ErrorStack> {
-        unsafe {
-            cvt(ffi::X509_STORE_set_purpose(
-                self.as_ptr(),
-                purpose.as_raw(),
-            ))
-            .map(|_| ())
-        }
+        unsafe { cvt(ffi::X509_STORE_set_purpose(self.as_ptr(), purpose.as_raw())).map(|_| ()) }
     }
 
     /// Sets certificate chain validation related parameters.

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -51,8 +51,9 @@ use crate::ssl::SslFiletype;
 use crate::stack::StackRef;
 #[cfg(any(ossl102, libressl261))]
 use crate::x509::verify::{X509VerifyFlags, X509VerifyParamRef};
-use crate::x509::{X509Object, X509};
+use crate::x509::{X509Object, X509PurposeId, X509};
 use crate::{cvt, cvt_p};
+use libc::c_int;
 use openssl_macros::corresponds;
 #[cfg(not(boringssl))]
 use std::ffi::CString;
@@ -123,6 +124,19 @@ impl X509StoreBuilderRef {
     #[cfg(any(ossl102, libressl261))]
     pub fn set_flags(&mut self, flags: X509VerifyFlags) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::X509_STORE_set_flags(self.as_ptr(), flags.bits())).map(|_| ()) }
+    }
+
+    /// Sets the certificate purpose.
+    /// The purpose value can be obtained by `X509Purpose::get_by_sname()`
+    #[corresponds(X509_STORE_set_purpose)]
+    pub fn set_purpose(&mut self, purpose: X509PurposeId) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::X509_STORE_set_purpose(
+                self.as_ptr(),
+                purpose.value() as c_int,
+            ))
+            .map(|_| ())
+        }
     }
 
     /// Sets certificate chain validation related parameters.

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -53,7 +53,6 @@ use crate::stack::StackRef;
 use crate::x509::verify::{X509VerifyFlags, X509VerifyParamRef};
 use crate::x509::{X509Object, X509PurposeId, X509};
 use crate::{cvt, cvt_p};
-use libc::c_int;
 use openssl_macros::corresponds;
 #[cfg(not(boringssl))]
 use std::ffi::CString;
@@ -127,13 +126,13 @@ impl X509StoreBuilderRef {
     }
 
     /// Sets the certificate purpose.
-    /// The purpose value can be obtained by `X509Purpose::get_by_sname()`
+    /// The purpose value can be obtained by `X509PurposeRef::get_by_sname()`
     #[corresponds(X509_STORE_set_purpose)]
     pub fn set_purpose(&mut self, purpose: X509PurposeId) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_STORE_set_purpose(
                 self.as_ptr(),
-                purpose.value() as c_int,
+                purpose.as_raw(),
             ))
             .map(|_| ())
         }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -21,7 +21,7 @@ use crate::x509::verify::{X509VerifyFlags, X509VerifyParam};
 #[cfg(ossl110)]
 use crate::x509::X509Builder;
 #[cfg(any(ossl102, libressl261))]
-use crate::x509::X509Purpose;
+use crate::x509::X509PurposeRef;
 #[cfg(ossl102)]
 use crate::x509::X509PurposeId;
 use crate::x509::{X509Name, X509Req, X509StoreContext, X509VerifyResult, X509};
@@ -452,12 +452,12 @@ fn test_verify_cert_with_purpose() {
     let chain = Stack::new().unwrap();
 
     let mut store_bldr = X509StoreBuilder::new().unwrap();
-    let purpose_idx = X509Purpose::get_by_sname("sslserver")
+    let purpose_idx = X509PurposeRef::get_by_sname("sslserver")
         .expect("Getting certificate purpose 'sslserver' failed");
-    let x509_purpose =
-        X509Purpose::from_idx(purpose_idx).expect("Getting certificate purpose failed");
+    let x509_purposeref =
+        X509PurposeRef::from_idx(purpose_idx).expect("Getting certificate purpose failed");
     store_bldr
-        .set_purpose(x509_purpose.purpose())
+        .set_purpose(x509_purposeref.purpose())
         .expect("Setting certificate purpose failed");
     store_bldr.add_cert(ca).unwrap();
 
@@ -479,10 +479,10 @@ fn test_verify_cert_with_wrong_purpose_fails() {
     let chain = Stack::new().unwrap();
 
     let mut store_bldr = X509StoreBuilder::new().unwrap();
-    let purpose_idx = X509Purpose::get_by_sname("timestampsign")
+    let purpose_idx = X509PurposeRef::get_by_sname("timestampsign")
         .expect("Getting certificate purpose 'timestampsign' failed");
     let x509_purpose =
-        X509Purpose::from_idx(purpose_idx).expect("Getting certificate purpose failed");
+        X509PurposeRef::from_idx(purpose_idx).expect("Getting certificate purpose failed");
     store_bldr
         .set_purpose(x509_purpose.purpose())
         .expect("Setting certificate purpose failed");

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -20,10 +20,10 @@ use crate::x509::store::X509StoreBuilder;
 use crate::x509::verify::{X509VerifyFlags, X509VerifyParam};
 #[cfg(ossl110)]
 use crate::x509::X509Builder;
-#[cfg(any(ossl102, libressl261))]
-use crate::x509::X509PurposeRef;
 #[cfg(ossl102)]
 use crate::x509::X509PurposeId;
+#[cfg(any(ossl102, libressl261))]
+use crate::x509::X509PurposeRef;
 use crate::x509::{X509Name, X509Req, X509StoreContext, X509VerifyResult, X509};
 use hex::{self, FromHex};
 #[cfg(any(ossl102, libressl261))]

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -16,12 +16,14 @@ use crate::x509::extension::{
 #[cfg(not(boringssl))]
 use crate::x509::store::X509Lookup;
 use crate::x509::store::X509StoreBuilder;
-#[cfg(ossl102)]
-use crate::x509::verify::X509PurposeFlags;
 #[cfg(any(ossl102, libressl261))]
 use crate::x509::verify::{X509VerifyFlags, X509VerifyParam};
 #[cfg(ossl110)]
 use crate::x509::X509Builder;
+#[cfg(any(ossl102, libressl261))]
+use crate::x509::X509Purpose;
+#[cfg(ossl102)]
+use crate::x509::X509PurposeId;
 use crate::x509::{X509Name, X509Req, X509StoreContext, X509VerifyResult, X509};
 use hex::{self, FromHex};
 #[cfg(any(ossl102, libressl261))]
@@ -440,6 +442,67 @@ fn test_verify_fails_with_crl_flag_set_and_no_crl() {
     )
 }
 
+#[test]
+#[cfg(any(ossl102, libressl261))]
+fn test_verify_cert_with_purpose() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let ca = include_bytes!("../../test/root-ca.pem");
+    let ca = X509::from_pem(ca).unwrap();
+    let chain = Stack::new().unwrap();
+
+    let mut store_bldr = X509StoreBuilder::new().unwrap();
+    let purpose_idx = X509Purpose::get_by_sname("sslserver")
+        .expect("Getting certificate purpose 'sslserver' failed");
+    let x509_purpose =
+        X509Purpose::from_idx(purpose_idx).expect("Getting certificate purpose failed");
+    store_bldr
+        .set_purpose(x509_purpose.purpose())
+        .expect("Setting certificate purpose failed");
+    store_bldr.add_cert(ca).unwrap();
+
+    let store = store_bldr.build();
+
+    let mut context = X509StoreContext::new().unwrap();
+    assert!(context
+        .init(&store, &cert, &chain, |c| c.verify_cert())
+        .unwrap());
+}
+
+#[test]
+#[cfg(any(ossl102, libressl261))]
+fn test_verify_cert_with_wrong_purpose_fails() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let ca = include_bytes!("../../test/root-ca.pem");
+    let ca = X509::from_pem(ca).unwrap();
+    let chain = Stack::new().unwrap();
+
+    let mut store_bldr = X509StoreBuilder::new().unwrap();
+    let purpose_idx = X509Purpose::get_by_sname("timestampsign")
+        .expect("Getting certificate purpose 'timestampsign' failed");
+    let x509_purpose =
+        X509Purpose::from_idx(purpose_idx).expect("Getting certificate purpose failed");
+    store_bldr
+        .set_purpose(x509_purpose.purpose())
+        .expect("Setting certificate purpose failed");
+    store_bldr.add_cert(ca).unwrap();
+
+    let store = store_bldr.build();
+
+    let mut context = X509StoreContext::new().unwrap();
+    assert_eq!(
+        context
+            .init(&store, &cert, &chain, |c| {
+                c.verify_cert()?;
+                Ok(c.error())
+            })
+            .unwrap()
+            .error_string(),
+        "unsupported certificate purpose"
+    )
+}
+
 #[cfg(ossl110)]
 #[test]
 fn x509_ref_version() {
@@ -724,7 +787,7 @@ fn test_set_purpose() {
     let mut store_bldr = X509StoreBuilder::new().unwrap();
     store_bldr.add_cert(ca).unwrap();
     let mut verify_params = X509VerifyParam::new().unwrap();
-    verify_params.set_purpose(X509PurposeFlags::ANY).unwrap();
+    verify_params.set_purpose(X509PurposeId::ANY).unwrap();
     store_bldr.set_param(&verify_params).unwrap();
     let store = store_bldr.build();
     let mut context = X509StoreContext::new().unwrap();
@@ -750,7 +813,7 @@ fn test_set_purpose_fails_verification() {
     store_bldr.add_cert(ca).unwrap();
     let mut verify_params = X509VerifyParam::new().unwrap();
     verify_params
-        .set_purpose(X509PurposeFlags::TIMESTAMP_SIGN)
+        .set_purpose(X509PurposeId::TIMESTAMP_SIGN)
         .unwrap();
     store_bldr.set_param(&verify_params).unwrap();
     let store = store_bldr.build();

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -4,6 +4,8 @@ use libc::{c_int, c_uint, c_ulong, time_t};
 use std::net::IpAddr;
 
 use crate::error::ErrorStack;
+#[cfg(ossl102)]
+use crate::x509::X509PurposeId;
 use crate::{cvt, cvt_p};
 use openssl_macros::corresponds;
 
@@ -180,30 +182,7 @@ impl X509VerifyParamRef {
     /// Sets the verification purpose
     #[corresponds(X509_VERIFY_PARAM_set_purpose)]
     #[cfg(ossl102)]
-    pub fn set_purpose(&mut self, purpose: X509PurposeFlags) -> Result<(), ErrorStack> {
-        unsafe {
-            cvt(ffi::X509_VERIFY_PARAM_set_purpose(
-                self.as_ptr(),
-                purpose.bits,
-            ))
-            .map(|_| ())
-        }
+    pub fn set_purpose(&mut self, purpose: X509PurposeId) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::X509_VERIFY_PARAM_set_purpose(self.as_ptr(), purpose.0)).map(|_| ()) }
     }
-}
-
-#[cfg(ossl102)]
-bitflags! {
-    /// Bitflags defining the purpose of the verification
-    pub struct X509PurposeFlags: c_int {
-        const SSL_CLIENT = ffi::X509_PURPOSE_SSL_CLIENT;
-        const SSL_SERVER = ffi::X509_PURPOSE_SSL_SERVER;
-        const NS_SSL_SERVER = ffi::X509_PURPOSE_NS_SSL_SERVER;
-        const SMIME_SIGN = ffi::X509_PURPOSE_SMIME_SIGN;
-        const SMIME_ENCRYPT = ffi::X509_PURPOSE_SMIME_ENCRYPT;
-        const CRL_SIGN = ffi::X509_PURPOSE_CRL_SIGN;
-        const ANY = ffi::X509_PURPOSE_ANY;
-        const OCSP_HELPER = ffi::X509_PURPOSE_OCSP_HELPER;
-        const TIMESTAMP_SIGN = ffi::X509_PURPOSE_TIMESTAMP_SIGN;
-    }
-
 }


### PR DESCRIPTION
- `X509_PURPOSE` id's  were implemented as bitfields, but they are just constants.
- Renamed `X509PurposeFlags` to `X509PurposeId`, as this seems to be the naming used in OpenSSL.
- Moved the definitions from x509/verify.rs to x509/mod.rs, as `X509_PURPOSE` is not specific to verification (`X509_STORE` also uses this).
- This PR is also part 1/4 of the split PR #1598, which grew too big over time.