### PR TITLE
Fix some deprecated patterns when using BoringSSL

### DIFF
--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -738,7 +738,7 @@ impl fmt::Debug for Asn1ObjectRef {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273))] {
+    if #[cfg(any(ossl110, libressl273, boringssl))] {
         use ffi::ASN1_STRING_get0_data;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -7,6 +7,7 @@
 
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
+#[cfg(not(boringssl))]
 use libc::c_int;
 use std::fmt;
 use std::mem;
@@ -314,7 +315,7 @@ impl<T> fmt::Debug for Dsa<T> {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273))] {
+    if #[cfg(any(ossl110, libressl273, boringssl))] {
         use ffi::{DSA_get0_key, DSA_get0_pqg, DSA_set0_key, DSA_set0_pqg};
     } else {
         #[allow(bad_style)]
@@ -493,7 +494,7 @@ impl DsaSigRef {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273))] {
+    if #[cfg(any(ossl110, libressl273, boringssl))] {
         use ffi::{DSA_SIG_set0, DSA_SIG_get0};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/ecdsa.rs
+++ b/openssl/src/ecdsa.rs
@@ -110,7 +110,7 @@ impl EcdsaSigRef {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273))] {
+    if #[cfg(any(ossl110, libressl273, boringssl))] {
         use ffi::{ECDSA_SIG_set0, ECDSA_SIG_get0};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -43,7 +43,7 @@ use crate::nid::Nid;
 use crate::{cvt, cvt_p};
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, boringssl))] {
         use ffi::{EVP_MD_CTX_free, EVP_MD_CTX_new};
     } else {
         use ffi::{EVP_MD_CTX_create as EVP_MD_CTX_new, EVP_MD_CTX_destroy as EVP_MD_CTX_free};

--- a/openssl/src/md_ctx.rs
+++ b/openssl/src/md_ctx.rs
@@ -93,7 +93,7 @@ use std::convert::TryFrom;
 use std::ptr;
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, boringssl))] {
         use ffi::{EVP_MD_CTX_free, EVP_MD_CTX_new};
     } else {
         use ffi::{EVP_MD_CTX_create as EVP_MD_CTX_new, EVP_MD_CTX_destroy as EVP_MD_CTX_free};

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -581,7 +581,7 @@ impl<T> fmt::Debug for Rsa<T> {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273))] {
+    if #[cfg(any(ossl110, libressl273, boringssl))] {
         use ffi::{
             RSA_get0_key, RSA_get0_factors, RSA_get0_crt_params, RSA_set0_key, RSA_set0_factors,
             RSA_set0_crt_params,


### PR DESCRIPTION
The RSA and DSA changes will be needed to avoid build breakage soon. The others are mostly tidying up. There's another place around BIO that we'd ideally also switch over, but that depends on resolving the __fixed_rust mess first.

This addresses a symptom of #1944, but not the root cause.

(@maurer FYI. Android will need to pick this patch up to avoid causing another problem with BoringSSL updates.)