### PR TITLE
Link README and Repo for openssl-macros

### DIFF
--- a/openssl-macros/Cargo.toml
+++ b/openssl-macros/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.1"
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "Internal macros used by the openssl crate."
+repository = "https://github.com/sfackler/rust-openssl"
+readme = "README.md"
 
 [lib]
 proc-macro = true

--- a/openssl-macros/README.md
+++ b/openssl-macros/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
Just adding some missing metadata that I noticed from the [openssl-macros crates.io page](https://crates.io/crates/openssl-macros/0.1.1). Follows the same technique used for the other crates in this workspace