### PR TITLE
Preparing openssl-sys fpr PKCS7 and X509 extensions

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -31,6 +31,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x2_09_01_00_0 {
             cfgs.push("libressl291");
         }
+        if libressl_version >= 0x3_01_00_00_0 {
+            cfgs.push("libressl310");
+        }
         if libressl_version >= 0x3_02_01_00_0 {
             cfgs.push("libressl321");
         }

--- a/openssl-sys/src/handwritten/asn1.rs
+++ b/openssl-sys/src/handwritten/asn1.rs
@@ -10,9 +10,46 @@ pub struct ASN1_ENCODING {
 
 extern "C" {
     pub fn ASN1_OBJECT_free(x: *mut ASN1_OBJECT);
+    pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> c_int;
 }
 
+pub enum ASN1_OBJECT {}
+
 stack!(stack_st_ASN1_OBJECT);
+
+#[repr(C)]
+pub struct ASN1_TYPE {
+    pub type_: c_int,
+    pub value: ASN1_TYPE_value,
+}
+#[repr(C)]
+pub union ASN1_TYPE_value {
+    pub ptr: *mut c_char,
+    pub boolean: ASN1_BOOLEAN,
+    pub asn1_string: *mut ASN1_STRING,
+    pub object: *mut ASN1_OBJECT,
+    pub integer: *mut ASN1_INTEGER,
+    pub enumerated: *mut ASN1_ENUMERATED,
+    pub bit_string: *mut ASN1_BIT_STRING,
+    pub octet_string: *mut ASN1_OCTET_STRING,
+    pub printablestring: *mut ASN1_PRINTABLESTRING,
+    pub t61string: *mut ASN1_T61STRING,
+    pub ia5string: *mut ASN1_IA5STRING,
+    pub generalstring: *mut ASN1_GENERALSTRING,
+    pub bmpstring: *mut ASN1_BMPSTRING,
+    pub universalstring: *mut ASN1_UNIVERSALSTRING,
+    pub utctime: *mut ASN1_UTCTIME,
+    pub generalizedtime: *mut ASN1_GENERALIZEDTIME,
+    pub visiblestring: *mut ASN1_VISIBLESTRING,
+    pub utf8string: *mut ASN1_UTF8STRING,
+    /*
+     * set and sequence are left complete and still contain the set or
+     * sequence bytes
+     */
+    pub set: *mut ASN1_STRING,
+    pub sequence: *mut ASN1_STRING,
+    pub asn1_value: *mut ASN1_VALUE,
+}
 
 extern "C" {
     pub fn ASN1_STRING_type_new(ty: c_int) -> *mut ASN1_STRING;
@@ -20,13 +57,13 @@ extern "C" {
     pub fn ASN1_STRING_get0_data(x: *const ASN1_STRING) -> *const c_uchar;
     #[cfg(any(all(ossl101, not(ossl110)), libressl))]
     pub fn ASN1_STRING_data(x: *mut ASN1_STRING) -> *mut c_uchar;
-
-    pub fn ASN1_BIT_STRING_free(x: *mut ASN1_BIT_STRING);
-
+    pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
     pub fn ASN1_STRING_free(x: *mut ASN1_STRING);
     pub fn ASN1_STRING_length(x: *const ASN1_STRING) -> c_int;
+    pub fn ASN1_STRING_set(x: *mut ASN1_STRING, data: *const c_void, len_in: c_int) -> c_int;
 
-    pub fn ASN1_STRING_set(x: *mut ASN1_STRING, data: *const c_void, len: c_int) -> c_int;
+    pub fn ASN1_BIT_STRING_free(x: *mut ASN1_BIT_STRING);
+    pub fn ASN1_OCTET_STRING_free(x: *mut ASN1_OCTET_STRING);
 
     pub fn ASN1_GENERALIZEDTIME_free(tm: *mut ASN1_GENERALIZEDTIME);
     pub fn ASN1_GENERALIZEDTIME_print(b: *mut BIO, tm: *const ASN1_GENERALIZEDTIME) -> c_int;
@@ -51,10 +88,14 @@ extern "C" {
     pub fn ASN1_TIME_set_string(s: *mut ASN1_TIME, str: *const c_char) -> c_int;
     #[cfg(ossl111)]
     pub fn ASN1_TIME_set_string_X509(s: *mut ASN1_TIME, str: *const c_char) -> c_int;
+
+    pub fn ASN1_TYPE_free(x: *mut ASN1_TYPE);
 }
 
 const_ptr_api! {
     extern "C" {
         pub fn ASN1_STRING_to_UTF8(out: *mut *mut c_uchar, s: #[const_ptr_if(any(ossl110, libressl280))] ASN1_STRING) -> c_int;
+        pub fn ASN1_STRING_type(x: #[const_ptr_if(any(ossl110, libressl280))]  ASN1_STRING) -> c_int;
+        pub fn ASN1_generate_v3(str: #[const_ptr_if(any(ossl110, libressl280))] c_char, cnf: *mut X509V3_CTX) -> *mut ASN1_TYPE;
     }
 }

--- a/openssl-sys/src/handwritten/mod.rs
+++ b/openssl-sys/src/handwritten/mod.rs
@@ -28,6 +28,7 @@ pub use self::stack::*;
 pub use self::tls1::*;
 pub use self::types::*;
 pub use self::x509::*;
+pub use self::x509_attr::*;
 pub use self::x509_vfy::*;
 pub use self::x509v3::*;
 
@@ -61,5 +62,6 @@ mod stack;
 mod tls1;
 mod types;
 mod x509;
+mod x509_attr;
 mod x509_vfy;
 mod x509v3;

--- a/openssl-sys/src/handwritten/pkcs7.rs
+++ b/openssl-sys/src/handwritten/pkcs7.rs
@@ -1,12 +1,195 @@
 use libc::*;
 use *;
 
-pub enum PKCS7_SIGNED {}
-pub enum PKCS7_ENVELOPE {}
-pub enum PKCS7_SIGN_ENVELOPE {}
-pub enum PKCS7_DIGEST {}
-pub enum PKCS7_ENCRYPT {}
-pub enum PKCS7 {}
+// use x509::stack_st_X509;
+// use x509_attr::stack_st_X509_ATTRIBUTE;
+
+#[cfg(ossl300)]
+#[repr(C)]
+pub struct PKCS7_CTX {
+    libctx: *mut OSSL_LIB_CTX,
+    propq: *mut c_char,
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_SIGNED {
+            pub version: *mut ASN1_INTEGER, /* version 1 */
+            pub md_algs: *mut stack_st_X509_ALGOR, /* md used */
+            pub cert: *mut stack_st_X509, /* [ 0 ] */
+            pub crl: *mut stack_st_X509_CRL, /* [ 1 ] */
+            pub signer_info: *mut stack_st_PKCS7_SIGNER_INFO,
+            pub contents: *mut PKCS7,
+        }
+    } else {
+        pub enum PKCS7_SIGNED {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_ENC_CONTENT {
+            pub content_type: *mut ASN1_OBJECT,
+            pub algorithm: *mut X509_ALGOR,
+            pub enc_data: *mut ASN1_OCTET_STRING, /* [ 0 ] */
+            pub cipher: *const EVP_CIPHER,
+            #[cfg(ossl300)]
+            pub ctx: *const PKCS7_CTX,
+       }
+    } else {
+        pub enum PKCS7_ENC_CONTENT {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_ENVELOPE {
+            pub version: *mut ASN1_INTEGER, /* version 0 */
+            pub recipientinfo: *mut stack_st_PKCS7_RECIP_INFO,
+            pub enc_data: *mut PKCS7_ENC_CONTENT,
+        }
+    }  else {
+        pub enum PKCS7_ENVELOPE {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_SIGN_ENVELOPE {
+            pub version: *mut ASN1_INTEGER, /* version 1 */
+            pub md_algs: *mut stack_st_X509_ALGOR, /* md used */
+            pub cert: *mut stack_st_X509, /* [ 0 ] */
+            pub crl: *mut stack_st_X509_CRL, /* [ 1 ] */
+            pub signer_info: *mut stack_st_PKCS7_SIGNER_INFO,
+            pub enc_data: *mut PKCS7_ENC_CONTENT,
+            pub recipientinfo: *mut stack_st_PKCS7_RECIP_INFO
+        }
+    } else {
+        pub enum PKCS7_SIGN_ENVELOPE {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_DIGEST {
+            pub version: *mut ASN1_INTEGER, /* version 0 */
+            pub md: *mut X509_ALGOR, /* md used */
+            pub contents: *mut PKCS7,
+            pub digest: *mut ASN1_OCTET_STRING,
+        }
+    } else {
+        pub enum PKCS7_DIGEST {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_ENCRYPT {
+            pub version: *mut ASN1_INTEGER, /* version 0 */
+            pub enc_data: *mut PKCS7_ENC_CONTENT,
+        }
+    } else {
+        pub enum PKCS7_ENCRYPT {}
+    }
+}
+
+extern "C" {
+    pub fn PKCS7_SIGNED_free(info: *mut PKCS7_SIGNED);
+    pub fn PKCS7_ENC_CONTENT_free(info: *mut PKCS7_ENC_CONTENT);
+    pub fn PKCS7_ENVELOPE_free(info: *mut PKCS7_ENVELOPE);
+    pub fn PKCS7_SIGN_ENVELOPE_free(info: *mut PKCS7_SIGN_ENVELOPE);
+    pub fn PKCS7_DIGEST_free(info: *mut PKCS7_DIGEST);
+    pub fn PKCS7_SIGNER_INFO_free(info: *mut PKCS7_SIGNER_INFO);
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7 {
+            /*
+             * The following is non NULL if it contains ASN1 encoding of this
+             * structure
+             */
+            pub asn1: *mut c_uchar,
+            pub length: c_long,
+            // # define PKCS7_S_HEADER  0
+            // # define PKCS7_S_BODY    1
+            // # define PKCS7_S_TAIL    2
+            pub state: c_int, /* used during processing */
+            pub detached: c_int,
+            pub type_: *mut ASN1_OBJECT,
+            /* content as defined by the type */
+            /*
+             * all encryption/message digests are applied to the 'contents', leaving
+             * out the 'type' field.
+             */
+            pub d: PKCS7_data,
+            #[cfg(ossl300)]
+            pub ctx: PKCS7_CTX,
+        }
+        #[repr(C)]
+        pub union PKCS7_data {
+            pub ptr: *mut c_char,
+            /* NID_pkcs7_data */
+            pub data: *mut ASN1_OCTET_STRING,
+            /* NID_pkcs7_signed */
+            pub sign: *mut PKCS7_SIGNED,
+            /* NID_pkcs7_enveloped */
+            pub enveloped: *mut PKCS7_ENVELOPE,
+            /* NID_pkcs7_signedAndEnveloped */
+            pub signed_and_enveloped: *mut PKCS7_SIGN_ENVELOPE,
+            /* NID_pkcs7_digest */
+            pub digest: *mut PKCS7_DIGEST,
+            /* NID_pkcs7_encrypted */
+            pub encrypted: *mut PKCS7_ENCRYPT,
+            /* Anything else */
+            pub other: *mut ASN1_TYPE,
+        }
+    } else {
+         pub enum PKCS7 {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl))] {
+        #[repr(C)]
+        pub struct PKCS7_ISSUER_AND_SERIAL {
+            pub issuer: *mut X509_NAME,
+            pub serial: *mut ASN1_INTEGER,
+        }
+    } else {
+        pub enum PKCS7_ISSUER_AND_SERIAL {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl))] {
+        #[repr(C)]
+        pub struct PKCS7_SIGNER_INFO {
+            pub version: *mut ASN1_INTEGER, /* version 1 */
+            pub issuer_and_serial: *mut PKCS7_ISSUER_AND_SERIAL,
+            pub digest_alg: *mut X509_ALGOR,
+            pub auth_attr: *mut stack_st_X509_ATTRIBUTE, /* [ 0 ] */
+            pub digest_enc_alg: *mut X509_ALGOR,
+            pub enc_digest: *mut ASN1_OCTET_STRING,
+            pub unauth_attr: *mut stack_st_X509_ATTRIBUTE, /* [ 1 ] */
+            pub pkey: *mut EVP_PKEY, /* The private key to sign with */
+            #[cfg(ossl300)]
+            pub ctx: *const PKCS7_CTX,
+        }
+    } else {
+        pub enum PKCS7_SIGNER_INFO {}
+    }
+}
+
+stack!(stack_st_PKCS7_SIGNER_INFO);
+stack!(stack_st_PKCS7_RECIP_INFO);
 
 extern "C" {
     pub fn d2i_PKCS7(a: *mut *mut PKCS7, pp: *mut *const c_uchar, length: c_long) -> *mut PKCS7;
@@ -15,6 +198,7 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn i2d_PKCS7(a: #[const_ptr_if(ossl300)] PKCS7, buf: *mut *mut u8) -> c_int;
+        pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: #[const_ptr_if(ossl300)]  PKCS7) -> c_int;
     }
 }
 
@@ -67,4 +251,53 @@ extern "C" {
     ) -> c_int;
 
     pub fn SMIME_read_PKCS7(bio: *mut BIO, bcont: *mut *mut BIO) -> *mut PKCS7;
+
+    pub fn PKCS7_new() -> *mut PKCS7;
+
+    pub fn PKCS7_set_type(p7: *mut PKCS7, nid_pkcs7: c_int) -> c_int;
+
+    pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> c_int;
+
+    pub fn PKCS7_add_signature(
+        p7: *mut PKCS7,
+        x509: *mut X509,
+        pkey: *mut EVP_PKEY,
+        digest: *const EVP_MD,
+    ) -> *mut PKCS7_SIGNER_INFO;
+
+    pub fn PKCS7_set_signed_attributes(
+        p7si: *mut PKCS7_SIGNER_INFO,
+        attributes: *mut stack_st_X509_ATTRIBUTE,
+    ) -> c_int;
+
+    pub fn PKCS7_add_signed_attribute(
+        p7si: *mut PKCS7_SIGNER_INFO,
+        nid: c_int,
+        attrtype: c_int,
+        data: *mut c_void,
+    ) -> c_int;
+
+    pub fn PKCS7_content_new(p7: *mut PKCS7, nid_pkcs7: c_int) -> c_int;
+
+    pub fn PKCS7_dataInit(p7: *mut PKCS7, bio: *mut BIO) -> *mut BIO;
+
+    pub fn PKCS7_dataFinal(p7: *mut PKCS7, bio: *mut BIO) -> c_int;
+
+    pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
+
+    pub fn PKCS7_SIGNER_INFO_get0_algs(
+        si: *mut PKCS7_SIGNER_INFO,
+        pk: *mut *mut EVP_PKEY,
+        pdig: *mut *mut X509_ALGOR,
+        psig: *mut *mut X509_ALGOR,
+    );
+}
+
+const_ptr_api! {
+    extern "C" {
+        pub fn PKCS7_get_signed_attribute(
+            si: #[const_ptr_if(ossl300)] PKCS7_SIGNER_INFO,
+            nid: c_int
+        ) -> *mut ASN1_TYPE;
+    }
 }

--- a/openssl-sys/src/handwritten/types.rs
+++ b/openssl-sys/src/handwritten/types.rs
@@ -3,14 +3,26 @@ use libc::*;
 #[allow(unused_imports)]
 use *;
 
+#[derive(Copy, Clone)]
+pub enum ASN1_BOOLEAN {}
+pub enum ASN1_ENUMERATED {}
 pub enum ASN1_INTEGER {}
 pub enum ASN1_GENERALIZEDTIME {}
 pub enum ASN1_STRING {}
 pub enum ASN1_BIT_STRING {}
 pub enum ASN1_TIME {}
-pub enum ASN1_TYPE {}
 pub enum ASN1_OBJECT {}
 pub enum ASN1_OCTET_STRING {}
+pub enum ASN1_PRINTABLESTRING {}
+pub enum ASN1_T61STRING {}
+pub enum ASN1_IA5STRING {}
+pub enum ASN1_GENERALSTRING {}
+pub enum ASN1_BMPSTRING {}
+pub enum ASN1_UNIVERSALSTRING {}
+pub enum ASN1_UTCTIME {}
+pub enum ASN1_VISIBLESTRING {}
+pub enum ASN1_UTF8STRING {}
+pub enum ASN1_VALUE {}
 
 pub enum bio_st {} // FIXME remove
 cfg_if! {
@@ -324,6 +336,8 @@ cfg_if! {
         }
     }
 }
+
+stack!(stack_st_X509_ALGOR);
 
 pub enum X509_LOOKUP_METHOD {}
 

--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -645,3 +645,22 @@ extern "C" {
     pub fn X509_print(bio: *mut BIO, x509: *mut X509) -> c_int;
     pub fn X509_REQ_print(bio: *mut BIO, req: *mut X509_REQ) -> c_int;
 }
+
+#[repr(C)]
+pub struct X509_PURPOSE {
+    pub purpose: c_int,
+    pub trust: c_int, // Default trust ID
+    pub flags: c_int,
+    pub check_purpose:
+        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
+    pub name: *mut c_char,
+    pub sname: *mut c_char,
+    pub usr_data: *mut c_void,
+}
+
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
+        pub fn X509_PURPOSE_get0(idx: c_int) -> *mut X509_PURPOSE;
+    }
+}

--- a/openssl-sys/src/handwritten/x509_attr.rs
+++ b/openssl-sys/src/handwritten/x509_attr.rs
@@ -1,0 +1,60 @@
+use libc::*;
+
+use *;
+
+pub enum X509_ATTRIBUTE {}
+
+stack!(stack_st_X509_ATTRIBUTE);
+
+extern "C" {
+    pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_create(
+        nid: c_int,
+        atrtype: c_int,
+        value: *mut c_void,
+    ) -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_create_by_NID(
+        attr: *mut *mut X509_ATTRIBUTE,
+        nid: c_int,
+        atrtype: c_int,
+        data: *const c_void,
+        len: c_int,
+    ) -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_create_by_OBJ(
+        attr: *mut *mut X509_ATTRIBUTE,
+        obj: *const ASN1_OBJECT,
+        atrtype: c_int,
+        data: *const c_void,
+        len: c_int,
+    ) -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_create_by_txt(
+        attr: *mut *mut X509_ATTRIBUTE,
+        atrname: *const c_char,
+        atrtype: c_int,
+        bytes: *const c_uchar,
+        len: c_int,
+    ) -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_set1_object(attr: *mut X509_ATTRIBUTE, obj: *const ASN1_OBJECT) -> c_int;
+    pub fn X509_ATTRIBUTE_set1_data(
+        attr: *mut X509_ATTRIBUTE,
+        attrtype: c_int,
+        data: *const c_void,
+        len: c_int,
+    ) -> c_int;
+    pub fn X509_ATTRIBUTE_get0_data(
+        attr: *mut X509_ATTRIBUTE,
+        idx: c_int,
+        atrtype: c_int,
+        data: *mut c_void,
+    ) -> *mut c_void;
+    pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
+    pub fn X509_ATTRIBUTE_get0_type(attr: *mut X509_ATTRIBUTE, idx: c_int) -> *mut ASN1_TYPE;
+
+}
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_ATTRIBUTE_count(
+            attr: #[const_ptr_if(any(ossl110, libressl291))] X509_ATTRIBUTE // const since OpenSSL v1.1.0
+        ) -> c_int;
+    }
+}

--- a/openssl-sys/src/handwritten/x509_vfy.rs
+++ b/openssl-sys/src/handwritten/x509_vfy.rs
@@ -4,6 +4,18 @@ use *;
 #[cfg(any(libressl, all(ossl102, not(ossl110))))]
 pub enum X509_VERIFY_PARAM_ID {}
 
+#[repr(C)]
+pub struct X509_PURPOSE {
+    pub purpose: c_int,
+    pub trust: c_int, // Default trust ID
+    pub flags: c_int,
+    pub check_purpose:
+        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
+    pub name: *mut c_char,
+    pub sname: *mut c_char,
+    pub usr_data: *mut c_void,
+}
+
 extern "C" {
     #[cfg(ossl110)]
     pub fn X509_LOOKUP_meth_free(method: *mut X509_LOOKUP_METHOD);
@@ -48,6 +60,9 @@ extern "C" {
 
     pub fn X509_STORE_set_default_paths(store: *mut X509_STORE) -> c_int;
     pub fn X509_STORE_set_flags(store: *mut X509_STORE, flags: c_ulong) -> c_int;
+    pub fn X509_STORE_set_purpose(ctx: *mut X509_STORE, purpose: c_int) -> c_int;
+    pub fn X509_STORE_set_trust(ctx: *mut X509_STORE, trust: c_int) -> c_int;
+
 }
 
 const_ptr_api! {
@@ -126,4 +141,11 @@ extern "C" {
     pub fn X509_VERIFY_PARAM_get_auth_level(param: *const X509_VERIFY_PARAM) -> c_int;
     #[cfg(ossl102)]
     pub fn X509_VERIFY_PARAM_set_purpose(param: *mut X509_VERIFY_PARAM, purpose: c_int) -> c_int;
+}
+
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
+        pub fn X509_PURPOSE_get0(idx: c_int) -> *mut X509_PURPOSE;
+    }
 }

--- a/openssl-sys/src/handwritten/x509_vfy.rs
+++ b/openssl-sys/src/handwritten/x509_vfy.rs
@@ -4,18 +4,6 @@ use *;
 #[cfg(any(libressl, all(ossl102, not(ossl110))))]
 pub enum X509_VERIFY_PARAM_ID {}
 
-#[repr(C)]
-pub struct X509_PURPOSE {
-    pub purpose: c_int,
-    pub trust: c_int, // Default trust ID
-    pub flags: c_int,
-    pub check_purpose:
-        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
-    pub name: *mut c_char,
-    pub sname: *mut c_char,
-    pub usr_data: *mut c_void,
-}
-
 extern "C" {
     #[cfg(ossl110)]
     pub fn X509_LOOKUP_meth_free(method: *mut X509_LOOKUP_METHOD);
@@ -141,11 +129,4 @@ extern "C" {
     pub fn X509_VERIFY_PARAM_get_auth_level(param: *const X509_VERIFY_PARAM) -> c_int;
     #[cfg(ossl102)]
     pub fn X509_VERIFY_PARAM_set_purpose(param: *mut X509_VERIFY_PARAM, purpose: c_int) -> c_int;
-}
-
-const_ptr_api! {
-    extern "C" {
-        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
-        pub fn X509_PURPOSE_get0(idx: c_int) -> *mut X509_PURPOSE;
-    }
 }

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -147,26 +147,3 @@ pub unsafe fn X509_LOOKUP_add_dir(
         std::ptr::null_mut(),
     )
 }
-
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SSL_CLIENT: c_int = 1;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SSL_SERVER: c_int = 2;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_NS_SSL_SERVER: c_int = 3;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SMIME_SIGN: c_int = 4;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SMIME_ENCRYPT: c_int = 5;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_CRL_SIGN: c_int = 6;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_ANY: c_int = 7;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_OCSP_HELPER: c_int = 8;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_TIMESTAMP_SIGN: c_int = 9;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_MIN: c_int = 1;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_MAX: c_int = 9;

--- a/openssl-sys/src/x509v3.rs
+++ b/openssl-sys/src/x509v3.rs
@@ -58,15 +58,25 @@ pub const EXFLAG_FRESHEST: u32 = 0x1000;
 #[cfg(any(ossl102, libressl261))]
 pub const EXFLAG_SS: u32 = 0x2000;
 
+#[cfg(not(boringssl))]
 pub const X509v3_KU_DIGITAL_SIGNATURE: u32 = 0x0080;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_NON_REPUDIATION: u32 = 0x0040;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_ENCIPHERMENT: u32 = 0x0020;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_DATA_ENCIPHERMENT: u32 = 0x0010;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_AGREEMENT: u32 = 0x0008;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_CERT_SIGN: u32 = 0x0004;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_CRL_SIGN: u32 = 0x0002;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_ENCIPHER_ONLY: u32 = 0x0001;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_DECIPHER_ONLY: u32 = 0x8000;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_UNDEF: u32 = 0xffff;
 
 pub const XKU_SSL_SERVER: u32 = 0x1;
@@ -79,3 +89,15 @@ pub const XKU_TIMESTAMP: u32 = 0x40;
 pub const XKU_DVCS: u32 = 0x80;
 #[cfg(ossl110)]
 pub const XKU_ANYEKU: u32 = 0x100;
+
+pub const X509_PURPOSE_SSL_CLIENT: c_int = 1;
+pub const X509_PURPOSE_SSL_SERVER: c_int = 2;
+pub const X509_PURPOSE_NS_SSL_SERVER: c_int = 3;
+pub const X509_PURPOSE_SMIME_SIGN: c_int = 4;
+pub const X509_PURPOSE_SMIME_ENCRYPT: c_int = 5;
+pub const X509_PURPOSE_CRL_SIGN: c_int = 6;
+pub const X509_PURPOSE_ANY: c_int = 7;
+pub const X509_PURPOSE_OCSP_HELPER: c_int = 8;
+pub const X509_PURPOSE_TIMESTAMP_SIGN: c_int = 9;
+pub const X509_PURPOSE_MIN: c_int = 1;
+pub const X509_PURPOSE_MAX: c_int = 9;

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -51,8 +51,9 @@ use crate::ssl::SslFiletype;
 use crate::stack::StackRef;
 #[cfg(any(ossl102, libressl261))]
 use crate::x509::verify::{X509VerifyFlags, X509VerifyParamRef};
-use crate::x509::{X509Object, X509};
+use crate::x509::{X509Object, X509PurposeId, X509};
 use crate::{cvt, cvt_p};
+use libc::c_int;
 use openssl_macros::corresponds;
 #[cfg(not(boringssl))]
 use std::ffi::CString;
@@ -123,6 +124,19 @@ impl X509StoreBuilderRef {
     #[cfg(any(ossl102, libressl261))]
     pub fn set_flags(&mut self, flags: X509VerifyFlags) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::X509_STORE_set_flags(self.as_ptr(), flags.bits())).map(|_| ()) }
