### PR TITLE
Allow running vcpkg on any Windows target

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -27,8 +27,6 @@ bindgen = { version = "0.64.0", optional = true, features = ["experimental"] }
 cc = "1.0.61"
 openssl-src = { version = "111", optional = true }
 pkg-config = "0.3.9"
-
-[target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2.8"
 
 # We don't actually use metadeps for annoying reasons but this is still here for tooling

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -232,8 +232,12 @@ fn try_pkg_config() {
 ///
 /// Note that if this succeeds then the function does not return as vcpkg
 /// should emit all of the cargo metadata that we need.
-#[cfg(target_env = "msvc")]
 fn try_vcpkg() {
+    let target = env::var("TARGET").unwrap();
+    if !target.contains("windows") {
+        return;
+    }
+
     // vcpkg will not emit any metadata if it can not find libraries
     // appropriate for the target triple with the desired linkage.
 
@@ -256,9 +260,6 @@ fn try_vcpkg() {
 
     process::exit(0);
 }
-
-#[cfg(not(target_env = "msvc"))]
-fn try_vcpkg() {}
 
 fn execute_command_and_get_output(cmd: &str, args: &[&str]) -> Option<String> {
     let out = Command::new(cmd).args(args).output();

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -4,7 +4,6 @@ extern crate cc;
 #[cfg(feature = "vendored")]
 extern crate openssl_src;
 extern crate pkg_config;
-#[cfg(target_env = "msvc")]
 extern crate vcpkg;
 
 use std::collections::HashSet;


### PR DESCRIPTION
`vcpkg-rs` doesn't support `-pc-windows-gnu` (mingw) _yet_, but its integration tests will try to build `openssl-sys`, which currently prevents using `vcpkg` for non-`msvc` targets.

This change should have no effect for `openssl-sys` right now, but [unblocks that work](https://github.com/mcgoo/vcpkg-rs/pull/52).