### PR TITLE
Fix LibreSSL version checking in openssl/

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -31,6 +31,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x2_09_01_00_0 {
             cfgs.push("libressl291");
         }
+        if libressl_version >= 0x3_01_00_00_0 {
+            cfgs.push("libressl310");
+        }
         if libressl_version >= 0x3_02_01_00_0 {
             cfgs.push("libressl321");
         }

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -16,8 +16,57 @@ fn main() {
         return;
     }
 
-    if let Ok(v) = env::var("DEP_OPENSSL_LIBRESSL_VERSION") {
-        println!("cargo:rustc-cfg=libressl{}", v);
+    if let Ok(v) = env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER") {
+        let version = u64::from_str_radix(&v, 16).unwrap();
+
+        if version >= 0x2_05_00_00_0 {
+            println!("cargo:rustc-cfg=libressl250");
+        }
+        if version >= 0x2_05_01_00_0 {
+            println!("cargo:rustc-cfg=libressl251");
+        }
+        if version >= 0x2_06_01_00_0 {
+            println!("cargo:rustc-cfg=libressl261");
+        }
+        if version >= 0x2_07_00_00_0 {
+            println!("cargo:rustc-cfg=libressl270");
+        }
+        if version >= 0x2_07_01_00_0 {
+            println!("cargo:rustc-cfg=libressl271");
+        }
+        if version >= 0x2_07_03_00_0 {
+            println!("cargo:rustc-cfg=libressl273");
+        }
+        if version >= 0x2_08_00_00_0 {
+            println!("cargo:rustc-cfg=libressl280");
+        }
+        if version >= 0x2_09_01_00_0 {
+            println!("cargo:rustc-cfg=libressl291");
+        }
+        if version >= 0x3_01_00_00_0 {
+            println!("cargo:rustc-cfg=libressl310");
+        }
+        if version >= 0x3_02_01_00_0 {
+            println!("cargo:rustc-cfg=libressl321");
+        }
+        if version >= 0x3_03_02_00_0 {
+            println!("cargo:rustc-cfg=libressl332");
+        }
+        if version >= 0x3_04_00_00_0 {
+            println!("cargo:rustc-cfg=libressl340");
+        }
+        if version >= 0x3_05_00_00_0 {
+            println!("cargo:rustc-cfg=libressl350");
+        }
+        if version >= 0x3_06_00_00_0 {
+            println!("cargo:rustc-cfg=libressl360");
+        }
+        if version >= 0x3_06_01_00_0 {
+            println!("cargo:rustc-cfg=libressl361");
+        }
+        if version >= 0x3_07_00_00_0 {
+            println!("cargo:rustc-cfg=libressl370");
+        }
     }
 
     if let Ok(vars) = env::var("DEP_OPENSSL_CONF") {

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -50,6 +50,9 @@ fn main() {
         if version >= 0x3_00_00_00_0 {
             println!("cargo:rustc-cfg=ossl300");
         }
+        if version >= 0x3_01_00_00_0 {
+            println!("cargo:rustc-cfg=ossl310");
+        }
     }
 
     if let Ok(version) = env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER") {

--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -401,9 +401,12 @@ cfg_if! {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(ossl310))]
     use crate::nid::Nid;
 
     #[test]
+    // Due to a bug in OpenSSL 3.1.0, this test can hang there. Skip for now.
+    #[cfg(not(ossl310))]
     fn test_error_library_code() {
         let stack = Nid::create("not-an-oid", "invalid", "invalid").unwrap_err();
         let errors = stack.errors();


### PR DESCRIPTION
Previously it only did exact version matching -- different from how OpenSSL worked, and causing it to make many APIs exposed only on a single version of LibreSSL. This fixes that, and in the process identifies a bug in openssl-sys.