### PR TITLE
Use type-safe wrappers instead of EVP_PKEY_assign

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -285,3 +285,19 @@ pub unsafe fn EVP_PKEY_CTX_add1_hkdf_info(
         info as *mut c_void,
     )
 }
+
+pub unsafe fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, rsa: *mut RSA) -> c_int {
+    EVP_PKEY_assign(pkey, EVP_PKEY_RSA, rsa as *mut c_void)
+}
+
+pub unsafe fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, dsa: *mut DSA) -> c_int {
+    EVP_PKEY_assign(pkey, EVP_PKEY_DSA, dsa as *mut c_void)
+}
+
+pub unsafe fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, dh: *mut DH) -> c_int {
+    EVP_PKEY_assign(pkey, EVP_PKEY_DH, dh as *mut c_void)
+}
+
+pub unsafe fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, ec_key: *mut EC_KEY) -> c_int {
+    EVP_PKEY_assign(pkey, EVP_PKEY_EC, ec_key as *mut c_void)
+}

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -406,11 +406,7 @@ impl<T> PKey<T> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
             let pkey = PKey::from_ptr(evp);
-            cvt(ffi::EVP_PKEY_assign(
-                pkey.0,
-                ffi::EVP_PKEY_RSA,
-                rsa.as_ptr() as *mut _,
-            ))?;
+            cvt(ffi::EVP_PKEY_assign_RSA(pkey.0, rsa.as_ptr()))?;
             mem::forget(rsa);
             Ok(pkey)
         }
@@ -422,11 +418,7 @@ impl<T> PKey<T> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
             let pkey = PKey::from_ptr(evp);
-            cvt(ffi::EVP_PKEY_assign(
-                pkey.0,
-                ffi::EVP_PKEY_DSA,
-                dsa.as_ptr() as *mut _,
-            ))?;
+            cvt(ffi::EVP_PKEY_assign_DSA(pkey.0, dsa.as_ptr()))?;
             mem::forget(dsa);
             Ok(pkey)
         }
@@ -434,15 +426,12 @@ impl<T> PKey<T> {
 
     /// Creates a new `PKey` containing a Diffie-Hellman key.
     #[corresponds(EVP_PKEY_assign_DH)]
+    #[cfg(not(boringssl))]
     pub fn from_dh(dh: Dh<T>) -> Result<PKey<T>, ErrorStack> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
             let pkey = PKey::from_ptr(evp);
-            cvt(ffi::EVP_PKEY_assign(
-                pkey.0,
-                ffi::EVP_PKEY_DH,
-                dh.as_ptr() as *mut _,
-            ))?;
+            cvt(ffi::EVP_PKEY_assign_DH(pkey.0, dh.as_ptr()))?;
             mem::forget(dh);
             Ok(pkey)
         }
@@ -454,11 +443,7 @@ impl<T> PKey<T> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
             let pkey = PKey::from_ptr(evp);
-            cvt(ffi::EVP_PKEY_assign(
-                pkey.0,
-                ffi::EVP_PKEY_EC,
-                ec_key.as_ptr() as *mut _,
-            ))?;
+            cvt(ffi::EVP_PKEY_assign_EC_KEY(pkey.0, ec_key.as_ptr()))?;
             mem::forget(ec_key);
             Ok(pkey)
         }
@@ -861,6 +846,7 @@ impl<T> TryFrom<PKey<T>> for Dsa<T> {
     }
 }
 
+#[cfg(not(boringssl))]
 impl<T> TryFrom<Dh<T>> for PKey<T> {
     type Error = ErrorStack;
 


### PR DESCRIPTION
In OpenSSL, these are macros, so they didn't get imported by bindgen, but they're proper functions in BoringSSL and we'd prefer callers use those for safety. For OpenSSL, just add the corresponding functions in openssl-sys, matching how rust-openssl handles EVP_PKEY_CTX_ctrl.

Using the type-safe wrappers flags that rust-openssl was trying to convert DH to EVP_PKEY, but BoringSSL doesn't actually support this. (DH is a legacy primitive, so we haven't routed it to EVP_PKEY right now.)