### PR TITLE
Enable HKDF support for BoringSSL

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -20,7 +20,7 @@ pub const EVP_PKEY_X448: c_int = NID_X448;
 pub const EVP_PKEY_ED448: c_int = NID_ED448;
 pub const EVP_PKEY_HMAC: c_int = NID_hmac;
 pub const EVP_PKEY_CMAC: c_int = NID_cmac;
-#[cfg(ossl110)]
+#[cfg(any(ossl110, boringssl))]
 pub const EVP_PKEY_HKDF: c_int = NID_hkdf;
 
 pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
@@ -188,13 +188,13 @@ pub const EVP_PKEY_CTRL_CIPHER: c_int = 12;
 
 pub const EVP_PKEY_ALG_CTRL: c_int = 0x1000;
 
-#[cfg(ossl111)]
+#[cfg(any(ossl111, boringssl))]
 pub const EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND: c_int = 0;
 
-#[cfg(ossl111)]
+#[cfg(any(ossl111, boringssl))]
 pub const EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY: c_int = 1;
 
-#[cfg(ossl111)]
+#[cfg(any(ossl111, boringssl))]
 pub const EVP_PKEY_HKDEF_MODE_EXPAND_ONLY: c_int = 2;
 
 #[cfg(ossl110)]
@@ -212,7 +212,7 @@ pub const EVP_PKEY_CTRL_HKDF_INFO: c_int = EVP_PKEY_ALG_CTRL + 6;
 #[cfg(ossl111)]
 pub const EVP_PKEY_CTRL_HKDF_MODE: c_int = EVP_PKEY_ALG_CTRL + 7;
 
-#[cfg(all(ossl111, not(ossl300)))]
+#[cfg(any(boringssl, all(ossl110, not(ossl300))))]
 pub unsafe fn EVP_PKEY_CTX_set_hkdf_mode(ctx: *mut EVP_PKEY_CTX, mode: c_int) -> c_int {
     EVP_PKEY_CTX_ctrl(
         ctx,
@@ -224,7 +224,7 @@ pub unsafe fn EVP_PKEY_CTX_set_hkdf_mode(ctx: *mut EVP_PKEY_CTX, mode: c_int) ->
     )
 }
 
-#[cfg(all(ossl110, not(ossl300)))]
+#[cfg(any(boringssl, all(ossl110, not(ossl300))))]
 pub unsafe fn EVP_PKEY_CTX_set_hkdf_md(ctx: *mut EVP_PKEY_CTX, md: *const EVP_MD) -> c_int {
     EVP_PKEY_CTX_ctrl(
         ctx,
@@ -236,7 +236,7 @@ pub unsafe fn EVP_PKEY_CTX_set_hkdf_md(ctx: *mut EVP_PKEY_CTX, md: *const EVP_MD
     )
 }
 
-#[cfg(all(ossl110, not(ossl300)))]
+#[cfg(any(boringssl, all(ossl110, not(ossl300))))]
 pub unsafe fn EVP_PKEY_CTX_set1_hkdf_salt(
     ctx: *mut EVP_PKEY_CTX,
     salt: *const u8,
@@ -252,7 +252,7 @@ pub unsafe fn EVP_PKEY_CTX_set1_hkdf_salt(
     )
 }
 
-#[cfg(all(ossl110, not(ossl300)))]
+#[cfg(any(boringssl, all(ossl110, not(ossl300))))]
 pub unsafe fn EVP_PKEY_CTX_set1_hkdf_key(
     ctx: *mut EVP_PKEY_CTX,
     key: *const u8,
@@ -268,7 +268,7 @@ pub unsafe fn EVP_PKEY_CTX_set1_hkdf_key(
     )
 }
 
-#[cfg(all(ossl110, not(ossl300)))]
+#[cfg(any(boringssl, all(ossl110, not(ossl300))))]
 pub unsafe fn EVP_PKEY_CTX_add1_hkdf_info(
     ctx: *mut EVP_PKEY_CTX,
     info: *const u8,

--- a/openssl/src/bio.rs
+++ b/openssl/src/bio.rs
@@ -25,7 +25,7 @@ impl<'a> MemBioSlice<'a> {
         let bio = unsafe {
             cvt_p(BIO_new_mem_buf(
                 buf.as_ptr() as *const _,
-                buf.len() as c_int,
+                buf.len() as crate::SLenType,
             ))?
         };
 
@@ -74,7 +74,7 @@ impl MemBio {
 }
 
 cfg_if! {
-    if #[cfg(ossl102)] {
+    if #[cfg(any(ossl102, boringssl))] {
         use ffi::BIO_new_mem_buf;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -239,7 +239,7 @@ where
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl270))] {
+    if #[cfg(any(ossl110, libressl270, boringssl))] {
         use ffi::{DH_set0_pqg, DH_get0_pqg, DH_get0_key, DH_set0_key};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -190,6 +190,11 @@ type LenType = libc::size_t;
 #[cfg(not(boringssl))]
 type LenType = libc::c_int;
 
+#[cfg(boringssl)]
+type SLenType = libc::ssize_t;
+#[cfg(not(boringssl))]
+type SLenType = libc::c_int;
+
 #[inline]
 fn cvt_p<T>(r: *mut T) -> Result<*mut T, ErrorStack> {
     if r.is_null() {

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -86,7 +86,7 @@ impl Id {
     pub const DH: Id = Id(ffi::EVP_PKEY_DH);
     pub const EC: Id = Id(ffi::EVP_PKEY_EC);
 
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, boringssl))]
     pub const HKDF: Id = Id(ffi::EVP_PKEY_HKDF);
 
     #[cfg(ossl111)]


### PR DESCRIPTION
Add support for HKDF via the PKey APIs. The usage of those and the test cases are the same as the ones currently with cfg(ossl111) on them.

Requires https://boringssl-review.googlesource.com/c/boringssl/+/57066