### PR TITLE
fixes #1768 -- integrate boringssl into the build process more naturally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,24 +311,14 @@ jobs:
               make install_sw
               ;;
             "boringssl")
-              sed -i rust/CMakeLists.txt -e '1s%^%include_directories(../include)\n%'
-              cpu=`echo ${{ matrix.target }} | cut -d - -f 1`
-              echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
-              echo "set(CMAKE_SYSTEM_PROCESSOR $cpu)" >> toolchain.cmake
-              echo "set(triple ${{ matrix.target }})" >> toolchain.cmake
-              echo 'set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} '$OS_FLAGS '" CACHE STRING "c++ flags")' >> toolchain.cmake
-              echo 'set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   '$OS_FLAGS '" CACHE STRING "c flags")' >> toolchain.cmake
-              echo 'set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} '$OS_FLAGS '" CACHE STRING "asm flags")' >> toolchain.cmake
-              cmake -DRUST_BINDINGS="${{ matrix.target }}" -B $OPENSSL_DIR -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake
-              make -C $OPENSSL_DIR
+              mkdir build
+              cd build
+              cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DRUST_BINDINGS="${{ matrix.target }}" -DCMAKE_INSTALL_PREFIX="${OPENSSL_DIR}"
+              make -j "$(nproc)"
+              make install
             esac
 
           if: matrix.library.version != 'vendored' && !steps.openssl-cache.outputs.cache-hit
-        - run: |
-            mkdir -p .cargo
-            echo '[patch.crates-io]' > .cargo/config.toml
-            echo 'bssl-sys = { path = "'$OPENSSL_DIR'/rust" }' >> .cargo/config.toml
-          if: matrix.library.name == 'boringssl'
         - uses: actions/cache@v1
           with:
             path: ~/.cargo/registry/index
@@ -357,9 +347,6 @@ jobs:
           if: matrix.library.name != 'boringssl'
         - name: Test openssl
           run: |
-            if [[ "${{ matrix.library.name }}" == "boringssl" ]]; then
-              features="--features unstable_boringssl"
-            fi
             if [[ "${{ matrix.library.version }}" == "vendored" ]]; then
               features="--features vendored"
             fi

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -17,9 +17,18 @@ extern crate libc;
 pub use libc::*;
 
 #[cfg(boringssl)]
-extern crate bssl_sys;
+#[path = "."]
+mod boringssl {
+    include!(env!("BORINGSSL_RUST_WRAPPER"));
+
+    pub fn init() {
+        unsafe {
+            CRYPTO_library_init();
+        }
+    }
+}
 #[cfg(boringssl)]
-pub use bssl_sys::*;
+pub use boringssl::*;
 
 #[cfg(openssl)]
 #[path = "."]

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -19,7 +19,6 @@ v111 = []
 
 vendored = ['ffi/vendored']
 bindgen = ['ffi/bindgen']
-unstable_boringssl = ["ffi/unstable_boringssl"]
 default = []
 
 [dependencies]

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -11,7 +11,7 @@ fn main() {
         println!("cargo:rustc-cfg=libressl");
     }
 
-    if env::var("CARGO_FEATURE_UNSTABLE_BORINGSSL").is_ok() {
+    if env::var("DEP_OPENSSL_BORINGSSL").is_ok() {
         println!("cargo:rustc-cfg=boringssl");
         return;
     }

--- a/openssl/src/bio.rs
+++ b/openssl/src/bio.rs
@@ -25,7 +25,7 @@ impl<'a> MemBioSlice<'a> {
         let bio = unsafe {
             cvt_p(BIO_new_mem_buf(
                 buf.as_ptr() as *const _,
-                buf.len() as c_int,
+                buf.len() as crate::SLenType,
             ))?
         };
 
@@ -74,7 +74,7 @@ impl MemBio {
 }
 
 cfg_if! {
-    if #[cfg(ossl102)] {
+    if #[cfg(any(ossl102, boringssl))] {
         use ffi::BIO_new_mem_buf;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -239,7 +239,7 @@ where
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl270))] {
+    if #[cfg(any(ossl110, libressl270, boringssl))] {
         use ffi::{DH_set0_pqg, DH_get0_pqg, DH_get0_key, DH_set0_key};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -190,6 +190,11 @@ type LenType = libc::size_t;
 #[cfg(not(boringssl))]
 type LenType = libc::c_int;
 
+#[cfg(boringssl)]
+type SLenType = libc::ssize_t;
+#[cfg(not(boringssl))]
+type SLenType = libc::c_int;
+
 #[inline]
 fn cvt_p<T>(r: *mut T) -> Result<*mut T, ErrorStack> {
     if r.is_null() {


### PR DESCRIPTION
This PR uses the in-development bindgen support for static inline functions (https://github.com/rust-lang/rust-bindgen/pull/2335) + an in-development boringssl patch (https://boringssl-review.googlesource.com/c/boringssl/+/56505) to allow using boringssl with rust-openssl without needing a .cargo/config override

This is not mergable as-is (requires a bindgen release + boringssl to merge my patch), putting this up for visibility only.