### PR TITLE
X509 and X509Req extensions

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -31,6 +31,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x2_09_01_00_0 {
             cfgs.push("libressl291");
         }
+        if libressl_version >= 0x3_01_00_00_0 {
+            cfgs.push("libressl310");
+        }
         if libressl_version >= 0x3_02_01_00_0 {
             cfgs.push("libressl321");
         }

--- a/openssl-sys/src/handwritten/asn1.rs
+++ b/openssl-sys/src/handwritten/asn1.rs
@@ -10,9 +10,46 @@ pub struct ASN1_ENCODING {
 
 extern "C" {
     pub fn ASN1_OBJECT_free(x: *mut ASN1_OBJECT);
+    pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> c_int;
 }
 
+pub enum ASN1_OBJECT {}
+
 stack!(stack_st_ASN1_OBJECT);
+
+#[repr(C)]
+pub struct ASN1_TYPE {
+    pub type_: c_int,
+    pub value: ASN1_TYPE_value,
+}
+#[repr(C)]
+pub union ASN1_TYPE_value {
+    pub ptr: *mut c_char,
+    pub boolean: ASN1_BOOLEAN,
+    pub asn1_string: *mut ASN1_STRING,
+    pub object: *mut ASN1_OBJECT,
+    pub integer: *mut ASN1_INTEGER,
+    pub enumerated: *mut ASN1_ENUMERATED,
+    pub bit_string: *mut ASN1_BIT_STRING,
+    pub octet_string: *mut ASN1_OCTET_STRING,
+    pub printablestring: *mut ASN1_PRINTABLESTRING,
+    pub t61string: *mut ASN1_T61STRING,
+    pub ia5string: *mut ASN1_IA5STRING,
+    pub generalstring: *mut ASN1_GENERALSTRING,
+    pub bmpstring: *mut ASN1_BMPSTRING,
+    pub universalstring: *mut ASN1_UNIVERSALSTRING,
+    pub utctime: *mut ASN1_UTCTIME,
+    pub generalizedtime: *mut ASN1_GENERALIZEDTIME,
+    pub visiblestring: *mut ASN1_VISIBLESTRING,
+    pub utf8string: *mut ASN1_UTF8STRING,
+    /*
+     * set and sequence are left complete and still contain the set or
+     * sequence bytes
+     */
+    pub set: *mut ASN1_STRING,
+    pub sequence: *mut ASN1_STRING,
+    pub asn1_value: *mut ASN1_VALUE,
+}
 
 extern "C" {
     pub fn ASN1_STRING_type_new(ty: c_int) -> *mut ASN1_STRING;
@@ -20,13 +57,13 @@ extern "C" {
     pub fn ASN1_STRING_get0_data(x: *const ASN1_STRING) -> *const c_uchar;
     #[cfg(any(all(ossl101, not(ossl110)), libressl))]
     pub fn ASN1_STRING_data(x: *mut ASN1_STRING) -> *mut c_uchar;
-
-    pub fn ASN1_BIT_STRING_free(x: *mut ASN1_BIT_STRING);
-
+    pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
     pub fn ASN1_STRING_free(x: *mut ASN1_STRING);
     pub fn ASN1_STRING_length(x: *const ASN1_STRING) -> c_int;
+    pub fn ASN1_STRING_set(x: *mut ASN1_STRING, data: *const c_void, len_in: c_int) -> c_int;
 
-    pub fn ASN1_STRING_set(x: *mut ASN1_STRING, data: *const c_void, len: c_int) -> c_int;
+    pub fn ASN1_BIT_STRING_free(x: *mut ASN1_BIT_STRING);
+    pub fn ASN1_OCTET_STRING_free(x: *mut ASN1_OCTET_STRING);
 
     pub fn ASN1_GENERALIZEDTIME_free(tm: *mut ASN1_GENERALIZEDTIME);
     pub fn ASN1_GENERALIZEDTIME_print(b: *mut BIO, tm: *const ASN1_GENERALIZEDTIME) -> c_int;
@@ -51,10 +88,14 @@ extern "C" {
     pub fn ASN1_TIME_set_string(s: *mut ASN1_TIME, str: *const c_char) -> c_int;
     #[cfg(ossl111)]
     pub fn ASN1_TIME_set_string_X509(s: *mut ASN1_TIME, str: *const c_char) -> c_int;
+
+    pub fn ASN1_TYPE_free(x: *mut ASN1_TYPE);
 }
 
 const_ptr_api! {
     extern "C" {
         pub fn ASN1_STRING_to_UTF8(out: *mut *mut c_uchar, s: #[const_ptr_if(any(ossl110, libressl280))] ASN1_STRING) -> c_int;
+        pub fn ASN1_STRING_type(x: #[const_ptr_if(any(ossl110, libressl280))]  ASN1_STRING) -> c_int;
+        pub fn ASN1_generate_v3(str: #[const_ptr_if(any(ossl110, libressl280))] c_char, cnf: *mut X509V3_CTX) -> *mut ASN1_TYPE;
     }
 }

--- a/openssl-sys/src/handwritten/mod.rs
+++ b/openssl-sys/src/handwritten/mod.rs
@@ -28,6 +28,7 @@ pub use self::stack::*;
 pub use self::tls1::*;
 pub use self::types::*;
 pub use self::x509::*;
+pub use self::x509_attr::*;
 pub use self::x509_vfy::*;
 pub use self::x509v3::*;
 
@@ -61,5 +62,6 @@ mod stack;
 mod tls1;
 mod types;
 mod x509;
+mod x509_attr;
 mod x509_vfy;
 mod x509v3;

--- a/openssl-sys/src/handwritten/pkcs7.rs
+++ b/openssl-sys/src/handwritten/pkcs7.rs
@@ -1,12 +1,195 @@
 use libc::*;
 use *;
 
-pub enum PKCS7_SIGNED {}
-pub enum PKCS7_ENVELOPE {}
-pub enum PKCS7_SIGN_ENVELOPE {}
-pub enum PKCS7_DIGEST {}
-pub enum PKCS7_ENCRYPT {}
-pub enum PKCS7 {}
+// use x509::stack_st_X509;
+// use x509_attr::stack_st_X509_ATTRIBUTE;
+
+#[cfg(ossl300)]
+#[repr(C)]
+pub struct PKCS7_CTX {
+    libctx: *mut OSSL_LIB_CTX,
+    propq: *mut c_char,
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_SIGNED {
+            pub version: *mut ASN1_INTEGER, /* version 1 */
+            pub md_algs: *mut stack_st_X509_ALGOR, /* md used */
+            pub cert: *mut stack_st_X509, /* [ 0 ] */
+            pub crl: *mut stack_st_X509_CRL, /* [ 1 ] */
+            pub signer_info: *mut stack_st_PKCS7_SIGNER_INFO,
+            pub contents: *mut PKCS7,
+        }
+    } else {
+        pub enum PKCS7_SIGNED {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_ENC_CONTENT {
+            pub content_type: *mut ASN1_OBJECT,
+            pub algorithm: *mut X509_ALGOR,
+            pub enc_data: *mut ASN1_OCTET_STRING, /* [ 0 ] */
+            pub cipher: *const EVP_CIPHER,
+            #[cfg(ossl300)]
+            pub ctx: *const PKCS7_CTX,
+       }
+    } else {
+        pub enum PKCS7_ENC_CONTENT {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_ENVELOPE {
+            pub version: *mut ASN1_INTEGER, /* version 0 */
+            pub recipientinfo: *mut stack_st_PKCS7_RECIP_INFO,
+            pub enc_data: *mut PKCS7_ENC_CONTENT,
+        }
+    }  else {
+        pub enum PKCS7_ENVELOPE {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_SIGN_ENVELOPE {
+            pub version: *mut ASN1_INTEGER, /* version 1 */
+            pub md_algs: *mut stack_st_X509_ALGOR, /* md used */
+            pub cert: *mut stack_st_X509, /* [ 0 ] */
+            pub crl: *mut stack_st_X509_CRL, /* [ 1 ] */
+            pub signer_info: *mut stack_st_PKCS7_SIGNER_INFO,
+            pub enc_data: *mut PKCS7_ENC_CONTENT,
+            pub recipientinfo: *mut stack_st_PKCS7_RECIP_INFO
+        }
+    } else {
+        pub enum PKCS7_SIGN_ENVELOPE {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_DIGEST {
+            pub version: *mut ASN1_INTEGER, /* version 0 */
+            pub md: *mut X509_ALGOR, /* md used */
+            pub contents: *mut PKCS7,
+            pub digest: *mut ASN1_OCTET_STRING,
+        }
+    } else {
+        pub enum PKCS7_DIGEST {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7_ENCRYPT {
+            pub version: *mut ASN1_INTEGER, /* version 0 */
+            pub enc_data: *mut PKCS7_ENC_CONTENT,
+        }
+    } else {
+        pub enum PKCS7_ENCRYPT {}
+    }
+}
+
+extern "C" {
+    pub fn PKCS7_SIGNED_free(info: *mut PKCS7_SIGNED);
+    pub fn PKCS7_ENC_CONTENT_free(info: *mut PKCS7_ENC_CONTENT);
+    pub fn PKCS7_ENVELOPE_free(info: *mut PKCS7_ENVELOPE);
+    pub fn PKCS7_SIGN_ENVELOPE_free(info: *mut PKCS7_SIGN_ENVELOPE);
+    pub fn PKCS7_DIGEST_free(info: *mut PKCS7_DIGEST);
+    pub fn PKCS7_SIGNER_INFO_free(info: *mut PKCS7_SIGNER_INFO);
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl251))] {
+        #[repr(C)]
+        pub struct PKCS7 {
+            /*
+             * The following is non NULL if it contains ASN1 encoding of this
+             * structure
+             */
+            pub asn1: *mut c_uchar,
+            pub length: c_long,
+            // # define PKCS7_S_HEADER  0
+            // # define PKCS7_S_BODY    1
+            // # define PKCS7_S_TAIL    2
+            pub state: c_int, /* used during processing */
+            pub detached: c_int,
+            pub type_: *mut ASN1_OBJECT,
+            /* content as defined by the type */
+            /*
+             * all encryption/message digests are applied to the 'contents', leaving
+             * out the 'type' field.
+             */
+            pub d: PKCS7_data,
+            #[cfg(ossl300)]
+            pub ctx: PKCS7_CTX,
+        }
+        #[repr(C)]
+        pub union PKCS7_data {
+            pub ptr: *mut c_char,
+            /* NID_pkcs7_data */
+            pub data: *mut ASN1_OCTET_STRING,
+            /* NID_pkcs7_signed */
+            pub sign: *mut PKCS7_SIGNED,
+            /* NID_pkcs7_enveloped */
+            pub enveloped: *mut PKCS7_ENVELOPE,
+            /* NID_pkcs7_signedAndEnveloped */
+            pub signed_and_enveloped: *mut PKCS7_SIGN_ENVELOPE,
+            /* NID_pkcs7_digest */
+            pub digest: *mut PKCS7_DIGEST,
+            /* NID_pkcs7_encrypted */
+            pub encrypted: *mut PKCS7_ENCRYPT,
+            /* Anything else */
+            pub other: *mut ASN1_TYPE,
+        }
+    } else {
+         pub enum PKCS7 {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl))] {
+        #[repr(C)]
+        pub struct PKCS7_ISSUER_AND_SERIAL {
+            pub issuer: *mut X509_NAME,
+            pub serial: *mut ASN1_INTEGER,
+        }
+    } else {
+        pub enum PKCS7_ISSUER_AND_SERIAL {}
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl101, libressl))] {
+        #[repr(C)]
+        pub struct PKCS7_SIGNER_INFO {
+            pub version: *mut ASN1_INTEGER, /* version 1 */
+            pub issuer_and_serial: *mut PKCS7_ISSUER_AND_SERIAL,
+            pub digest_alg: *mut X509_ALGOR,
+            pub auth_attr: *mut stack_st_X509_ATTRIBUTE, /* [ 0 ] */
+            pub digest_enc_alg: *mut X509_ALGOR,
+            pub enc_digest: *mut ASN1_OCTET_STRING,
+            pub unauth_attr: *mut stack_st_X509_ATTRIBUTE, /* [ 1 ] */
+            pub pkey: *mut EVP_PKEY, /* The private key to sign with */
+            #[cfg(ossl300)]
+            pub ctx: *const PKCS7_CTX,
+        }
+    } else {
+        pub enum PKCS7_SIGNER_INFO {}
+    }
+}
+
+stack!(stack_st_PKCS7_SIGNER_INFO);
+stack!(stack_st_PKCS7_RECIP_INFO);
 
 extern "C" {
     pub fn d2i_PKCS7(a: *mut *mut PKCS7, pp: *mut *const c_uchar, length: c_long) -> *mut PKCS7;
@@ -15,6 +198,7 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn i2d_PKCS7(a: #[const_ptr_if(ossl300)] PKCS7, buf: *mut *mut u8) -> c_int;
+        pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: #[const_ptr_if(ossl300)]  PKCS7) -> c_int;
     }
 }
 
@@ -67,4 +251,53 @@ extern "C" {
     ) -> c_int;
 
     pub fn SMIME_read_PKCS7(bio: *mut BIO, bcont: *mut *mut BIO) -> *mut PKCS7;
+
+    pub fn PKCS7_new() -> *mut PKCS7;
+
+    pub fn PKCS7_set_type(p7: *mut PKCS7, nid_pkcs7: c_int) -> c_int;
+
+    pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> c_int;
+
+    pub fn PKCS7_add_signature(
+        p7: *mut PKCS7,
+        x509: *mut X509,
+        pkey: *mut EVP_PKEY,
+        digest: *const EVP_MD,
+    ) -> *mut PKCS7_SIGNER_INFO;
+
+    pub fn PKCS7_set_signed_attributes(
+        p7si: *mut PKCS7_SIGNER_INFO,
+        attributes: *mut stack_st_X509_ATTRIBUTE,
+    ) -> c_int;
+
+    pub fn PKCS7_add_signed_attribute(
+        p7si: *mut PKCS7_SIGNER_INFO,
+        nid: c_int,
+        attrtype: c_int,
+        data: *mut c_void,
+    ) -> c_int;
+
+    pub fn PKCS7_content_new(p7: *mut PKCS7, nid_pkcs7: c_int) -> c_int;
+
+    pub fn PKCS7_dataInit(p7: *mut PKCS7, bio: *mut BIO) -> *mut BIO;
+
+    pub fn PKCS7_dataFinal(p7: *mut PKCS7, bio: *mut BIO) -> c_int;
+
+    pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
+
+    pub fn PKCS7_SIGNER_INFO_get0_algs(
+        si: *mut PKCS7_SIGNER_INFO,
+        pk: *mut *mut EVP_PKEY,
+        pdig: *mut *mut X509_ALGOR,
+        psig: *mut *mut X509_ALGOR,
+    );
+}
+
+const_ptr_api! {
+    extern "C" {
+        pub fn PKCS7_get_signed_attribute(
+            si: #[const_ptr_if(ossl300)] PKCS7_SIGNER_INFO,
+            nid: c_int
+        ) -> *mut ASN1_TYPE;
+    }
 }

--- a/openssl-sys/src/handwritten/types.rs
+++ b/openssl-sys/src/handwritten/types.rs
@@ -3,14 +3,26 @@ use libc::*;
 #[allow(unused_imports)]
 use *;
 
+#[derive(Copy, Clone)]
+pub enum ASN1_BOOLEAN {}
+pub enum ASN1_ENUMERATED {}
 pub enum ASN1_INTEGER {}
 pub enum ASN1_GENERALIZEDTIME {}
 pub enum ASN1_STRING {}
 pub enum ASN1_BIT_STRING {}
 pub enum ASN1_TIME {}
-pub enum ASN1_TYPE {}
 pub enum ASN1_OBJECT {}
 pub enum ASN1_OCTET_STRING {}
+pub enum ASN1_PRINTABLESTRING {}
+pub enum ASN1_T61STRING {}
+pub enum ASN1_IA5STRING {}
+pub enum ASN1_GENERALSTRING {}
+pub enum ASN1_BMPSTRING {}
+pub enum ASN1_UNIVERSALSTRING {}
+pub enum ASN1_UTCTIME {}
+pub enum ASN1_VISIBLESTRING {}
+pub enum ASN1_UTF8STRING {}
+pub enum ASN1_VALUE {}
 
 pub enum bio_st {} // FIXME remove
 cfg_if! {
@@ -324,6 +336,8 @@ cfg_if! {
         }
     }
 }
+
+stack!(stack_st_X509_ALGOR);
 
 pub enum X509_LOOKUP_METHOD {}
 

--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -645,3 +645,22 @@ extern "C" {
     pub fn X509_print(bio: *mut BIO, x509: *mut X509) -> c_int;
     pub fn X509_REQ_print(bio: *mut BIO, req: *mut X509_REQ) -> c_int;
 }
+
+#[repr(C)]
+pub struct X509_PURPOSE {
+    pub purpose: c_int,
+    pub trust: c_int, // Default trust ID
+    pub flags: c_int,
+    pub check_purpose:
+        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
+    pub name: *mut c_char,
+    pub sname: *mut c_char,
+    pub usr_data: *mut c_void,
+}
+
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
+        pub fn X509_PURPOSE_get0(idx: c_int) -> *mut X509_PURPOSE;
+    }
+}

