### PR TITLE
Documentation typo for X509Crl

### DIFF
--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1545,7 +1545,7 @@ foreign_type_and_impl_send_sync! {
     type CType = ffi::X509_REVOKED;
     fn drop = ffi::X509_REVOKED_free;
 
-    /// An `X509` certificate request.
+    /// An `X509` certificate revocation list.
     pub struct X509Revoked;
     /// Reference to `X509Crl`.
     pub struct X509RevokedRef;


### PR DESCRIPTION
Fixed x509Crl description from "a X509 certificate request" to "a X509 certificate revocation list"