### PR TITLE
Add X509Name::to_owned()

### DIFF
--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1064,6 +1064,13 @@ impl X509NameRef {
         Ok(cmp.cmp(&0))
     }
 
+    /// Copies the name to a new `X509Name`.
+    #[corresponds(X509_NAME_dup)]
+    #[cfg(any(boringssl, ossl110, libressl270))]
+    pub fn to_owned(&self) -> Result<X509Name, ErrorStack> {
+        unsafe { cvt_p(ffi::X509_NAME_dup(self.as_ptr())).map(|n| X509Name::from_ptr(n)) }
+    }
+
     to_der! {
         /// Serializes the certificate into a DER-encoded X509 name structure.
         ///

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -616,6 +616,16 @@ fn test_name_cmp() {
 }
 
 #[test]
+#[cfg(any(boringssl, ossl110, libressl270))]
+fn test_name_to_owned() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let name = cert.subject_name();
+    let copied_name = name.to_owned().unwrap();
+    assert_eq!(Ordering::Equal, name.try_cmp(&copied_name).unwrap());
+}
+
+#[test]
 #[cfg(any(ossl102, libressl261))]
 fn test_verify_param_set_time_fails_verification() {
     const TEST_T_2030: time_t = 1893456000;


### PR DESCRIPTION
The X509_NAME_dup() function can fail but that isn't compatible with the ToOwned trait. Follow the pattern used in BigNum to add a custom, fallible to_owned() function.