### PR TITLE
Pick up OPENSSL_NO_* with BoringSSL

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -226,6 +226,11 @@ See rust-openssl documentation for more information:
         }
     }
 
+    for enabled in &enabled {
+        println!("cargo:rustc-cfg=osslconf=\"{}\"", enabled);
+    }
+    println!("cargo:conf={}", enabled.join(","));
+
     if is_boringssl {
         println!("cargo:rustc-cfg=boringssl");
         println!("cargo:boringssl=true");
@@ -235,11 +240,6 @@ See rust-openssl documentation for more information:
 
     // We set this for any non-BoringSSL lib.
     println!("cargo:rustc-cfg=openssl");
-
-    for enabled in &enabled {
-        println!("cargo:rustc-cfg=osslconf=\"{}\"", enabled);
-    }
-    println!("cargo:conf={}", enabled.join(","));
 
     for cfg in cfgs::get(openssl_version, libressl_version) {
         println!("cargo:rustc-cfg={}", cfg);

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -13,7 +13,6 @@ fn main() {
 
     if env::var("DEP_OPENSSL_BORINGSSL").is_ok() {
         println!("cargo:rustc-cfg=boringssl");
-        return;
     }
 
     if let Ok(v) = env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER") {

--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -329,52 +329,52 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_rc4() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia128_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_128_cfb128() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia128_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_128_ecb() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia192_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_192_cfb128() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia192_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_192_ecb() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia256_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_256_cfb128() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia256_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_256_ecb() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAST")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
     pub fn cast5_cfb64() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_cast5_cfb64() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAST")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
     pub fn cast5_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_cast5_ecb() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_IDEA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
     pub fn idea_cfb64() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_idea_cfb64() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_IDEA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
     pub fn idea_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_idea_ecb() as *mut _) }
     }

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -187,7 +187,7 @@ impl EcGroupRef {
     /// a term in the polynomial.  It will be set to 3 `1`s or 5 `1`s depending on
     /// using a trinomial or pentanomial.
     #[corresponds(EC_GROUP_get_curve_GF2m)]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_EC2M")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn components_gf2m(
         &self,
         p: &mut BigNumRef,
@@ -552,7 +552,7 @@ impl EcPointRef {
     /// Places affine coordinates of a curve over a binary field in the provided
     /// `x` and `y` `BigNum`s
     #[corresponds(EC_POINT_get_affine_coordinates_GF2m)]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_EC2M")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn affine_coordinates_gf2m(
         &self,
         group: &EcGroupRef,
@@ -1255,7 +1255,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_EC2M")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     fn is_on_curve() {
         let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
         let mut ctx = BigNumContext::new().unwrap();

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -157,7 +157,7 @@ impl MessageDigest {
         unsafe { MessageDigest(ffi::EVP_shake256()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_RMD160")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_RMD160"))]
     pub fn ripemd160() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_ripemd160()) }
     }

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -140,7 +140,7 @@ pub mod base64;
 pub mod bn;
 pub mod cipher;
 pub mod cipher_ctx;
-#[cfg(all(not(boringssl), not(libressl), not(osslconf = "OPENSSL_NO_CMS")))]
+#[cfg(all(not(libressl), not(osslconf = "OPENSSL_NO_CMS")))]
 pub mod cms;
 pub mod conf;
 pub mod derive;
@@ -162,7 +162,7 @@ pub mod md;
 pub mod md_ctx;
 pub mod memcmp;
 pub mod nid;
-#[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_OCSP")))]
+#[cfg(not(osslconf = "OPENSSL_NO_OCSP"))]
 pub mod ocsp;
 pub mod pkcs12;
 pub mod pkcs5;

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -252,12 +252,12 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_bf_ecb()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_BF")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
     pub fn bf_cfb64() -> Cipher {
         unsafe { Cipher(ffi::EVP_bf_cfb64()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_BF")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
     pub fn bf_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_bf_ofb()) }
     }
@@ -300,22 +300,22 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_chacha20_poly1305()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
     pub fn seed_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_cbc()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
     pub fn seed_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_cfb128()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
     pub fn seed_ecb() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_ecb()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
     pub fn seed_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_ofb()) }
     }
@@ -1534,7 +1534,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED", ossl300)))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
     fn test_seed_cbc() {
         #[cfg(ossl300)]
         let _provider = crate::provider::Provider::try_load(None, "legacy", true).unwrap();
@@ -1548,7 +1548,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED", ossl300)))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
     fn test_seed_cfb128() {
         #[cfg(ossl300)]
         let _provider = crate::provider::Provider::try_load(None, "legacy", true).unwrap();
@@ -1562,7 +1562,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED", ossl300)))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
     fn test_seed_ecb() {
         #[cfg(ossl300)]
         let _provider = crate::provider::Provider::try_load(None, "legacy", true).unwrap();
@@ -1576,7 +1576,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED", ossl300)))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
     fn test_seed_ofb() {
         #[cfg(ossl300)]
         let _provider = crate::provider::Provider::try_load(None, "legacy", true).unwrap();


### PR DESCRIPTION
This PR is (I expect) *not* yet ready to merge. It probably breaks the bssl-sys path, which unfortunately diverges even further from upstream BoringSSL's supported path than the bindgen path. (Android's rust-openssl story was, alas, not set up with a clear enough understanding of BoringSSL's needs. CC @maurer) I suspect we'll need to figure out a cleaner story for how cfg options flow from C libraries up through to crates that use them.

In the meantime, I've uploaded this for reference and to confirm that other configurations work in CI the way I expect them to.

---

BoringSSL defines OpenSSL-compatible OPENSSL_NO_* values to aid porting. This removes a ton of boringssl cfg lines that weren't actually necessary. This addresses part of issue #1944, though not the version number half.