### PR TITLE
Add SSL_CTX_set_num_tickets and friends

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -897,3 +897,17 @@ extern "C" {
     #[cfg(ossl110)]
     pub fn OPENSSL_init_ssl(opts: u64, settings: *const OPENSSL_INIT_SETTINGS) -> c_int;
 }
+
+extern "C" {
+    #[cfg(ossl111)]
+    pub fn SSL_CTX_set_num_tickets(ctx: *mut SSL_CTX, num_tickets: size_t) -> c_int;
+
+    #[cfg(ossl111)]
+    pub fn SSL_set_num_tickets(s: *mut SSL, num_tickets: size_t) -> c_int;
+
+    #[cfg(ossl111)]
+    pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> size_t;
+
+    #[cfg(ossl111)]
+    pub fn SSL_get_num_tickets(s: *const SSL) -> size_t;
+}

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1687,6 +1687,16 @@ impl SslContextBuilder {
         }
     }
 
+    /// Sets the number of TLS 1.3 session tickets that will be sent to a client after a full
+    /// handshake.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    #[corresponds(SSL_CTX_set_num_tickets)]
+    #[cfg(ossl111)]
+    pub fn set_num_tickets(&mut self, num_tickets: usize) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::SSL_CTX_set_num_tickets(self.as_ptr(), num_tickets)).map(|_| ()) }
+    }
+
     /// Consumes the builder, returning a new `SslContext`.
     pub fn build(self) -> SslContext {
         self.0
@@ -1879,6 +1889,16 @@ impl SslContextRef {
     pub fn verify_mode(&self) -> SslVerifyMode {
         let mode = unsafe { ffi::SSL_CTX_get_verify_mode(self.as_ptr()) };
         SslVerifyMode::from_bits(mode).expect("SSL_CTX_get_verify_mode returned invalid mode")
+    }
+
+    /// Gets the number of TLS 1.3 session tickets that will be sent to a client after a full
+    /// handshake.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    #[corresponds(SSL_CTX_get_num_tickets)]
+    #[cfg(ossl111)]
+    pub fn num_tickets(&self) -> usize {
+        unsafe { ffi::SSL_CTX_get_num_tickets(self.as_ptr()) }
     }
 }
 
@@ -3282,6 +3302,26 @@ impl SslRef {
             mem::forget(cert_store);
             Ok(())
         }
+    }
+
+    /// Sets the number of TLS 1.3 session tickets that will be sent to a client after a full
+    /// handshake.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    #[corresponds(SSL_set_num_tickets)]
+    #[cfg(ossl111)]
+    pub fn set_num_tickets(&mut self, num_tickets: usize) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::SSL_set_num_tickets(self.as_ptr(), num_tickets)).map(|_| ()) }
+    }
+
+    /// Gets the number of TLS 1.3 session tickets that will be sent to a client after a full
+    /// handshake.
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
+    #[corresponds(SSL_get_num_tickets)]
+    #[cfg(ossl111)]
+    pub fn num_tickets(&self) -> usize {
+        unsafe { ffi::SSL_get_num_tickets(self.as_ptr()) }
     }
 }
 

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1477,3 +1477,17 @@ fn test_ssl_set_cert_chain_file() {
     let mut ssl = Ssl::new(&ctx).unwrap();
     ssl.set_certificate_chain_file("test/cert.pem").unwrap();
 }
+
+#[test]
+#[cfg(ossl111)]
+fn set_num_tickets() {
+    let mut ctx = SslContext::builder(SslMethod::tls_server()).unwrap();
+    ctx.set_num_tickets(3).unwrap();
+    let ctx = ctx.build();
+    assert_eq!(3, ctx.num_tickets());
+
+    let mut ssl = Ssl::new(&ctx).unwrap();
+    ssl.set_num_tickets(5).unwrap();
+    let ssl = ssl;
+    assert_eq!(5, ssl.num_tickets());
+}


### PR DESCRIPTION
These are required to disable session tickets on TLS 1.3 connections.

Note that libressl added these functions in 3.5.2, but they are for compatibility only and have no effect, so I didn't include these definitions for libressl. Let me know if I should add support them too.