### PR TITLE
Add bindings to SSL_bytes_to_cipher_list

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -648,6 +648,15 @@ extern "C" {
         num: size_t,
         readbytes: *mut size_t,
     ) -> c_int;
+    #[cfg(ossl111)]
+    pub fn SSL_bytes_to_cipher_list(
+        s: *mut SSL,
+        bytes: *const c_uchar,
+        len: size_t,
+        isv2format: c_int,
+        sk: *mut *mut stack_st_SSL_CIPHER,
+        scsvs: *mut *mut stack_st_SSL_CIPHER,
+    ) -> c_int;
 }
 
 extern "C" {

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1458,6 +1458,9 @@ fn client_hello() {
         assert!(ssl.client_hello_session_id().is_some());
         assert!(ssl.client_hello_ciphers().is_some());
         assert!(ssl.client_hello_compression_methods().is_some());
+        assert!(ssl
+            .bytes_to_ciphers_stack(ssl.client_hello_ciphers().unwrap(), ssl.client_hello_isv2())
+            .is_ok());
 
         CALLED_BACK.store(true, Ordering::SeqCst);
         Ok(ClientHelloResponse::SUCCESS)


### PR DESCRIPTION
I have a use case where I need to change the SSL context on the server side based on the supported cipher suite provided in the client hello callback. Without `SSL_bytes_to_cipher_list` support in rust-openssl, there really isn't a convenient way to handle the output from `client_hello_ciphers`, as the format is a real mess.