### PR TITLE
Add DTLS 1.2 support in newer releases of SSL libs.

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -712,8 +712,6 @@ extern "C" {
     pub fn DTLSv1_2_method() -> *const SSL_METHOD;
 }
 
-
-
 extern "C" {
     pub fn SSL_get_error(ssl: *const SSL, ret: c_int) -> c_int;
     pub fn SSL_get_version(ssl: *const SSL) -> *const c_char;

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -680,9 +680,6 @@ cfg_if! {
 
             pub fn TLS_client_method() -> *const SSL_METHOD;
 
-            // DTLS 1.2 support doesn't exist in LibresSSL 2.9.1
-            #[cfg(ossl110)]
-            pub fn DTLSv1_2_method() -> *const SSL_METHOD;
         }
     } else {
         extern "C" {
@@ -709,6 +706,13 @@ cfg_if! {
         }
     }
 }
+
+extern "C" {
+    #[cfg(ossl110)]
+    pub fn DTLSv1_2_method() -> *const SSL_METHOD;
+}
+
+
 
 extern "C" {
     pub fn SSL_get_error(ssl: *const SSL, ret: c_int) -> c_int;

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -679,6 +679,10 @@ cfg_if! {
             pub fn TLS_server_method() -> *const SSL_METHOD;
 
             pub fn TLS_client_method() -> *const SSL_METHOD;
+
+            // DTLS 1.2 support doesn't exist in LibresSSL 2.9.1
+            #[cfg(ossl110)]
+            pub fn DTLSv1_2_method() -> *const SSL_METHOD;
         }
     } else {
         extern "C" {
@@ -699,7 +703,8 @@ cfg_if! {
 
             pub fn DTLSv1_method() -> *const SSL_METHOD;
 
-            #[cfg(ossl102)]
+            // DTLS 1.2 support started in OpenSSL 1.0.2, LibreSSL 3.3.2
+            #[cfg(any(ossl102,libressl332))]
             pub fn DTLSv1_2_method() -> *const SSL_METHOD;
         }
     }


### PR DESCRIPTION
Both SSL 1.1/3.0 and LibreSSL 3.3.2 and up support the DTLS 1.2 methods.