### PR TITLE
add X509::pathlen

### DIFF
--- a/openssl-sys/src/handwritten/x509v3.rs
+++ b/openssl-sys/src/handwritten/x509v3.rs
@@ -97,6 +97,8 @@ extern "C" {
     ) -> c_int;
 
     #[cfg(ossl110)]
+    pub fn X509_get_pathlen(x: *mut X509) -> c_long;
+    #[cfg(ossl110)]
     pub fn X509_get_extension_flags(x: *mut X509) -> u32;
     #[cfg(ossl110)]
     pub fn X509_get_key_usage(x: *mut X509) -> u32;

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -483,6 +483,14 @@ impl X509Ref {
         }
     }
 
+    /// Retrieves the path length extension from a certificate, if it exists.
+    #[corresponds(X509_get_pathlen)]
+    #[cfg(ossl110)]
+    pub fn pathlen(&self) -> Option<u32> {
+        let v = unsafe { ffi::X509_get_pathlen(self.as_ptr()) };
+        u32::try_from(v).ok()
+    }
+
     /// Returns this certificate's subject key id, if it exists.
     #[corresponds(X509_get0_subject_key_id)]
     #[cfg(ossl110)]

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -170,6 +170,22 @@ fn test_subject_alt_name() {
 
 #[test]
 #[cfg(ossl110)]
+fn test_retrieve_pathlen() {
+    let cert = include_bytes!("../../test/root-ca.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    assert_eq!(cert.pathlen(), None);
+
+    let cert = include_bytes!("../../test/intermediate-ca.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    assert_eq!(cert.pathlen(), Some(0));
+
+    let cert = include_bytes!("../../test/alt_name_cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    assert_eq!(cert.pathlen(), None);
+}
+
+#[test]
+#[cfg(ossl110)]
 fn test_subject_key_id() {
     let cert = include_bytes!("../../test/certv3.pem");
     let cert = X509::from_pem(cert).unwrap();


### PR DESCRIPTION
From https://www.openssl.org/docs/man1.1.1/man3/X509_get_pathlen.html.
Needed when handle intermediate CA cert.