### PR TITLE
Fix cert verification failure tests

### DIFF
--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -490,6 +490,7 @@ fn test_verify_cert_with_wrong_purpose_fails() {
 
     let store = store_bldr.build();
 
+    let expected_error = ffi::X509_V_ERR_INVALID_PURPOSE;
     let mut context = X509StoreContext::new().unwrap();
     assert_eq!(
         context
@@ -498,8 +499,8 @@ fn test_verify_cert_with_wrong_purpose_fails() {
                 Ok(c.error())
             })
             .unwrap()
-            .error_string(),
-        "unsupported certificate purpose"
+            .as_raw(),
+        expected_error
     )
 }
 
@@ -828,7 +829,7 @@ fn test_set_purpose_fails_verification() {
     store_bldr.set_param(&verify_params).unwrap();
     let store = store_bldr.build();
 
-    let expected_error = "unsupported certificate purpose";
+    let expected_error = ffi::X509_V_ERR_INVALID_PURPOSE;
     let mut context = X509StoreContext::new().unwrap();
     assert_eq!(
         context
@@ -837,7 +838,7 @@ fn test_set_purpose_fails_verification() {
                 Ok(c.error())
             })
             .unwrap()
-            .error_string(),
+            .as_raw(),
         expected_error
     )
 }


### PR DESCRIPTION
This swaps the verification failure tests over from checking the error string to checking the error id against the constant exposed by openssl-sys to make the tests more reliable. This was required by the string changing in OpenSSL 3.0.8.

Fixes #1815 