### PR TITLE
Allow running pkg-config when targetting windows from non-windows hosts

### DIFF
--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -196,15 +196,13 @@ https://github.com/sfackler/rust-openssl#windows
 /// typically tells us all the information that we need.
 fn try_pkg_config() {
     let target = env::var("TARGET").unwrap();
-    let host = env::var("HOST").unwrap();
 
-    // If we're going to windows-gnu we can use pkg-config, but only so long as
-    // we're coming from a windows host.
-    //
-    // Otherwise if we're going to windows we probably can't use pkg-config.
-    if target.contains("windows-gnu") && host.contains("windows") {
+    // If we're using mingw (windows-gnu*), we can use pkg-config, but we need
+    // to allow mismatched host/target.
+    if target.contains("windows-gnu") {
         env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
     } else if target.contains("windows") {
+        // MSVC targets use vcpkg instead.
         return;
     }
 


### PR DESCRIPTION
FIxes #1984 

Unfortunately, the cross-compile tests in CI don't actually use `pkgconfig` at all, because they set `OPENSSL_DIR`:

https://github.com/sfackler/rust-openssl/blob/0f0bbe42bcfe817bb943e3ed36efee9a875c8458/.github/workflows/ci.yml#L209

Testing on a macOS host with `PKG_CONFIG_PATH_x86_64_pc_windows_gnu` pointing at a `vcpkg`-installed version of OpenSSL:

```
% CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine64 cargo test --target x86_64-pc-windows-gnu         
   Compiling openssl-sys v0.9.90 (~/rust-openssl/openssl-sys)
   Compiling openssl v0.10.55 (~/rust-openssl/openssl)
    Finished test [unoptimized + debuginfo] target(s) in 6.92s
     Running unittests src/lib.rs (~/rust-openssl/target/x86_64-pc-windows-gnu/debug/deps/openssl-48026ed6f097cb90.exe)
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
007c:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
007c:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
007c:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
007c:fixme:hid:handle_IRP_MN_QUERY_ID Unhandled type 00000005
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000
preloader: Warning: failed to reserve range 0000000000010000-0000000000110000

running 370 tests
[snip]

test result: ok. 364 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 3.50s
```