--- a/openssl-sys/src/handwritten/x509_attr.rs
+++ b/openssl-sys/src/handwritten/x509_attr.rs
@@ -1,0 +1,60 @@
+use libc::*;
+
+use *;
+
+pub enum X509_ATTRIBUTE {}
+
+stack!(stack_st_X509_ATTRIBUTE);
+
+extern "C" {
+    pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_create(
+        nid: c_int,
+        atrtype: c_int,
+        value: *mut c_void,
+    ) -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_create_by_NID(
+        attr: *mut *mut X509_ATTRIBUTE,
+        nid: c_int,
+        atrtype: c_int,
+        data: *const c_void,
+        len: c_int,
+    ) -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_create_by_OBJ(
+        attr: *mut *mut X509_ATTRIBUTE,
+        obj: *const ASN1_OBJECT,
+        atrtype: c_int,
+        data: *const c_void,
+        len: c_int,
+    ) -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_create_by_txt(
+        attr: *mut *mut X509_ATTRIBUTE,
+        atrname: *const c_char,
+        atrtype: c_int,
+        bytes: *const c_uchar,
+        len: c_int,
+    ) -> *mut X509_ATTRIBUTE;
+    pub fn X509_ATTRIBUTE_set1_object(attr: *mut X509_ATTRIBUTE, obj: *const ASN1_OBJECT) -> c_int;
+    pub fn X509_ATTRIBUTE_set1_data(
+        attr: *mut X509_ATTRIBUTE,
+        attrtype: c_int,
+        data: *const c_void,
+        len: c_int,
+    ) -> c_int;
+    pub fn X509_ATTRIBUTE_get0_data(
+        attr: *mut X509_ATTRIBUTE,
+        idx: c_int,
+        atrtype: c_int,
+        data: *mut c_void,
+    ) -> *mut c_void;
+    pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
+    pub fn X509_ATTRIBUTE_get0_type(attr: *mut X509_ATTRIBUTE, idx: c_int) -> *mut ASN1_TYPE;
+
+}
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_ATTRIBUTE_count(
+            attr: #[const_ptr_if(any(ossl110, libressl291))] X509_ATTRIBUTE // const since OpenSSL v1.1.0
+        ) -> c_int;
+    }
+}