+    }
+
+    /// Sets the certificate purpose.
+    /// The purpose value can be obtained by `X509Purpose::get_by_sname()`
+    #[corresponds(X509_STORE_set_purpose)]
+    pub fn set_purpose(&mut self, purpose: X509PurposeId) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::X509_STORE_set_purpose(
+                self.as_ptr(),
+                purpose.value() as c_int,
+            ))
+            .map(|_| ())
+        }
     }
 
     /// Sets certificate chain validation related parameters.

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -16,12 +16,14 @@ use crate::x509::extension::{
 #[cfg(not(boringssl))]
 use crate::x509::store::X509Lookup;
 use crate::x509::store::X509StoreBuilder;
-#[cfg(ossl102)]
-use crate::x509::verify::X509PurposeFlags;
 #[cfg(any(ossl102, libressl261))]
 use crate::x509::verify::{X509VerifyFlags, X509VerifyParam};
 #[cfg(ossl110)]
 use crate::x509::X509Builder;
+#[cfg(any(ossl102, libressl261))]
+use crate::x509::X509Purpose;
+#[cfg(ossl102)]
+use crate::x509::X509PurposeId;
 use crate::x509::{X509Name, X509Req, X509StoreContext, X509VerifyResult, X509};
 use hex::{self, FromHex};
 #[cfg(any(ossl102, libressl261))]
@@ -440,6 +442,67 @@ fn test_verify_fails_with_crl_flag_set_and_no_crl() {
     )
 }
 
