### PR TITLE
Added support for building boringssl with bindgen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
             - false
           library:
             - name: boringssl
-              version: 5697a9202615925696f8dc7f4e286d44d474769e
+              version: 93e8d4463d59d671e9c5c6171226341f04b07907
             - name: openssl
               version: vendored
             - name: openssl
@@ -215,10 +215,6 @@ jobs:
               library:
                 name: libressl
                 version: 3.7.0
-          exclude:
-            - library:
-                name: boringssl
-              bindgen: true
       name: ${{ matrix.target }}-${{ matrix.library.name }}-${{ matrix.library.version }}-${{ matrix.bindgen }}
       runs-on: ubuntu-latest
       env:
@@ -311,16 +307,26 @@ jobs:
               make install_sw
               ;;
             "boringssl")
-              sed -i rust/CMakeLists.txt -e '1s%^%include_directories(../include)\n%'
-              cpu=`echo ${{ matrix.target }} | cut -d - -f 1`
+              mkdir build
+              cd build
+
               echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
               echo "set(CMAKE_SYSTEM_PROCESSOR $cpu)" >> toolchain.cmake
               echo "set(triple ${{ matrix.target }})" >> toolchain.cmake
               echo 'set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} '$OS_FLAGS '" CACHE STRING "c++ flags")' >> toolchain.cmake
               echo 'set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   '$OS_FLAGS '" CACHE STRING "c flags")' >> toolchain.cmake
               echo 'set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} '$OS_FLAGS '" CACHE STRING "asm flags")' >> toolchain.cmake
-              cmake -DRUST_BINDINGS="${{ matrix.target }}" -B $OPENSSL_DIR -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake
-              make -C $OPENSSL_DIR
+
+              cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DRUST_BINDINGS="${{ matrix.target }}" -DCMAKE_INSTALL_PREFIX="${OPENSSL_DIR}" -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake
+              make -j "$(nproc)"
+              make install
+
+              # Copy stuff around so it's all as the build system expects.
+              cp -r rust/ "$OPENSSL_DIR/rust"
+              mkdir -p "$OPENSSL_DIR/crypto/"
+              mkdir -p "$OPENSSL_DIR/ssl/"
+              cp "$OPENSSL_DIR/lib/libcrypto.a" "$OPENSSL_DIR/crypto/"
+              cp "$OPENSSL_DIR/lib/libssl.a" "$OPENSSL_DIR/ssl/"
             esac
 
           if: matrix.library.version != 'vendored' && !steps.openssl-cache.outputs.cache-hit
@@ -328,7 +334,7 @@ jobs:
             mkdir -p .cargo
             echo '[patch.crates-io]' > .cargo/config.toml
             echo 'bssl-sys = { path = "'$OPENSSL_DIR'/rust" }' >> .cargo/config.toml
-          if: matrix.library.name == 'boringssl'
+          if: matrix.library.name == 'boringssl' && !matrix.bindgen
         - uses: actions/cache@v3
           with:
             path: ~/.cargo/registry/index
@@ -350,14 +356,14 @@ jobs:
             if [[ "${{ matrix.library.version }}" == "vendored" ]]; then
               features="--features vendored"
             fi
-            if [[ "${{ matrix.bindgen }}" == "true" ]]; then
+            if [[ "${{ matrix.bindgen }}" == "true" && "${{ matrix.library.name }}" != "boringssl" ]]; then
               features="$features --features bindgen"
             fi
             cargo run --manifest-path=systest/Cargo.toml --target ${{ matrix.target }} $features
           if: matrix.library.name != 'boringssl'
         - name: Test openssl
           run: |
-            if [[ "${{ matrix.library.name }}" == "boringssl" ]]; then
+            if [[ "${{ matrix.library.name }}" == "boringssl" && "${{ matrix.bindgen }}" != "true" ]]; then
               features="--features unstable_boringssl"
             fi
             if [[ "${{ matrix.library.version }}" == "vendored" ]]; then

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2"
 bssl-sys = { version = "0.1.0", optional = true }
 
 [build-dependencies]
-bindgen = { version = "0.60.1", optional = true }
+bindgen = { version = "0.64.0", optional = true, features = ["experimental"] }
 cc = "1.0"
 openssl-src = { version = "111", optional = true }
 pkg-config = "0.3.9"

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -16,10 +16,24 @@
 extern crate libc;
 pub use libc::*;
 
-#[cfg(boringssl)]
+#[cfg(feature = "unstable_boringssl")]
 extern crate bssl_sys;
-#[cfg(boringssl)]
+#[cfg(feature = "unstable_boringssl")]
 pub use bssl_sys::*;
+
+#[cfg(all(boringssl, not(feature = "unstable_boringssl")))]
+#[path = "."]
+mod boringssl {
+    include!(concat!(env!("OUT_DIR"), "/bindgen.rs"));
+
+    pub fn init() {
+        unsafe {
+            CRYPTO_library_init();
+        }
+    }
+}
+#[cfg(all(boringssl, not(feature = "unstable_boringssl")))]
+pub use boringssl::*;
 
 #[cfg(openssl)]
 #[path = "."]

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -11,7 +11,7 @@ fn main() {
         println!("cargo:rustc-cfg=libressl");
     }
 
-    if env::var("CARGO_FEATURE_UNSTABLE_BORINGSSL").is_ok() {
+    if env::var("DEP_OPENSSL_BORINGSSL").is_ok() {
         println!("cargo:rustc-cfg=boringssl");
         return;
     }

--- a/openssl/src/bio.rs
+++ b/openssl/src/bio.rs
@@ -25,7 +25,7 @@ impl<'a> MemBioSlice<'a> {
         let bio = unsafe {
             cvt_p(BIO_new_mem_buf(
                 buf.as_ptr() as *const _,
-                buf.len() as c_int,
+                buf.len() as crate::SLenType,
             ))?
         };
 
@@ -74,7 +74,7 @@ impl MemBio {
 }
 
 cfg_if! {
-    if #[cfg(ossl102)] {
+    if #[cfg(any(ossl102, boringssl))] {
         use ffi::BIO_new_mem_buf;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -239,7 +239,7 @@ where
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl270))] {
+    if #[cfg(any(ossl110, libressl270, boringssl))] {
         use ffi::{DH_set0_pqg, DH_get0_pqg, DH_get0_key, DH_set0_key};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -190,6 +190,11 @@ type LenType = libc::size_t;
 #[cfg(not(boringssl))]
 type LenType = libc::c_int;
 
+#[cfg(boringssl)]
+type SLenType = libc::ssize_t;
+#[cfg(not(boringssl))]
+type SLenType = libc::c_int;
+
 #[inline]
 fn cvt_p<T>(r: *mut T) -> Result<*mut T, ErrorStack> {
     if r.is_null() {


### PR DESCRIPTION
This allows building it without the bssl-sys crate. This is an alternative approach to fixing #1768 (in contrast to #1806).

This maintains support for using the bssl-sys crate.