--- a/openssl-sys/src/handwritten/x509_vfy.rs
+++ b/openssl-sys/src/handwritten/x509_vfy.rs
@@ -4,6 +4,18 @@ use *;
 #[cfg(any(libressl, all(ossl102, not(ossl110))))]
 pub enum X509_VERIFY_PARAM_ID {}
 
+#[repr(C)]
+pub struct X509_PURPOSE {
+    pub purpose: c_int,
+    pub trust: c_int, // Default trust ID
+    pub flags: c_int,
+    pub check_purpose:
+        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
+    pub name: *mut c_char,
+    pub sname: *mut c_char,
+    pub usr_data: *mut c_void,
+}
+
 extern "C" {
     #[cfg(ossl110)]
     pub fn X509_LOOKUP_meth_free(method: *mut X509_LOOKUP_METHOD);
@@ -48,6 +60,9 @@ extern "C" {
 
     pub fn X509_STORE_set_default_paths(store: *mut X509_STORE) -> c_int;
     pub fn X509_STORE_set_flags(store: *mut X509_STORE, flags: c_ulong) -> c_int;
+    pub fn X509_STORE_set_purpose(ctx: *mut X509_STORE, purpose: c_int) -> c_int;
+    pub fn X509_STORE_set_trust(ctx: *mut X509_STORE, trust: c_int) -> c_int;
+
 }
 
 const_ptr_api! {
@@ -126,4 +141,11 @@ extern "C" {
     pub fn X509_VERIFY_PARAM_get_auth_level(param: *const X509_VERIFY_PARAM) -> c_int;
     #[cfg(ossl102)]
     pub fn X509_VERIFY_PARAM_set_purpose(param: *mut X509_VERIFY_PARAM, purpose: c_int) -> c_int;
+}
+
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
+        pub fn X509_PURPOSE_get0(idx: c_int) -> *mut X509_PURPOSE;
+    }
 }

--- a/openssl-sys/src/handwritten/x509_vfy.rs
+++ b/openssl-sys/src/handwritten/x509_vfy.rs
@@ -4,18 +4,6 @@ use *;
 #[cfg(any(libressl, all(ossl102, not(ossl110))))]
 pub enum X509_VERIFY_PARAM_ID {}
 
-#[repr(C)]
-pub struct X509_PURPOSE {
-    pub purpose: c_int,
-    pub trust: c_int, // Default trust ID
-    pub flags: c_int,
-    pub check_purpose:
-        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
-    pub name: *mut c_char,
-    pub sname: *mut c_char,
-    pub usr_data: *mut c_void,
-}
-
 extern "C" {
     #[cfg(ossl110)]
     pub fn X509_LOOKUP_meth_free(method: *mut X509_LOOKUP_METHOD);
@@ -141,11 +129,4 @@ extern "C" {
     pub fn X509_VERIFY_PARAM_get_auth_level(param: *const X509_VERIFY_PARAM) -> c_int;
     #[cfg(ossl102)]
     pub fn X509_VERIFY_PARAM_set_purpose(param: *mut X509_VERIFY_PARAM, purpose: c_int) -> c_int;
-}
-
-const_ptr_api! {
-    extern "C" {
-        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
-        pub fn X509_PURPOSE_get0(idx: c_int) -> *mut X509_PURPOSE;
-    }
 }

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -147,26 +147,3 @@ pub unsafe fn X509_LOOKUP_add_dir(
         std::ptr::null_mut(),
     )
 }
-
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SSL_CLIENT: c_int = 1;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SSL_SERVER: c_int = 2;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_NS_SSL_SERVER: c_int = 3;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SMIME_SIGN: c_int = 4;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_SMIME_ENCRYPT: c_int = 5;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_CRL_SIGN: c_int = 6;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_ANY: c_int = 7;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_OCSP_HELPER: c_int = 8;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_TIMESTAMP_SIGN: c_int = 9;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_MIN: c_int = 1;
-#[cfg(ossl102)]
-pub const X509_PURPOSE_MAX: c_int = 9;

--- a/openssl-sys/src/x509v3.rs
+++ b/openssl-sys/src/x509v3.rs
@@ -58,15 +58,25 @@ pub const EXFLAG_FRESHEST: u32 = 0x1000;
 #[cfg(any(ossl102, libressl261))]
 pub const EXFLAG_SS: u32 = 0x2000;
 
