### PR TITLE
Bump LibreSSL to 3.7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
               bindgen: true
               library:
                 name: libressl
-                version: 3.7.1
+                version: 3.7.2
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:
@@ -191,7 +191,7 @@ jobs:
               bindgen: false
               library:
                 name: libressl
-                version: 3.7.1
+                version: 3.7.2
       name: ${{ matrix.target }}-${{ matrix.library.name }}-${{ matrix.library.version }}-${{ matrix.bindgen }}
       runs-on: ubuntu-latest
       env:

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -284,6 +284,7 @@ See rust-openssl documentation for more information:
             (3, 6, _) => ('3', '6', 'x'),
             (3, 7, 0) => ('3', '7', '0'),
             (3, 7, 1) => ('3', '7', '1'),
+            (3, 7, _) => ('3', '7', 'x'),
             _ => version_error(),
         };
 
@@ -326,7 +327,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3.0.0), or LibreSSL 2.5
-through 3.7.1, but a different version of OpenSSL was found. The build is now aborting
+through 3.7.x, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "


### PR DESCRIPTION
[3.7 series is now stable](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.7.2-relnotes.txt)