### PR TITLE
bn: Add mod_sqrt

### DIFF
--- a/openssl-sys/src/handwritten/bn.rs
+++ b/openssl-sys/src/handwritten/bn.rs
@@ -73,6 +73,13 @@ extern "C" {
         m: *const BIGNUM,
         ctx: *mut BN_CTX,
     ) -> c_int;
+    #[cfg(ossl110)]
+    pub fn BN_mod_sqrt(
+        ret: *mut BIGNUM,
+        a: *const BIGNUM,
+        p: *const BIGNUM,
+        ctx: *mut BN_CTX,
+    ) -> *mut BIGNUM;
 
     pub fn BN_mod_word(r: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
     pub fn BN_div_word(r: *mut BIGNUM, w: BN_ULONG) -> BN_ULONG;

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -639,6 +639,26 @@ impl BigNumRef {
         }
     }
 
+    /// Places into `self` the modular square root of `a` such that `self^2 = a (mod p)`
+    #[corresponds(BN_mod_sqrt)]
+    #[cfg(ossl110)]
+    pub fn mod_sqrt(
+        &mut self,
+        a: &BigNumRef,
+        p: &BigNumRef,
+        ctx: &mut BigNumContextRef,
+    ) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt_p(ffi::BN_mod_sqrt(
+                self.as_ptr(),
+                a.as_ptr(),
+                p.as_ptr(),
+                ctx.as_ptr(),
+            ))
+            .map(|_| ())
+        }
+    }
+
     /// Places the result of `a^p` in `self`.
     #[corresponds(BN_exp)]
     pub fn exp(

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -1475,4 +1475,17 @@ mod tests {
         b.set_const_time();
         assert!(b.is_const_time())
     }
+
+    #[cfg(ossl110)]
+    #[test]
+    fn test_mod_sqrt() {
+        let mut ctx = BigNumContext::new().unwrap();
+
+        let s = BigNum::from_hex_str("47A8DD7626B9908C80ACD7E0D3344D69").unwrap();
+        let p = BigNum::from_hex_str("81EF47265B58BCE5").unwrap();
+        let mut out = BigNum::new().unwrap();
+
+        out.mod_sqrt(&s, &p, &mut ctx).unwrap();
+        assert_eq!(out, BigNum::from_hex_str("7C6D179E19B97BDD").unwrap());
+    }
 }


### PR DESCRIPTION
This is a naive implementation of `mod_sqrt` for BigNum. The [docs for OpenSSL](https://www.openssl.org/docs/man1.1.1/man3/BN_mod_sqrt.html) say `BN_mod_sqrt` allocates a new BIGNUM for the return value, but the code suggests this is only the case when `in` is `NULL`. Otherwise, it seems to operate on `in` directly.

I needed this for a project and thought I'd submit what I came up with.