+#[cfg(not(boringssl))]
 pub const X509v3_KU_DIGITAL_SIGNATURE: u32 = 0x0080;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_NON_REPUDIATION: u32 = 0x0040;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_ENCIPHERMENT: u32 = 0x0020;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_DATA_ENCIPHERMENT: u32 = 0x0010;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_AGREEMENT: u32 = 0x0008;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_KEY_CERT_SIGN: u32 = 0x0004;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_CRL_SIGN: u32 = 0x0002;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_ENCIPHER_ONLY: u32 = 0x0001;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_DECIPHER_ONLY: u32 = 0x8000;
+#[cfg(not(boringssl))]
 pub const X509v3_KU_UNDEF: u32 = 0xffff;
 
 pub const XKU_SSL_SERVER: u32 = 0x1;
@@ -79,3 +89,15 @@ pub const XKU_TIMESTAMP: u32 = 0x40;
 pub const XKU_DVCS: u32 = 0x80;
 #[cfg(ossl110)]
 pub const XKU_ANYEKU: u32 = 0x100;
+
+pub const X509_PURPOSE_SSL_CLIENT: c_int = 1;
+pub const X509_PURPOSE_SSL_SERVER: c_int = 2;
+pub const X509_PURPOSE_NS_SSL_SERVER: c_int = 3;
+pub const X509_PURPOSE_SMIME_SIGN: c_int = 4;
+pub const X509_PURPOSE_SMIME_ENCRYPT: c_int = 5;
+pub const X509_PURPOSE_CRL_SIGN: c_int = 6;
+pub const X509_PURPOSE_ANY: c_int = 7;
+pub const X509_PURPOSE_OCSP_HELPER: c_int = 8;
+pub const X509_PURPOSE_TIMESTAMP_SIGN: c_int = 9;
+pub const X509_PURPOSE_MIN: c_int = 1;
+pub const X509_PURPOSE_MAX: c_int = 9;

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -27,6 +27,7 @@ bitflags = "1.0"
 cfg-if = "1.0"
 foreign-types = "0.3.1"
 libc = "0.2"
+num_enum = "0.5"
 once_cell = "1.5.2"
 
 openssl-macros = { version = "0.1.0", path = "../openssl-macros" }

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -79,6 +79,10 @@ fn main() {
             println!("cargo:rustc-cfg=libressl291");
         }
 
+        if version >= 0x3_01_00_00_0 {
+            println!("cargo:rustc-cfg=libressl310");
+        }
+
         if version >= 0x3_02_01_00_0 {
             println!("cargo:rustc-cfg=libressl321");
         }

--- a/openssl/examples/mk_certs.rs
+++ b/openssl/examples/mk_certs.rs
@@ -5,14 +5,21 @@ use openssl::asn1::Asn1Time;
 use openssl::bn::{BigNum, MsbOption};
 use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
 use openssl::pkey::{PKey, PKeyRef, Private};
 use openssl::rsa::Rsa;
+use openssl::stack::Stack;
 use openssl::x509::extension::{
-    AuthorityKeyIdentifier, BasicConstraints, KeyUsage, SubjectAlternativeName,
+    AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName,
     SubjectKeyIdentifier,
 };
 use openssl::x509::{X509NameBuilder, X509Ref, X509Req, X509ReqBuilder, X509VerifyResult, X509};
 
