### PR TITLE
Add SSL_CTX_sess_number and friends

### DIFF
--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -321,6 +321,18 @@ pub const SSL_CTRL_SET_TMP_ECDH: c_int = 4;
 pub const SSL_CTRL_GET_SESSION_REUSED: c_int = 8;
 pub const SSL_CTRL_EXTRA_CHAIN_CERT: c_int = 14;
 pub const SSL_CTRL_SET_MTU: c_int = 17;
+pub const SSL_CTRL_SESS_NUMBER: c_int = 20;
+pub const SSL_CTRL_SESS_CONNECT: c_int = 21;
+pub const SSL_CTRL_SESS_CONNECT_GOOD: c_int = 22;
+pub const SSL_CTRL_SESS_CONNECT_RENEGOTIATE: c_int = 23;
+pub const SSL_CTRL_SESS_ACCEPT: c_int = 24;
+pub const SSL_CTRL_SESS_ACCEPT_GOOD: c_int = 25;
+pub const SSL_CTRL_SESS_ACCEPT_RENEGOTIATE: c_int = 26;
+pub const SSL_CTRL_SESS_HIT: c_int = 27;
+pub const SSL_CTRL_SESS_CB_HIT: c_int = 28;
+pub const SSL_CTRL_SESS_MISSES: c_int = 29;
+pub const SSL_CTRL_SESS_TIMEOUTS: c_int = 30;
+pub const SSL_CTRL_SESS_CACHE_FULL: c_int = 31;
 #[cfg(any(libressl, all(ossl101, not(ossl110))))]
 pub const SSL_CTRL_OPTIONS: c_int = 32;
 pub const SSL_CTRL_MODE: c_int = 33;
@@ -554,6 +566,54 @@ pub unsafe fn SSL_CTX_sess_set_cache_size(ctx: *mut SSL_CTX, t: c_long) -> c_lon
 
 pub unsafe fn SSL_CTX_sess_get_cache_size(ctx: *mut SSL_CTX) -> c_long {
     SSL_CTX_ctrl(ctx, SSL_CTRL_GET_SESS_CACHE_SIZE, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_number(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_NUMBER, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_connect(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_CONNECT, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_connect_good(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_CONNECT_GOOD, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_connect_renegotiate(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_CONNECT_RENEGOTIATE, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_accept(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_ACCEPT, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_accept_good(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_ACCEPT_GOOD, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_accept_renegotiate(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_ACCEPT_RENEGOTIATE, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_hits(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_HIT, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_cb_hits(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_CB_HIT, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_misses(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_MISSES, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_timeouts(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_TIMEOUTS, 0, ptr::null_mut())
+}
+
+pub unsafe fn SSL_CTX_sess_cache_full(ctx: *mut SSL_CTX) -> c_long {
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SESS_CACHE_FULL, 0, ptr::null_mut())
 }
 
 pub unsafe fn SSL_CTX_set_session_cache_mode(ctx: *mut SSL_CTX, m: c_long) -> c_long {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1911,6 +1911,80 @@ impl SslContextRef {
     pub fn num_tickets(&self) -> usize {
         unsafe { ffi::SSL_CTX_get_num_tickets(self.as_ptr()) }
     }
+
+    /// Gets the current number of sessions in the internal session cache.
+    #[corresponds(SSL_CTX_sess_number)]
+    pub fn get_session_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_number(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of started SSL/TLS handshakes in client mode
+    #[corresponds(SSL_CTX_sess_connect)]
+    pub fn get_connect_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_connect(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of successfully established SSL/TLS handshakes in client mode
+    #[corresponds(SSL_CTX_sess_connect_good)]
+    pub fn get_connect_good_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_connect_good(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of started renegotiations in client mode
+    #[corresponds(SSL_CTX_sess_connect_renegotiate)]
+    pub fn get_connect_renegotiate_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_connect_renegotiate(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of started SSL/TLS handshakes in server mode
+    #[corresponds(SSL_CTX_sess_accept)]
+    pub fn get_accept_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_accept(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of successfully established SSL/TLS handshakes in server mode
+    #[corresponds(SSL_CTX_sess_accept_good)]
+    pub fn get_accept_good_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_accept_good(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of started renegotiations in server mode
+    #[corresponds(SSL_CTX_sess_accept_renegotiate)]
+    pub fn get_accept_renegotiate_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_accept_renegotiate(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of successfully reused sessions
+    #[corresponds(SSL_CTX_sess_hits)]
+    pub fn get_session_hits_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_hits(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of successfully reused sessions from the external cache in server mode
+    #[corresponds(SSL_CTX_sess_cb_hits)]
+    pub fn get_session_callback_hits_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_cb_hits(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of sessions proposed by clients that were not found in the internal session
+    /// in server mode
+    #[corresponds(SSL_CTX_sess_misses)]
+    pub fn get_session_misses_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_misses(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of sessions proposed by clients that were found in the session cache but
+    /// were invalid due to a timeout
+    #[corresponds(SSL_CTX_sess_timeouts)]
+    pub fn get_session_timeouts_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_timeouts(self.as_ptr()) as i64 }
+    }
+
+    /// Gets the number of sessions removed because the maximum session cache size was exceeded
+    #[corresponds(SSL_CTX_sess_cache_full)]
+    pub fn get_session_cache_full_count(&self) -> i64 {
+        unsafe { ffi::SSL_CTX_sess_cache_full(self.as_ptr()) as i64 }
+    }
 }
 
 /// Information about the state of a cipher.

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1462,6 +1462,20 @@ fn client_hello() {
             .bytes_to_cipher_list(ssl.client_hello_ciphers().unwrap(), ssl.client_hello_isv2())
             .is_ok());
 
+        let context = ssl.ssl_context();
+        assert_eq!(0, context.get_session_count());
+        assert_eq!(0, context.get_connect_count());
+        assert_eq!(0, context.get_connect_good_count());
+        assert_eq!(0, context.get_connect_renegotiate_count());
+        assert_eq!(1, context.get_accept_count());
+        assert_eq!(0, context.get_accept_good_count());
+        assert_eq!(0, context.get_accept_renegotiate_count());
+        assert_eq!(0, context.get_session_hits_count());
+        assert_eq!(0, context.get_session_callback_hits_count());
+        assert_eq!(0, context.get_session_misses_count());
+        assert_eq!(0, context.get_session_timeouts_count());
+        assert_eq!(0, context.get_session_cache_full_count());
+
         CALLED_BACK.store(true, Ordering::SeqCst);
         Ok(ClientHelloResponse::SUCCESS)
     });


### PR DESCRIPTION
From https://www.openssl.org/docs/manmaster/man3/SSL_CTX_sess_number.html

These allow inspection of statistics for the internal and external session cache and the number of connections started, completed, and renegotiated for servers and clients.