+#[test]
+#[cfg(any(ossl102, libressl261))]
+fn test_verify_cert_with_purpose() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let ca = include_bytes!("../../test/root-ca.pem");
+    let ca = X509::from_pem(ca).unwrap();
+    let chain = Stack::new().unwrap();
+
+    let mut store_bldr = X509StoreBuilder::new().unwrap();
+    let purpose_idx = X509Purpose::get_by_sname("sslserver")
+        .expect("Getting certificate purpose 'sslserver' failed");
+    let x509_purpose =
+        X509Purpose::from_idx(purpose_idx).expect("Getting certificate purpose failed");
+    store_bldr
+        .set_purpose(x509_purpose.purpose())
+        .expect("Setting certificate purpose failed");
+    store_bldr.add_cert(ca).unwrap();
+
+    let store = store_bldr.build();
+
+    let mut context = X509StoreContext::new().unwrap();
+    assert!(context
+        .init(&store, &cert, &chain, |c| c.verify_cert())
+        .unwrap());
+}
+
+#[test]
+#[cfg(any(ossl102, libressl261))]
+fn test_verify_cert_with_wrong_purpose_fails() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let ca = include_bytes!("../../test/root-ca.pem");
+    let ca = X509::from_pem(ca).unwrap();
+    let chain = Stack::new().unwrap();
+
+    let mut store_bldr = X509StoreBuilder::new().unwrap();
+    let purpose_idx = X509Purpose::get_by_sname("timestampsign")
+        .expect("Getting certificate purpose 'timestampsign' failed");
+    let x509_purpose =
+        X509Purpose::from_idx(purpose_idx).expect("Getting certificate purpose failed");
+    store_bldr
+        .set_purpose(x509_purpose.purpose())
+        .expect("Setting certificate purpose failed");
+    store_bldr.add_cert(ca).unwrap();
+
+    let store = store_bldr.build();
+
+    let mut context = X509StoreContext::new().unwrap();
+    assert_eq!(
+        context
+            .init(&store, &cert, &chain, |c| {
+                c.verify_cert()?;
+                Ok(c.error())
+            })
+            .unwrap()
+            .error_string(),
+        "unsupported certificate purpose"
+    )
+}
+
 #[cfg(ossl110)]
 #[test]
 fn x509_ref_version() {
@@ -724,7 +787,7 @@ fn test_set_purpose() {
     let mut store_bldr = X509StoreBuilder::new().unwrap();
     store_bldr.add_cert(ca).unwrap();
     let mut verify_params = X509VerifyParam::new().unwrap();
-    verify_params.set_purpose(X509PurposeFlags::ANY).unwrap();
+    verify_params.set_purpose(X509PurposeId::ANY).unwrap();
     store_bldr.set_param(&verify_params).unwrap();
     let store = store_bldr.build();
     let mut context = X509StoreContext::new().unwrap();
@@ -750,7 +813,7 @@ fn test_set_purpose_fails_verification() {
     store_bldr.add_cert(ca).unwrap();
     let mut verify_params = X509VerifyParam::new().unwrap();
     verify_params
-        .set_purpose(X509PurposeFlags::TIMESTAMP_SIGN)
+        .set_purpose(X509PurposeId::TIMESTAMP_SIGN)
         .unwrap();
     store_bldr.set_param(&verify_params).unwrap();
     let store = store_bldr.build();

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -4,6 +4,8 @@ use libc::{c_int, c_uint, c_ulong, time_t};
 use std::net::IpAddr;
 
 use crate::error::ErrorStack;
+#[cfg(ossl102)]
+use crate::x509::X509PurposeId;
 use crate::{cvt, cvt_p};
 use openssl_macros::corresponds;
 
@@ -180,30 +182,7 @@ impl X509VerifyParamRef {
     /// Sets the verification purpose
     #[corresponds(X509_VERIFY_PARAM_set_purpose)]
     #[cfg(ossl102)]
-    pub fn set_purpose(&mut self, purpose: X509PurposeFlags) -> Result<(), ErrorStack> {
-        unsafe {
-            cvt(ffi::X509_VERIFY_PARAM_set_purpose(
-                self.as_ptr(),
-                purpose.bits,
-            ))
-            .map(|_| ())
-        }
+    pub fn set_purpose(&mut self, purpose: X509PurposeId) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::X509_VERIFY_PARAM_set_purpose(self.as_ptr(), purpose.0)).map(|_| ()) }
     }
-}
-
-#[cfg(ossl102)]
-bitflags! {
-    /// Bitflags defining the purpose of the verification
-    pub struct X509PurposeFlags: c_int {
-        const SSL_CLIENT = ffi::X509_PURPOSE_SSL_CLIENT;
-        const SSL_SERVER = ffi::X509_PURPOSE_SSL_SERVER;
-        const NS_SSL_SERVER = ffi::X509_PURPOSE_NS_SSL_SERVER;
-        const SMIME_SIGN = ffi::X509_PURPOSE_SMIME_SIGN;
-        const SMIME_ENCRYPT = ffi::X509_PURPOSE_SMIME_ENCRYPT;
-        const CRL_SIGN = ffi::X509_PURPOSE_CRL_SIGN;
-        const ANY = ffi::X509_PURPOSE_ANY;
-        const OCSP_HELPER = ffi::X509_PURPOSE_OCSP_HELPER;
-        const TIMESTAMP_SIGN = ffi::X509_PURPOSE_TIMESTAMP_SIGN;
-    }
-
 }


### PR DESCRIPTION
- Part 2/4 of the split #1598.
- This branch implements several additional bindings into OpenSSL, primarily for X509 and PKCS7.
- Please note, that this PR redefines `openssl_sys::openssl::handwritten::asn1::ASN1_TYPE`, which was an `enum`, but should actually be a `struct`. This breaks compatibility. If this is not desired, we need to find another solution, but that would by dirty in my opinion (trying to appeal to the maintainer's honour).