+fn mk_key_pair() -> Result<PKey<Private>, ErrorStack> {
+    let rsa = Rsa::generate(2048)?;
+    let key_pair = PKey::from_rsa(rsa)?;
+    Ok(key_pair)
+}
 /// Make a CA certificate and private key
 fn mk_ca_cert() -> Result<(X509, PKey<Private>), ErrorStack> {
     let rsa = Rsa::generate(2048)?;
@@ -72,6 +79,49 @@ fn mk_request(key_pair: &PKey<Private>) -> Result<X509Req, ErrorStack> {
     x509_name.append_entry_by_text("CN", "www.example.com")?;
     let x509_name = x509_name.build();
     req_builder.set_subject_name(&x509_name)?;
+
+    req_builder.sign(key_pair, MessageDigest::sha256())?;
+    let req = req_builder.build();
+    Ok(req)
+}
+
+/// Make a X509 request with the given private key and a challengePassword attribute
+fn mk_request_with_attribute(key_pair: &PKey<Private>) -> Result<X509Req, ErrorStack> {
+    let mut req_builder = X509ReqBuilder::new()?;
+    req_builder.set_pubkey(key_pair)?;
+
+    let mut x509_name = X509NameBuilder::new()?;
+    x509_name.append_entry_by_text("CN", "myserver.localhost")?;
+    let x509_name = x509_name.build();
+
+    req_builder.set_version(0)?; // 0x00 -> Version: 1
+    req_builder.set_subject_name(&x509_name)?;
+    let extensions = {
+        let context = req_builder.x509v3_context(None);
+        let mut ext_stack = Stack::new()?;
+        ext_stack.push(
+            KeyUsage::new()
+                .digital_signature()
+                .key_encipherment()
+                .build()?,
+        )?;
+        ext_stack.push(ExtendedKeyUsage::new().server_auth().build()?)?;
+        ext_stack.push(
+            SubjectAlternativeName::new()
+                .dns("myserver.localhost")
+                .build(&context)?,
+        )?;
+        ext_stack.push(
+            SubjectAlternativeName::new()
+                .ip("127.0.0.1")
+                .build(&context)?,
+        )?;
+        ext_stack.push(SubjectAlternativeName::new().ip("::1").build(&context)?)?;
+        ext_stack
+    };
+    req_builder.add_extensions(&extensions)?;
+    req_builder
+        .add_attribute_by_nid(Nid::PKCS9_CHALLENGEPASSWORD, "my_secret_challenge_password")?;
 
     req_builder.sign(key_pair, MessageDigest::sha256())?;
     let req = req_builder.build();
@@ -146,6 +196,11 @@ fn real_main() -> Result<(), ErrorStack> {
         X509VerifyResult::OK => println!("Certificate verified!"),
         ver_err => println!("Failed to verify certificate: {}", ver_err),
     };
+
+    let server_key_pair = mk_key_pair()?;
+    let csr = mk_request_with_attribute(&server_key_pair)?;
+    println!("CSR with challengePassword was created:");
+    println!("{}", std::str::from_utf8(&csr.to_pem()?).unwrap());
 
     Ok(())
 }

--- a/openssl/src/bio.rs
+++ b/openssl/src/bio.rs
@@ -21,7 +21,7 @@ impl<'a> MemBioSlice<'a> {
     pub fn new(buf: &'a [u8]) -> Result<MemBioSlice<'a>, ErrorStack> {
         ffi::init();
 
-        assert!(buf.len() <= c_int::max_value() as usize);
+        assert!(buf.len() <= c_int::MAX as usize);
         let bio = unsafe {
             cvt_p(BIO_new_mem_buf(
                 buf.as_ptr() as *const _,
@@ -34,6 +34,21 @@ impl<'a> MemBioSlice<'a> {
 
     pub fn as_ptr(&self) -> *mut ffi::BIO {
         self.0
+    }
+}
+
+// A reference to an OpenSSL memory BIO (binary IO).
+#[cfg(not(boringssl))]
+pub struct MemBioRef(*mut ffi::BIO);
+
+#[cfg(not(boringssl))]
+impl MemBioRef {
+    pub fn as_ptr(&self) -> *mut ffi::BIO {
+        self.0
+    }
+
+    pub unsafe fn from_ptr(bio: *mut ffi::BIO) -> MemBioRef {
+        MemBioRef(bio)
     }
 }
 

--- a/openssl/src/bio.rs
+++ b/openssl/src/bio.rs
@@ -37,21 +37,6 @@ impl<'a> MemBioSlice<'a> {
     }
 }
 
-// A reference to an OpenSSL memory BIO (binary IO).
-#[cfg(not(boringssl))]
-pub struct MemBioRef(*mut ffi::BIO);
-
-#[cfg(not(boringssl))]
-impl MemBioRef {
-    pub fn as_ptr(&self) -> *mut ffi::BIO {
-        self.0
-    }
-
-    pub unsafe fn from_ptr(bio: *mut ffi::BIO) -> MemBioRef {
-        MemBioRef(bio)
-    }
-}
-
 pub struct MemBio(*mut ffi::BIO);
 
 impl Drop for MemBio {

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -1248,6 +1248,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(ossl300))]
     fn test_des_ede3_cbc() {
         let pt = "54686973206973206120746573742e";
         let ct = "6f2867cfefda048a4046ef7e556c7132";

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -9,7 +9,7 @@
 
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
-use libc::{c_int, c_long, c_uint};
+use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_void};
 use std::cmp::{self, Ordering};
 use std::error::Error;
 use std::ffi::{CStr, CString};
@@ -18,12 +18,16 @@ use std::marker::PhantomData;
 use std::mem;
 use std::path::Path;
 use std::ptr;
+use std::ptr::null_mut;
 use std::slice;
 use std::str;
 
 use crate::asn1::{
-    Asn1BitStringRef, Asn1IntegerRef, Asn1ObjectRef, Asn1StringRef, Asn1TimeRef, Asn1Type,
+    Asn1BitStringRef, Asn1IntegerRef, Asn1Object, Asn1ObjectRef, Asn1OctetStringRef, Asn1String,
+    Asn1StringRef, Asn1TagValue, Asn1TimeRef, Asn1TypeRef,
 };
+#[cfg(ossl110)]
+use crate::bio::MemBio;
 use crate::bio::MemBioSlice;
 use crate::conf::ConfRef;
 use crate::error::ErrorStack;
@@ -450,6 +454,34 @@ impl X509Ref {
         }
     }
 
+    /// Returns this certificate's key usage extension value, if it exists.
+    #[corresponds(X509_get_ext_d2i)]
+    pub fn key_usage(&self) -> Option<&Asn1BitStringRef> {
+        unsafe {
+            let ptr = ffi::X509_get_ext_d2i(
+                self.as_ptr(),
+                ffi::NID_key_usage,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            );
+            Asn1BitStringRef::from_const_ptr_opt(ptr as *const _)
+        }
+    }
+
+    /// Returns this certificate's extended key usage extension value, if it exists.
+    #[corresponds(X509_get_ext_d2i)]
+    pub fn extended_key_usage(&self) -> Option<Stack<Asn1Object>> {
+        unsafe {
+            let ptr = ffi::X509_get_ext_d2i(
+                self.as_ptr(),
+                ffi::NID_ext_key_usage,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            );
+            Stack::from_ptr_opt(ptr as *mut _)
+        }
+    }
+
     #[corresponds(X509_get_pubkey)]
     pub fn public_key(&self) -> Result<PKey<Public>, ErrorStack> {
         unsafe {
@@ -570,6 +602,62 @@ impl X509Ref {
             let r = ffi::X509_get_serialNumber(self.as_ptr());
             Asn1IntegerRef::from_const_ptr_opt(r).expect("serial number must not be null")
         }
+    }
+
+    /// Returns the certificate's extensions.
+    #[corresponds(X509_get0_extensions)]
+    #[cfg(ossl110)]
+    pub fn extensions(&self) -> Result<&StackRef<X509Extension>, ErrorStack> {
+        unsafe {
+            let result = ffi::X509_get0_extensions(self.as_ptr() as *const _);
+            if result.is_null() {
+                return Err(ErrorStack::get());
+            }
+            Ok(StackRef::from_const_ptr(result))
+        }
+    }
+
+    /// Returns the location of an extension within a certificate.
+    #[corresponds(X509_get_ext_by_NID)]
+    pub fn get_extension_by_nid(&self, nid: &Nid) -> Option<i32> {
+        unsafe {
+            let pos: i32 = ffi::X509_get_ext_by_NID(
+                self.as_ptr(),
+                nid.as_raw(),
+                -1, // start search from first extension
+            );
+            if pos == -1 {
+                None
+            } else {
+                Some(pos)
+            }
+        }
+    }
+
+    /// Returns the X509 extension at position `pos` in an X509 certificate.
+    pub fn get_extension(&self, pos: i32) -> Result<&X509ExtensionRef, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::X509_get_ext(self.as_ptr(), pos as c_int))?;
+            Ok(X509ExtensionRef::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the certificates key usage extension flags. If the extension is not present in the
+    /// certificate, 0 will be returned.
+    /// Note: this does not include the critical flag.
+    #[cfg(ossl110)]
+    #[corresponds(X509_get_key_usage)]
+    pub fn key_usage_flags(&self) -> u32 {
+        unsafe { ffi::X509_get_key_usage(self.as_ptr()) }
+    }
+
+    /// Returns the certificates extended key usage extension flags. If the extension is not
+    /// present in the certificate, 0 will be returned.
+    /// Note: this does not include the critical flag.
+    #[cfg(ossl110)]
+    #[corresponds(X509_get_extended_key_usage)]
+    pub fn extended_key_usage_flags(&self) -> u32 {
+        unsafe { ffi::X509_get_extended_key_usage(self.as_ptr()) }
     }
 
     to_pem! {
@@ -726,8 +814,28 @@ impl fmt::Debug for X509 {
         if let Ok(public_key) = &self.public_key() {
             debug_struct.field("public_key", public_key);
         };
-        // TODO: Print extensions once they are supported on the X509 struct.
-
+        cfg_if! { if #[cfg(ossl110)] {
+            unsafe {
+                let extensions = ffi::X509_get0_extensions(self.as_ptr() as *const _);
+                let title = CString::new("X509 Extensions").unwrap();
+                if !extensions.is_null() {
+                    if let Ok(bio) = MemBio::new() {
+                        let result = cvt(ffi::X509V3_extensions_print(
+                            bio.as_ptr(),
+                            title.as_ptr() as *const _,
+                            extensions,
+                            0,
+                            4,
+                        ));
+                        if result.is_ok() {
+                            if let Ok(ext_str) = String::from_utf8(bio.get_buf().to_vec()) {
+                                debug_struct.field("X509 Extensions", &ext_str);
+                            }
+                        }
+                    }
+                }
+            }
+        }};
         debug_struct.finish()
     }
 }
@@ -773,6 +881,75 @@ impl PartialEq<X509Ref> for X509 {
 }
 
 impl Eq for X509 {}
+
+foreign_type_and_impl_send_sync! {
+    type CType = ffi::X509_ATTRIBUTE;
+    fn drop = ffi::X509_ATTRIBUTE_free;
+
+    /// Permit additional fields to be added to an `X509` v3 certificate.
+    pub struct X509Attribute;
+    /// Reference to `X509Attribute`.
+    pub struct X509AttributeRef;
+}
+
+impl Stackable for X509Attribute {
+    type StackType = ffi::stack_st_X509_ATTRIBUTE;
+}
+
+impl X509Attribute {
+    /// Creates an X509 attribute, which can be added to X509 certificates, signing requests and
+    /// PKCS7 messages.
+    ///
+    /// The attribute type is derived from the ASN1 string value. So be sure to use
+    /// Asn1String::type_new() for strings other than octet strings.
+    ///
+    pub fn from_string(nid: Nid, value: Asn1String) -> Result<X509Attribute, ErrorStack> {
+        unsafe {
+            let asn1_type = cvt(ffi::ASN1_STRING_type(value.as_ptr()))?;
+            let attribute = cvt_p(ffi::X509_ATTRIBUTE_create(
+                nid.as_raw(),
+                asn1_type,
+                value.as_ptr() as *mut c_void,
+            ));
+            #[allow(clippy::forget_copy)]
+            mem::forget(value); // Asn1String does not implement the Copy trait, so clippy is wrong here.
+            attribute.map(X509Attribute)
+        }
+    }
+
+    /// Creates an X509 attribute from an `Asn1Object`.
+    pub fn from_object(nid: Nid, value: Asn1Object) -> Result<X509Attribute, ErrorStack> {
+        unsafe {
+            let asn1_type = Asn1TagValue::OBJECT;
+            let attribute = cvt_p(ffi::X509_ATTRIBUTE_create(
+                nid.as_raw(),
+                asn1_type.as_raw(),
+                value.as_ptr() as *mut c_void,
+            ));
+            #[allow(clippy::forget_copy)]
+            mem::forget(value); // Asn1String does not implement the Copy trait, so clippy is wrong here.
+            attribute.map(X509Attribute)
+        }
+    }
+}
+
+impl X509AttributeRef {
+    /// Get object id (NID) of attribute
+    pub fn object(&self) -> Result<&Asn1ObjectRef, ErrorStack> {
+        unsafe {
+            let object_ptr = cvt_p(ffi::X509_ATTRIBUTE_get0_object(self.as_ptr()))?;
+            Ok(Asn1ObjectRef::from_ptr(object_ptr))
+        }
+    }
+
+    /// Get an item from the list of `ASN1_TYPE`s.
+    pub fn typ(&self, idx: isize) -> Result<&Asn1TypeRef, ErrorStack> {
+        unsafe {
+            let type_ptr = cvt_p(ffi::X509_ATTRIBUTE_get0_type(self.as_ptr(), idx as c_int))?;
+            Ok(Asn1TypeRef::from_ptr(type_ptr))
+        }
+    }
+}
 
 /// A context object required to construct certain `X509` extension values.
 pub struct X509v3Context<'a>(ffi::X509V3_CTX, PhantomData<(&'a X509Ref, &'a ConfRef)>);
@@ -834,7 +1011,7 @@ impl X509Extension {
     pub fn new_nid(
         conf: Option<&ConfRef>,
         context: Option<&X509v3Context<'_>>,
-        name: Nid,
+        nid: Nid,
         value: &str,
     ) -> Result<X509Extension, ErrorStack> {
         let value = CString::new(value).unwrap();
@@ -842,10 +1019,52 @@ impl X509Extension {
             ffi::init();
             let conf = conf.map_or(ptr::null_mut(), ConfRef::as_ptr);
             let context = context.map_or(ptr::null_mut(), X509v3Context::as_ptr);
-            let name = name.as_raw();
+            let nid = nid.as_raw();
             let value = value.as_ptr() as *mut _;
 
-            cvt_p(ffi::X509V3_EXT_nconf_nid(conf, context, name, value)).map(X509Extension)
+            cvt_p(ffi::X509V3_EXT_nconf_nid(conf, context, nid, value)).map(X509Extension)
+        }
+    }
+
+    /// Create a new X509 extension with OID `oid`. The raw value is used instead of a config
+    /// string as in `new()` and `new_nid()`.
+    pub fn create_by_obj(
+        critical: bool,
+        oid: &Asn1ObjectRef,
+        value: &[u8],
+    ) -> Result<X509Extension, ErrorStack> {
+        let ex = null_mut();
+        let mut octet_string = Asn1String::type_new(Asn1TagValue::OCTET_STRING)?;
+        octet_string.set(value)?;
+        unsafe {
+            cvt_p(ffi::X509_EXTENSION_create_by_OBJ(
+                ex,
+                oid.as_ptr(),
+                c_int::from(critical),
+                octet_string.as_ptr() as *mut ffi::ASN1_OCTET_STRING,
+            ))
+            .map(X509Extension)
+        }
+    }
+
+    /// Create a new X509 extension with NID `nid`. The raw value is used instead of a config
+    /// string as in `new()` and `new_nid()`.
+    pub fn create_by_nid(
+        critical: bool,
+        nid: &Nid,
+        value: &[u8],
+    ) -> Result<X509Extension, ErrorStack> {
+        let ex = null_mut();
+        let mut octet_string = Asn1String::type_new(Asn1TagValue::OCTET_STRING)?;
+        octet_string.set(value)?;
+        unsafe {
+            cvt_p(ffi::X509_EXTENSION_create_by_NID(
+                ex,
+                nid.as_raw(),
+                c_int::from(critical),
+                octet_string.as_ptr() as *mut ffi::ASN1_OCTET_STRING,
+            ))
+            .map(X509Extension)
         }
     }
 
@@ -858,6 +1077,29 @@ impl X509Extension {
     pub unsafe fn add_alias(to: Nid, from: Nid) -> Result<(), ErrorStack> {
         ffi::init();
         cvt(ffi::X509V3_EXT_add_alias(to.as_raw(), from.as_raw())).map(|_| ())
+    }
+}
+
+impl X509ExtensionRef {
+    /// Returns true, if the extension is marked as critical.
+    pub fn is_critical(&self) -> bool {
+        unsafe { ffi::X509_EXTENSION_get_critical(self.as_ptr()) == 1 }
+    }
+
+    /// Returns the extension type.
+    pub fn object(&self) -> Result<&Asn1ObjectRef, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::X509_EXTENSION_get_object(self.as_ptr()))?;
+            Ok(Asn1ObjectRef::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the extension data (DER).
+    pub fn data(&self) -> Result<&Asn1OctetStringRef, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::X509_EXTENSION_get_data(self.as_ptr()))?;
+            Ok(Asn1OctetStringRef::from_ptr(ptr))
+        }
     }
 }
 
@@ -919,7 +1161,7 @@ impl X509NameBuilder {
         &mut self,
         field: &str,
         value: &str,
-        ty: Asn1Type,
+        ty: Asn1TagValue,
     ) -> Result<(), ErrorStack> {
         unsafe {
             let field = CString::new(field).unwrap();
@@ -967,7 +1209,7 @@ impl X509NameBuilder {
         &mut self,
         field: Nid,
         value: &str,
-        ty: Asn1Type,
+        ty: Asn1TagValue,
     ) -> Result<(), ErrorStack> {
         unsafe {
             assert!(value.len() <= c_int::max_value() as usize);
@@ -1072,6 +1314,14 @@ impl X509NameRef {
         /// [`i2d_X509_NAME`]: https://www.openssl.org/docs/manmaster/crypto/i2d_X509_NAME.html
         to_der,
         ffi::i2d_X509_NAME
+    }
+
+    /// Compares the X509NameRef with an`other` X509NameRef
+    /// Returns 0 if equal.
+    #[corresponds(X509_NAME_cmp)]
+    #[allow(clippy::unnecessary_cast)]
+    pub fn cmp_with(&self, other: &X509NameRef) -> i32 {
+        unsafe { ffi::X509_NAME_cmp(self.as_ptr() as *const _, other.as_ptr() as *const _) as i32 }
     }
 }
 
@@ -1258,6 +1508,38 @@ impl X509ReqBuilder {
         }
     }
 
+    /// Permits an attribute to be added to the certificate or certificate request.
+    pub fn add_attribute(&mut self, name: &str, value: &str) -> Result<(), ErrorStack> {
+        let name = CString::new(name).unwrap();
+        let len = value.len();
+        let value = CString::new(value).unwrap();
+        unsafe {
+            cvt(ffi::X509_REQ_add1_attr_by_txt(
+                self.0.as_ptr(),
+                name.as_ptr() as *const c_char,
+                ffi::MBSTRING_UTF8,
+                value.as_ptr() as *const c_uchar,
+                len as c_int,
+            ))
+            .map(|_| ())
+        }
+    }
+
+    pub fn add_attribute_by_nid(&mut self, nid: Nid, value: &str) -> Result<(), ErrorStack> {
+        let len = value.len();
+        let value = CString::new(value).unwrap();
+        unsafe {
+            cvt(ffi::X509_REQ_add1_attr_by_NID(
+                self.0.as_ptr(),
+                nid.as_raw(),
+                ffi::MBSTRING_UTF8,
+                value.as_ptr() as *const c_uchar,
+                len as c_int,
+            ))
+            .map(|_| ())
+        }
+    }
+
     /// Sign the request using a private key.
     ///
     /// This corresponds to [`X509_REQ_sign`].
@@ -1409,6 +1691,18 @@ impl X509ReqRef {
             let extensions = cvt_p(ffi::X509_REQ_get_extensions(self.as_ptr()))?;
             Ok(Stack::from_ptr(extensions))
         }
+    }
+}
+
+impl fmt::Debug for X509Req {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug_struct = formatter.debug_struct("X509Req");
+        debug_struct.field("version", &self.version());
+        debug_struct.field("subject", &self.subject_name());
+        if let Ok(public_key) = &self.public_key() {
+            debug_struct.field("public_key", public_key);
+        };
+        debug_struct.finish()
     }
 }
 

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -51,8 +51,9 @@ use crate::ssl::SslFiletype;
 use crate::stack::StackRef;
 #[cfg(any(ossl102, libressl261))]
 use crate::x509::verify::{X509VerifyFlags, X509VerifyParamRef};
-use crate::x509::{X509Object, X509};
+use crate::x509::{X509Object, X509PurposeId, X509};
 use crate::{cvt, cvt_p};
+use libc::c_int;
 use openssl_macros::corresponds;
 #[cfg(not(boringssl))]
 use std::ffi::CString;
@@ -123,6 +124,19 @@ impl X509StoreBuilderRef {
     #[cfg(any(ossl102, libressl261))]
     pub fn set_flags(&mut self, flags: X509VerifyFlags) -> Result<(), ErrorStack> {
         unsafe { cvt(ffi::X509_STORE_set_flags(self.as_ptr(), flags.bits())).map(|_| ()) }
+    }
+
+    /// Sets the certificate purpose.
+    /// The purpose value can be obtained by `X509Purpose::get_by_sname()`
+    #[corresponds(X509_STORE_set_purpose)]
+    pub fn set_purpose(&mut self, purpose: X509PurposeId) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::X509_STORE_set_purpose(
+                self.as_ptr(),
+                purpose.value() as c_int,
+            ))
+            .map(|_| ())
+        }
     }
 
     /// Sets certificate chain validation related parameters.

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -1,3 +1,5 @@
+#[cfg(ossl110)]
+use crate::asn1::Asn1Object;
 use std::cmp::Ordering;
 
 use crate::asn1::Asn1Time;
