### PR TITLE
Recognise LibreSSL 3.7.x

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -285,6 +285,7 @@ See rust-openssl documentation for more information:
             (3, 6, 0) => ('3', '6', '0'),
             (3, 6, _) => ('3', '6', 'x'),
             (3, 7, 0) => ('3', '7', '0'),
+            (3, 7, _) => ('3', '7', 'x'),
             _ => version_error(),
         };
 
@@ -327,7 +328,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3.0.0), or LibreSSL 2.5
-through 3.7.0, but a different version of OpenSSL was found. The build is now aborting
+through 3.7.x, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "


### PR DESCRIPTION
OpenBSD 7.3-beta currently features LibreSSL 3.7.1.
I am not sure about the policy here, 3.7.1 is not "released" per se yet.
The odd OpenBSD releases are normally happening around May 1st (give or take a few weeks).
But anyway the uname has changed to 7.3-beta, which usually triggers testers to build stuff,
and currently Rust code using openssl-sys will fail to build, without this fix.