### PR TITLE
DTLS1 and DTLS1_2 SslVersion for set_min_proto_version()

### DIFF
--- a/openssl-sys/src/tls1.rs
+++ b/openssl-sys/src/tls1.rs
@@ -10,6 +10,9 @@ pub const TLS1_2_VERSION: c_int = 0x303;
 #[cfg(any(ossl111, libressl340))]
 pub const TLS1_3_VERSION: c_int = 0x304;
 
+pub const DTLS1_VERSION: c_int = 0xFEFF;
+pub const DTLS1_2_VERSION: c_int = 0xFEFD;
+
 pub const TLS1_AD_DECODE_ERROR: c_int = 50;
 pub const TLS1_AD_UNRECOGNIZED_NAME: c_int = 112;
 

--- a/openssl-sys/src/tls1.rs
+++ b/openssl-sys/src/tls1.rs
@@ -11,6 +11,7 @@ pub const TLS1_2_VERSION: c_int = 0x303;
 pub const TLS1_3_VERSION: c_int = 0x304;
 
 pub const DTLS1_VERSION: c_int = 0xFEFF;
+#[cfg(any(ossl102, libressl332))]
 pub const DTLS1_2_VERSION: c_int = 0xFEFD;
 
 pub const TLS1_AD_DECODE_ERROR: c_int = 50;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -644,6 +644,16 @@ impl SslVersion {
     /// Requires OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[cfg(any(ossl111, libressl340))]
     pub const TLS1_3: SslVersion = SslVersion(ffi::TLS1_3_VERSION);
+
+    /// DTLSv1.0
+    ///
+    /// DTLS 1.0 corresponds to TLS 1.1.
+    pub const DTLS1: SslVersion = SslVersion(ffi::DTLS1_VERSION);
+
+    /// DTLSv1.2
+    ///
+    /// DTLS 1.2 corresponds to TLS 1.2 to harmonize versions. There was never a DTLS 1.1.
+    pub const DTLS1_2: SslVersion = SslVersion(ffi::DTLS1_2_VERSION);
 }
 
 cfg_if! {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -653,6 +653,7 @@ impl SslVersion {
     /// DTLSv1.2
     ///
     /// DTLS 1.2 corresponds to TLS 1.2 to harmonize versions. There was never a DTLS 1.1.
+    #[cfg(any(ossl102, libressl332))]
     pub const DTLS1_2: SslVersion = SslVersion(ffi::DTLS1_2_VERSION);
 }
 


### PR DESCRIPTION
Expose constants to allow limiting the DTLS version.

The relevant openssl constants are taken from here: https://github.com/openssl/openssl/blob/418c6c520764491262018c45481a20ef10cd3bca/include/openssl/prov_ssl.h#L28-L29

The comment about there being no DTLS 1.1 is from the RFC: https://www.rfc-editor.org/rfc/rfc9147.html#name-introduction
