### PR TITLE
Bump syn dep to 2

### DIFF
--- a/openssl-macros/Cargo.toml
+++ b/openssl-macros/Cargo.toml
@@ -11,4 +11,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["full"] }
+syn = { version = "2", features = ["full"] }


### PR DESCRIPTION
This avoids duplication of `syn` dependency in projects that use `serde` (which already did upgrade to syn 2).