@@ -613,6 +615,163 @@ fn test_name_cmp() {
     let issuer = cert.issuer_name();
     assert_eq!(Ordering::Equal, subject.try_cmp(subject).unwrap());
     assert_eq!(Ordering::Greater, subject.try_cmp(issuer).unwrap());
+}
+
+#[cfg(ossl110)]
+fn prepare_cert_builder() -> (X509Builder, PKey<Private>) {
+    let rsa = Rsa::generate(2048).unwrap();
+    let pkey = PKey::from_rsa(rsa).unwrap();
+    let mut name = X509Name::builder().unwrap();
+    name.append_entry_by_nid(Nid::COMMONNAME, "Example Name")
+        .unwrap();
+    let name = name.build();
+    let mut builder = X509::builder().unwrap();
+    builder.set_version(2).unwrap(); // 2 -> X509v3
+    builder.set_subject_name(&name).unwrap();
+    builder.set_issuer_name(&name).unwrap();
+    builder.set_pubkey(&pkey).unwrap();
+    (builder, pkey)
+}
+
+#[test]
+#[cfg(ossl110)]
+#[cfg(not(boringssl))]
+fn test_key_usage() {
+    // Create an X.509 certificate with an extended key usage extension.
+    let (mut builder, pkey) = prepare_cert_builder();
+    builder
+        .append_extension(
+            KeyUsage::new()
+                .digital_signature()
+                .non_repudiation()
+                .key_encipherment()
+                .data_encipherment()
+                .key_agreement()
+                .key_cert_sign()
+                //.crl_sign()
+                .decipher_only()
+                .encipher_only()
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+    builder.sign(&pkey, MessageDigest::sha256()).unwrap();
+    let cert = builder.build();
+
+    let ku_bit_string = cert.key_usage().unwrap();
+    assert_eq!(ku_bit_string.len(), 2);
+    let mut ku_bits: u32 = 0;
+    ku_bits |= ku_bit_string.as_slice()[0] as u32;
+    ku_bits |= (ku_bit_string.as_slice()[1] as u32) << 8;
+    assert!(ku_bits & ffi::X509v3_KU_DIGITAL_SIGNATURE > 0);
+    assert!(ku_bits & ffi::X509v3_KU_NON_REPUDIATION > 0);
+    assert!(ku_bits & ffi::X509v3_KU_KEY_ENCIPHERMENT > 0);
+    assert!(ku_bits & ffi::X509v3_KU_DATA_ENCIPHERMENT > 0);
+    assert!(ku_bits & ffi::X509v3_KU_KEY_AGREEMENT > 0);
+    assert!(ku_bits & ffi::X509v3_KU_KEY_CERT_SIGN > 0);
+    assert_eq!(ku_bits & ffi::X509v3_KU_CRL_SIGN, 0);
+    assert!(ku_bits & ffi::X509v3_KU_ENCIPHER_ONLY > 0);
+    assert!(ku_bits & ffi::X509v3_KU_DECIPHER_ONLY > 0);
+}
+
+#[test]
+#[cfg(ossl110)]
+fn test_key_usage_data() {
+    // Create an X.509 certificate with an extended key usage extension.
+    let (mut builder, pkey) = prepare_cert_builder();
+    builder
+        .append_extension(KeyUsage::new().key_cert_sign().build().unwrap())
+        .unwrap();
+    builder.sign(&pkey, MessageDigest::sha256()).unwrap();
+    let cert = builder.build();
+
+    let ku_ext_pos = cert.get_extension_by_nid(&Nid::KEY_USAGE).unwrap();
+    let ku_ext = cert.get_extension(ku_ext_pos).unwrap();
+    assert!(!ku_ext.is_critical());
+    assert_eq!(
+        ku_ext.object().unwrap(),
+        Asn1Object::from_nid(&Nid::KEY_USAGE).unwrap().as_ref()
+    );
+    assert_eq!(
+        ku_ext.data().unwrap().as_slice(),
+        [0x03, 0x02, 0x02, 0x04,] //   BIT STRING (6 bit) 000001
+    );
+}
+
+#[test]
+#[cfg(ossl110)]
+fn test_extended_key_usage() {
+    // Create an X.509 certificate with an extended key usage extension.
+    let (mut builder, pkey) = prepare_cert_builder();
+    builder
+        .append_extension(
+            ExtendedKeyUsage::new()
+                .critical()
+                .server_auth()
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+    builder.sign(&pkey, MessageDigest::sha256()).unwrap();
+    let cert = builder.build();
+
+    let asn1obj_stack = cert.extended_key_usage().unwrap();
+    assert_eq!(asn1obj_stack.get(0).unwrap().nid(), Nid::SERVER_AUTH)
+}
+
+#[test]
+#[cfg(ossl110)]
+fn test_extended_key_usage_data() {
+    // Create an X.509 certificate with an extended key usage extension.
+    let (mut builder, pkey) = prepare_cert_builder();
+    builder
+        .append_extension(
+            ExtendedKeyUsage::new()
+                .critical()
+                .server_auth()
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+    builder.sign(&pkey, MessageDigest::sha256()).unwrap();
+    let cert = builder.build();
+
+    let eku_ext_pos = cert.get_extension_by_nid(&Nid::EXT_KEY_USAGE).unwrap();
+    let eku_ext = cert.get_extension(eku_ext_pos).unwrap();
+    assert!(eku_ext.is_critical());
+    assert_eq!(
+        eku_ext.object().unwrap(),
+        Asn1Object::from_nid(&Nid::EXT_KEY_USAGE).unwrap().as_ref()
+    );
+    assert_eq!(
+        eku_ext.data().unwrap().as_slice(),
+        [
+            0x30, 0x0a, // SEQUENCE LENGTH=10
+            0x06, 0x08, //   OBJECT IDENTIFIER LENGTH=8
+            0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x01 // 1.3.6.1.5.5.7.3.1 (serverAuth)
+        ]
+    );
+}
+
+#[test]
+#[cfg(ossl110)]
+fn test_extended_key_usage_flags() {
+    // Create an X.509 certificate with an extended key usage extension.
+    let (mut builder, pkey) = prepare_cert_builder();
+    builder
+        .append_extension(
+            ExtendedKeyUsage::new()
+                .critical()
+                .client_auth()
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+    builder.sign(&pkey, MessageDigest::sha256()).unwrap();
+    let cert = builder.build();
+    let eku_flags = cert.extended_key_usage_flags();
+    assert!(eku_flags & ffi::XKU_SSL_SERVER == 0);
+    assert!(eku_flags & ffi::XKU_SSL_CLIENT == ffi::XKU_SSL_CLIENT);
 }
 
 #[test]

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -16,12 +16,14 @@ use crate::x509::extension::{
 #[cfg(not(boringssl))]
 use crate::x509::store::X509Lookup;
 use crate::x509::store::X509StoreBuilder;
-#[cfg(ossl102)]
-use crate::x509::verify::X509PurposeFlags;
 #[cfg(any(ossl102, libressl261))]
 use crate::x509::verify::{X509VerifyFlags, X509VerifyParam};
 #[cfg(ossl110)]
 use crate::x509::X509Builder;
+#[cfg(any(ossl102, libressl261))]
+use crate::x509::X509Purpose;
+#[cfg(ossl102)]
+use crate::x509::X509PurposeId;
 use crate::x509::{X509Name, X509Req, X509StoreContext, X509VerifyResult, X509};
 use hex::{self, FromHex};
 #[cfg(any(ossl102, libressl261))]
@@ -440,6 +442,67 @@ fn test_verify_fails_with_crl_flag_set_and_no_crl() {
     )
 }
 
+#[test]
+#[cfg(any(ossl102, libressl261))]
+fn test_verify_cert_with_purpose() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let ca = include_bytes!("../../test/root-ca.pem");
+    let ca = X509::from_pem(ca).unwrap();
+    let chain = Stack::new().unwrap();
+
+    let mut store_bldr = X509StoreBuilder::new().unwrap();
+    let purpose_idx = X509Purpose::get_by_sname("sslserver")
+        .expect("Getting certificate purpose 'sslserver' failed");
+    let x509_purpose =
+        X509Purpose::from_idx(purpose_idx).expect("Getting certificate purpose failed");
+    store_bldr
+        .set_purpose(x509_purpose.purpose())
+        .expect("Setting certificate purpose failed");
+    store_bldr.add_cert(ca).unwrap();
+
+    let store = store_bldr.build();
+
+    let mut context = X509StoreContext::new().unwrap();
+    assert!(context
+        .init(&store, &cert, &chain, |c| c.verify_cert())
+        .unwrap());
+}
+
+#[test]
+#[cfg(any(ossl102, libressl261))]
+fn test_verify_cert_with_wrong_purpose_fails() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let ca = include_bytes!("../../test/root-ca.pem");
+    let ca = X509::from_pem(ca).unwrap();
+    let chain = Stack::new().unwrap();
+
+    let mut store_bldr = X509StoreBuilder::new().unwrap();
+    let purpose_idx = X509Purpose::get_by_sname("timestampsign")
+        .expect("Getting certificate purpose 'timestampsign' failed");
+    let x509_purpose =
+        X509Purpose::from_idx(purpose_idx).expect("Getting certificate purpose failed");
+    store_bldr
+        .set_purpose(x509_purpose.purpose())
+        .expect("Setting certificate purpose failed");
+    store_bldr.add_cert(ca).unwrap();
+
+    let store = store_bldr.build();
+
+    let mut context = X509StoreContext::new().unwrap();
+    assert_eq!(
+        context
+            .init(&store, &cert, &chain, |c| {
+                c.verify_cert()?;
+                Ok(c.error())
+            })
+            .unwrap()
+            .error_string(),
+        "unsupported certificate purpose"
+    )
+}
+
 #[cfg(ossl110)]
 #[test]
 fn x509_ref_version() {
@@ -724,7 +787,7 @@ fn test_set_purpose() {
     let mut store_bldr = X509StoreBuilder::new().unwrap();
     store_bldr.add_cert(ca).unwrap();
     let mut verify_params = X509VerifyParam::new().unwrap();
-    verify_params.set_purpose(X509PurposeFlags::ANY).unwrap();
+    verify_params.set_purpose(X509PurposeId::ANY).unwrap();
     store_bldr.set_param(&verify_params).unwrap();
     let store = store_bldr.build();
     let mut context = X509StoreContext::new().unwrap();
@@ -750,7 +813,7 @@ fn test_set_purpose_fails_verification() {
     store_bldr.add_cert(ca).unwrap();
     let mut verify_params = X509VerifyParam::new().unwrap();
     verify_params
-        .set_purpose(X509PurposeFlags::TIMESTAMP_SIGN)
+        .set_purpose(X509PurposeId::TIMESTAMP_SIGN)
         .unwrap();
     store_bldr.set_param(&verify_params).unwrap();
     let store = store_bldr.build();

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -4,6 +4,8 @@ use libc::{c_int, c_uint, c_ulong, time_t};
 use std::net::IpAddr;
 
 use crate::error::ErrorStack;
+#[cfg(ossl102)]
+use crate::x509::X509PurposeId;
 use crate::{cvt, cvt_p};
 use openssl_macros::corresponds;
 
@@ -180,30 +182,7 @@ impl X509VerifyParamRef {
     /// Sets the verification purpose
     #[corresponds(X509_VERIFY_PARAM_set_purpose)]
     #[cfg(ossl102)]
-    pub fn set_purpose(&mut self, purpose: X509PurposeFlags) -> Result<(), ErrorStack> {
-        unsafe {
-            cvt(ffi::X509_VERIFY_PARAM_set_purpose(
-                self.as_ptr(),
-                purpose.bits,
-            ))
-            .map(|_| ())
-        }
+    pub fn set_purpose(&mut self, purpose: X509PurposeId) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::X509_VERIFY_PARAM_set_purpose(self.as_ptr(), purpose.0)).map(|_| ()) }
     }
-}
-
-#[cfg(ossl102)]
-bitflags! {
-    /// Bitflags defining the purpose of the verification
-    pub struct X509PurposeFlags: c_int {
-        const SSL_CLIENT = ffi::X509_PURPOSE_SSL_CLIENT;
-        const SSL_SERVER = ffi::X509_PURPOSE_SSL_SERVER;
-        const NS_SSL_SERVER = ffi::X509_PURPOSE_NS_SSL_SERVER;
-        const SMIME_SIGN = ffi::X509_PURPOSE_SMIME_SIGN;
-        const SMIME_ENCRYPT = ffi::X509_PURPOSE_SMIME_ENCRYPT;
-        const CRL_SIGN = ffi::X509_PURPOSE_CRL_SIGN;
-        const ANY = ffi::X509_PURPOSE_ANY;
-        const OCSP_HELPER = ffi::X509_PURPOSE_OCSP_HELPER;
-        const TIMESTAMP_SIGN = ffi::X509_PURPOSE_TIMESTAMP_SIGN;
-    }
-
 }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -108,7 +108,10 @@ fn main() {
             || s.starts_with("CRYPTO_EX_")
     });
     cfg.skip_struct(|s| {
-        s == "ProbeResult" || s == "X509_OBJECT_data" // inline union
+        s == "ProbeResult" ||
+        s == "X509_OBJECT_data" || // inline union
+        s == "PKCS7_data" ||
+        s == "ASN1_TYPE_value"
     });
     cfg.skip_fn(move |s| {
         s == "CRYPTO_memcmp" ||                 // uses volatile
@@ -128,7 +131,9 @@ fn main() {
     cfg.skip_field_type(|s, field| {
         (s == "EVP_PKEY" && field == "pkey") ||      // union
             (s == "GENERAL_NAME" && field == "d") || // union
-            (s == "X509_OBJECT" && field == "data") // union
+            (s == "X509_OBJECT" && field == "data") || // union
+            (s == "PKCS7" && field == "d") || // union
+            (s == "ASN1_TYPE" && field == "value") // union
     });
     cfg.skip_signededness(|s| {
         s.ends_with("_cb")


### PR DESCRIPTION
- This is part 3/4 of the split #1598.
- It contains implementations for creating and reading X509 certs and requests. This handles X509 extensions and attributes.
- #1788 and #1789 are prerequisites for this PR.