### PR TITLE
Fix link errors for X509_get0_authority_xxx methods on Ubuntu/bionic

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -91,6 +91,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if openssl_version >= 0x1_01_01_03_0 {
             cfgs.push("ossl111c");
         }
+        if openssl_version >= 0x1_01_01_04_0 {
+            cfgs.push("ossl111d");
+        }
     }
 
     cfgs

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -905,9 +905,13 @@ extern "C" {
     #[cfg(ossl111)]
     pub fn SSL_set_num_tickets(s: *mut SSL, num_tickets: size_t) -> c_int;
 
-    #[cfg(ossl111)]
+    #[cfg(ossl111b)]
     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> size_t;
+    #[cfg(all(ossl111, not(ossl111b)))]
+    pub fn SSL_CTX_get_num_tickets(ctx: *mut SSL_CTX) -> size_t;
 
-    #[cfg(ossl111)]
+    #[cfg(ossl111b)]
     pub fn SSL_get_num_tickets(s: *const SSL) -> size_t;
+    #[cfg(all(ossl111, not(ossl111b)))]
+    pub fn SSL_get_num_tickets(s: *mut SSL) -> size_t;
 }

--- a/openssl-sys/src/handwritten/x509v3.rs
+++ b/openssl-sys/src/handwritten/x509v3.rs
@@ -106,9 +106,9 @@ extern "C" {
     pub fn X509_get0_subject_key_id(x: *mut X509) -> *const ASN1_OCTET_STRING;
     #[cfg(ossl110)]
     pub fn X509_get0_authority_key_id(x: *mut X509) -> *const ASN1_OCTET_STRING;
-    #[cfg(ossl111)]
+    #[cfg(ossl111d)]
     pub fn X509_get0_authority_issuer(x: *mut X509) -> *const stack_st_GENERAL_NAME;
-    #[cfg(ossl111)]
+    #[cfg(ossl111d)]
     pub fn X509_get0_authority_serial(x: *mut X509) -> *const ASN1_INTEGER;
 }
 

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -505,7 +505,7 @@ impl X509Ref {
 
     /// Returns this certificate's authority issuer name entries, if they exist.
     #[corresponds(X509_get0_authority_issuer)]
-    #[cfg(ossl111)]
+    #[cfg(ossl111d)]
     pub fn authority_issuer(&self) -> Option<&StackRef<GeneralName>> {
         unsafe {
             let stack = ffi::X509_get0_authority_issuer(self.as_ptr());
@@ -515,7 +515,7 @@ impl X509Ref {
 
     /// Returns this certificate's authority serial number, if it exists.
     #[corresponds(X509_get0_authority_serial)]
-    #[cfg(ossl111)]
+    #[cfg(ossl111d)]
     pub fn authority_serial(&self) -> Option<&Asn1IntegerRef> {
         unsafe {
             let r = ffi::X509_get0_authority_serial(self.as_ptr());

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -195,7 +195,7 @@ fn test_authority_key_id() {
 }
 
 #[test]
-#[cfg(ossl111)]
+#[cfg(ossl111d)]
 fn test_authority_issuer_and_serial() {
     let cert = include_bytes!("../../test/authority_key_identifier.pem");
     let cert = X509::from_pem(cert).unwrap();


### PR DESCRIPTION
The `X509_get0_authority_issuer` and `X509_get0_authority_serial` methods were introduced in OpenSSL version 1.1.1d which can cause linker errors when building for Ubuntu/bionic which provides OpenSSL 1.1.1 in the `bionic-updates` package suite.

See issue: #1908 