### PR TITLE
Drop dependency on autocfg

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -27,7 +27,6 @@ bindgen = { version = "0.64.0", optional = true, features = ["experimental"] }
 cc = "1.0"
 openssl-src = { version = "111", optional = true }
 pkg-config = "0.3.9"
-autocfg = "1.0"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2.8"

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -4,7 +4,6 @@
     clippy::unusual_byte_groupings
 )]
 
-extern crate autocfg;
 #[cfg(feature = "bindgen")]
 extern crate bindgen;
 extern crate cc;
@@ -74,8 +73,6 @@ fn check_ssl_kind() {
 }
 
 fn main() {
-    check_rustc_versions();
-
     check_ssl_kind();
 
     let target = env::var("TARGET").unwrap();
@@ -131,14 +128,6 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=crypt32");
         println!("cargo:rustc-link-lib=dylib=ws2_32");
         println!("cargo:rustc-link-lib=dylib=advapi32");
-    }
-}
-
-fn check_rustc_versions() {
-    let cfg = autocfg::new();
-
-    if cfg.probe_rustc_version(1, 31) {
-        println!("cargo:rustc-cfg=const_fn");
     }
 }
 

--- a/openssl-sys/src/err.rs
+++ b/openssl-sys/src/err.rs
@@ -20,51 +20,47 @@ cfg_if! {
 
         pub const ERR_RFLAG_FATAL: c_ulong = 0x1 << ERR_RFLAGS_OFFSET;
 
-        const_fn! {
-            pub const fn ERR_SYSTEM_ERROR(errcode: c_ulong) -> bool {
-                errcode & ERR_SYSTEM_FLAG != 0
-            }
+        pub const fn ERR_SYSTEM_ERROR(errcode: c_ulong) -> bool {
+            errcode & ERR_SYSTEM_FLAG != 0
+        }
 
-            pub const fn ERR_GET_LIB(errcode: c_ulong) -> c_int {
-                // hacks since `if` isn't yet stable in const functions :(
-                ((ERR_LIB_SYS as c_ulong * (ERR_SYSTEM_ERROR(errcode) as c_ulong)) |
-                (((errcode >> ERR_LIB_OFFSET) & ERR_LIB_MASK) * (!ERR_SYSTEM_ERROR(errcode) as c_ulong))) as c_int
-            }
+        pub const fn ERR_GET_LIB(errcode: c_ulong) -> c_int {
+            // hacks since `if` isn't yet stable in const functions :(
+            ((ERR_LIB_SYS as c_ulong * (ERR_SYSTEM_ERROR(errcode) as c_ulong)) |
+            (((errcode >> ERR_LIB_OFFSET) & ERR_LIB_MASK) * (!ERR_SYSTEM_ERROR(errcode) as c_ulong))) as c_int
+        }
 
-            pub const fn ERR_GET_FUNC(_errcode: c_ulong) -> c_int {
-                0
-            }
+        pub const fn ERR_GET_FUNC(_errcode: c_ulong) -> c_int {
+            0
+        }
 
-            pub const fn ERR_GET_REASON(errcode: c_ulong) -> c_int {
-                // hacks since `if` isn't yet stable in const functions :(
-                ((ERR_LIB_SYS as c_ulong * (ERR_SYSTEM_ERROR(errcode) as c_ulong)) |
-                ((errcode & ERR_REASON_MASK) * (!ERR_SYSTEM_ERROR(errcode) as c_ulong))) as c_int
-            }
+        pub const fn ERR_GET_REASON(errcode: c_ulong) -> c_int {
+            // hacks since `if` isn't yet stable in const functions :(
+            ((ERR_LIB_SYS as c_ulong * (ERR_SYSTEM_ERROR(errcode) as c_ulong)) |
+            ((errcode & ERR_REASON_MASK) * (!ERR_SYSTEM_ERROR(errcode) as c_ulong))) as c_int
+        }
 
-            pub const fn ERR_PACK(lib: c_int, _func: c_int, reason: c_int) -> c_ulong {
-                ((lib as c_ulong & ERR_LIB_MASK) << ERR_LIB_OFFSET) |
-                (reason as c_ulong & ERR_REASON_MASK)
-            }
+        pub const fn ERR_PACK(lib: c_int, _func: c_int, reason: c_int) -> c_ulong {
+            ((lib as c_ulong & ERR_LIB_MASK) << ERR_LIB_OFFSET) |
+            (reason as c_ulong & ERR_REASON_MASK)
         }
     } else {
-        const_fn! {
-            pub const fn ERR_PACK(l: c_int, f: c_int, r: c_int) -> c_ulong {
-                ((l as c_ulong & 0x0FF) << 24) |
-                ((f as c_ulong & 0xFFF) << 12) |
-                (r as c_ulong & 0xFFF)
-            }
+        pub const fn ERR_PACK(l: c_int, f: c_int, r: c_int) -> c_ulong {
+            ((l as c_ulong & 0x0FF) << 24) |
+            ((f as c_ulong & 0xFFF) << 12) |
+            (r as c_ulong & 0xFFF)
+        }
 
-            pub const fn ERR_GET_LIB(l: c_ulong) -> c_int {
-                ((l >> 24) & 0x0FF) as c_int
-            }
+        pub const fn ERR_GET_LIB(l: c_ulong) -> c_int {
+            ((l >> 24) & 0x0FF) as c_int
+        }
 
-            pub const fn ERR_GET_FUNC(l: c_ulong) -> c_int {
-                ((l >> 12) & 0xFFF) as c_int
-            }
+        pub const fn ERR_GET_FUNC(l: c_ulong) -> c_int {
+            ((l >> 12) & 0xFFF) as c_int
+        }
 
-            pub const fn ERR_GET_REASON(l: c_ulong) -> c_int {
-                (l & 0xFFF) as c_int
-            }
+        pub const fn ERR_GET_REASON(l: c_ulong) -> c_int {
+            (l & 0xFFF) as c_int
         }
     }
 }

--- a/openssl-sys/src/macros.rs
+++ b/openssl-sys/src/macros.rs
@@ -70,24 +70,6 @@ macro_rules! stack {
     };
 }
 
-#[cfg(const_fn)]
-macro_rules! const_fn {
-    ($(pub const fn $name:ident($($arg:ident: $t:ty),*) -> $ret:ty $b:block)*) => {
-        $(
-            pub const fn $name($($arg: $t),*) -> $ret $b
-        )*
-    }
-}
-
-#[cfg(not(const_fn))]
-macro_rules! const_fn {
-    ($(pub const fn $name:ident($($arg:ident: $t:ty),*) -> $ret:ty $b:block)*) => {
-        $(
-            pub fn $name($($arg: $t),*) -> $ret $b
-        )*
-    }
-}
-
 // openssl changes `*mut` to `*const` in certain parameters in certain versions;
 // in C this is ABI and (mostly) API compatible.
 //


### PR DESCRIPTION
It's used to check for a Rust version well below our MSRV.