### PR TITLE
Add OpenSSL TLS 1.3 PSK callbacks

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -390,6 +390,50 @@ extern "C" {
 
 extern "C" {
     #[cfg(ossl111)]
+    pub fn SSL_CTX_set_psk_find_session_callback(
+        ctx: *mut SSL_CTX,
+        psk_find_session_cb: Option<
+            extern "C" fn(*mut SSL, *const c_uchar, size_t, *mut *mut SSL_SESSION) -> c_int,
+        >,
+    );
+
+    #[cfg(ossl111)]
+    pub fn SSL_set_psk_find_session_callback(
+        ssl: *mut SSL,
+        psk_find_session_cb: Option<
+            extern "C" fn(*mut SSL, *const c_uchar, size_t, *mut *mut SSL_SESSION) -> c_int,
+        >,
+    );
+
+    #[cfg(ossl111)]
+    pub fn SSL_CTX_set_psk_use_session_callback(
+        ctx: *mut SSL_CTX,
+        psk_use_session_cb: Option<
+            extern "C" fn(
+                *mut SSL,
+                *const EVP_MD,
+                *mut *const c_uchar,
+                *mut size_t,
+                *mut *mut SSL_SESSION,
+            ) -> c_int,
+        >,
+    );
+
+    #[cfg(ossl111)]
+    pub fn SSL_set_psk_use_session_callback(
+        ctx: *mut SSL,
+        psk_use_session_cb: Option<
+            extern "C" fn(
+                *mut SSL,
+                *const EVP_MD,
+                *mut *const c_uchar,
+                *mut size_t,
+                *mut *mut SSL_SESSION,
+            ) -> c_int,
+        >,
+    );
+
+    #[cfg(ossl111)]
     pub fn SSL_CTX_add_custom_ext(
         ctx: *mut SSL_CTX,
         ext_type: c_uint,
@@ -476,6 +520,7 @@ const_ptr_api! {
     }
 }
 extern "C" {
+    pub fn SSL_CIPHER_find(ssl: *mut SSL, ptr: *const c_uchar) -> *const SSL_CIPHER;
     #[cfg(ossl111)]
     pub fn SSL_CIPHER_get_handshake_digest(cipher: *const SSL_CIPHER) -> *const EVP_MD;
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const c_char;
@@ -531,10 +576,13 @@ extern "C" {
     pub fn SSL_state_string(ssl: *const SSL) -> *const c_char;
     pub fn SSL_state_string_long(ssl: *const SSL) -> *const c_char;
 
+    pub fn SSL_SESSION_new() -> *mut SSL_SESSION;
     pub fn SSL_SESSION_get_time(s: *const SSL_SESSION) -> c_long;
     pub fn SSL_SESSION_get_timeout(s: *const SSL_SESSION) -> c_long;
     #[cfg(any(ossl110, libressl270))]
     pub fn SSL_SESSION_get_protocol_version(s: *const SSL_SESSION) -> c_int;
+    #[cfg(ossl111)]
+    pub fn SSL_SESSION_set_protocol_version(s: *mut SSL_SESSION, version: c_int) -> c_int;
 
     #[cfg(any(ossl111, libressl340))]
     pub fn SSL_SESSION_set_max_early_data(ctx: *mut SSL_SESSION, max_early_data: u32) -> c_int;
@@ -787,6 +835,17 @@ extern "C" {
         out: *mut c_uchar,
         outlen: size_t,
     ) -> size_t;
+    #[cfg(any(ossl110, libressl273))]
+    pub fn SSL_SESSION_set1_master_key(
+        session: *mut SSL_SESSION,
+        key: *const c_uchar,
+        key_len: size_t,
+    ) -> c_int;
+
+    #[cfg(any(ossl110))]
+    pub fn SSL_SESSION_get0_cipher(session: *const SSL_SESSION) -> *const SSL_CIPHER;
+    #[cfg(any(ossl111))]
+    pub fn SSL_SESSION_set_cipher(session: *mut SSL_SESSION, cipher: *const SSL_CIPHER) -> c_int;
 }
 
 extern "C" {

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -135,6 +135,198 @@ where
     }
 }
 
+#[cfg(ossl111)]
+pub extern "C" fn raw_ssl_ctx_psk_find_session<F>(
+    ssl: *mut ffi::SSL,
+    identity: *const c_uchar,
+    identity_len: size_t,
+    session: *mut *mut ffi::SSL_SESSION,
+) -> c_int
+where
+    F: Fn(&mut SslRef, &[u8]) -> Result<Option<SslSession>, ErrorStack> + 'static + Sync + Send,
+{
+    unsafe {
+        let ssl = SslRef::from_ptr_mut(ssl);
+        let callback_idx = SslContext::cached_ex_index::<F>();
+
+        let callback = ssl
+            .ssl_context()
+            .ex_data(callback_idx)
+            .expect("BUG: psk find session callback missing") as *const F;
+
+        raw_psk_find_session(callback, ssl, identity, identity_len, session)
+    }
+}
+
+#[cfg(ossl111)]
+pub extern "C" fn raw_ssl_psk_find_session<F>(
+    ssl: *mut ffi::SSL,
+    identity: *const c_uchar,
+    identity_len: size_t,
+    session: *mut *mut ffi::SSL_SESSION,
+) -> c_int
+where
+    F: Fn(&mut SslRef, &[u8]) -> Result<Option<SslSession>, ErrorStack> + 'static + Sync + Send,
+{
+    unsafe {
+        let ssl = SslRef::from_ptr_mut(ssl);
+        let callback_idx = Ssl::cached_ex_index::<F>();
+
+        let callback = ssl
+            .ex_data(callback_idx)
+            .expect("BUG: psk find session callback missing") as *const F;
+
+        raw_psk_find_session(callback, ssl, identity, identity_len, session)
+    }
+}
+
+#[cfg(ossl111)]
+pub extern "C" fn raw_psk_find_session<F>(
+    callback: *const F,
+    ssl: &mut SslRef,
+    identity: *const c_uchar,
+    identity_len: size_t,
+    session: *mut *mut ffi::SSL_SESSION,
+) -> c_int
+where
+    F: Fn(&mut SslRef, &[u8]) -> Result<Option<SslSession>, ErrorStack> + 'static + Sync + Send,
+{
+    unsafe {
+        let identity_sl = slice::from_raw_parts(identity as *const u8, identity_len as usize);
+
+        match (*callback)(ssl, identity_sl) {
+            Ok(ssl_session) => {
+                *session = if let Some(ssl_session) = ssl_session {
+                    let p = ssl_session.as_ptr();
+                    mem::forget(ssl_session);
+
+                    p
+                } else {
+                    ptr::null_mut()
+                };
+
+                1
+            }
+            Err(e) => {
+                e.put();
+                0
+            }
+        }
+    }
+}
+
+#[cfg(ossl111)]
+pub extern "C" fn raw_ssl_ctx_psk_use_session<F>(
+    ssl: *mut ffi::SSL,
+    md: *const ffi::EVP_MD,
+    id: *mut *const c_uchar,
+    idlen: *mut size_t,
+    session: *mut *mut ffi::SSL_SESSION,
+) -> c_int
+where
+    F: for<'a> Fn(
+            &'a mut SslRef,
+            Option<crate::hash::MessageDigest>,
+        ) -> Result<Option<(SslSession, Vec<u8>)>, ErrorStack>
+        + 'static
+        + Sync
+        + Send,
+{
+    unsafe {
+        let ssl = SslRef::from_ptr_mut(ssl);
+        let callback_idx = SslContext::cached_ex_index::<F>();
+
+        let callback = ssl
+            .ssl_context()
+            .ex_data(callback_idx)
+            .expect("BUG: psk use session callback missing") as *const F;
+
+        raw_psk_use_session(callback, ssl, md, id, idlen, session)
+    }
+}
+
+#[cfg(ossl111)]
+pub extern "C" fn raw_ssl_psk_use_session<F>(
+    ssl: *mut ffi::SSL,
+    md: *const ffi::EVP_MD,
+    id: *mut *const c_uchar,
+    idlen: *mut size_t,
+    session: *mut *mut ffi::SSL_SESSION,
+) -> c_int
+where
+    F: for<'a> Fn(
+            &'a mut SslRef,
+            Option<crate::hash::MessageDigest>,
+        ) -> Result<Option<(SslSession, Vec<u8>)>, ErrorStack>
+        + 'static
+        + Sync
+        + Send,
+{
+    unsafe {
+        let ssl = SslRef::from_ptr_mut(ssl);
+        let callback_idx = Ssl::cached_ex_index::<F>();
+
+        let callback = ssl
+            .ex_data(callback_idx)
+            .expect("BUG: psk use session callback missing") as *const F;
+
+        raw_psk_use_session(callback, ssl, md, id, idlen, session)
+    }
+}
+
+#[cfg(ossl111)]
+pub extern "C" fn raw_psk_use_session<F>(
+    callback: *const F,
+    ssl: &mut SslRef,
+    md: *const ffi::EVP_MD,
+    id: *mut *const c_uchar,
+    idlen: *mut size_t,
+    session: *mut *mut ffi::SSL_SESSION,
+) -> c_int
+where
+    F: for<'a> Fn(
+            &'a mut SslRef,
+            Option<crate::hash::MessageDigest>,
+        ) -> Result<Option<(SslSession, Vec<u8>)>, ErrorStack>
+        + 'static
+        + Sync
+        + Send,
+{
+    unsafe {
+        let psk_idx = Ssl::cached_ex_index::<Vec<u8>>();
+
+        let md = if md.is_null() {
+            None
+        } else {
+            Some(crate::hash::MessageDigest::from_ptr(md))
+        };
+
+        match (*callback)(ssl, md) {
+            Ok(ssl_session) => {
+                *session = if let Some((ssl_session, psk_id)) = ssl_session {
+                    *id = psk_id.as_ptr() as *const c_uchar;
+                    *idlen = psk_id.len() as size_t;
+
+                    ssl.set_ex_data(psk_idx, psk_id);
+
+                    let p = ssl_session.as_ptr();
+                    mem::forget(ssl_session);
+
+                    p
+                } else {
+                    ptr::null_mut()
+                };
+
+                1
+            }
+            Err(e) => {
+                e.put();
+                0
+            }
+        }
+    }
+}
+
 pub extern "C" fn ssl_raw_verify<F>(
     preverify_ok: c_int,
     x509_ctx: *mut ffi::X509_STORE_CTX,

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1424,6 +1424,83 @@ fn psk_ciphers() {
 }
 
 #[test]
+#[cfg(ossl111)]
+fn psk_tls13_callbacks() {
+    use crate::ssl::{SslCipherRef, SslSession, SslVersion};
+
+    static PSK_FIND_SESSION_CALLED_BACK: AtomicBool = AtomicBool::new(false);
+    static PSK_USE_SESSION_CALLED_BACK: AtomicBool = AtomicBool::new(false);
+
+    let mut server = Server::builder();
+    server
+        .ctx()
+        .set_min_proto_version(Some(SslVersion::TLS1_3))
+        .unwrap();
+    server.ctx().set_psk_find_session_callback(|ssl, identity| {
+        if "PSK_id".as_bytes() != identity {
+            unreachable!("PSK is hard-coded for this test");
+        }
+
+        // TLS_AES_128_GCM_SHA256 from RFC 8446
+        let cipher = SslCipherRef::find(ssl, &[0x13, 0x01])?;
+
+        let mut session = SslSession::new()?;
+        session.set_cipher(cipher)?;
+        session.set_master_key("junkjunkjunkjunk".as_bytes())?;
+        session.set_protocol_version(SslVersion::TLS1_3)?;
+
+        PSK_FIND_SESSION_CALLED_BACK.store(true, Ordering::SeqCst);
+
+        Ok(Some(session))
+    });
+
+    let server = server.build();
+
+    let mut client = server.client();
+    client
+        .ctx()
+        .set_min_proto_version(Some(SslVersion::TLS1_3))
+        .unwrap();
+    client.ctx().set_psk_use_session_callback(|ssl, md| {
+        // TLS_AES_128_GCM_SHA256 from RFC 8446
+        let cipher = SslCipherRef::find(ssl, &[0x13, 0x01])?;
+
+        if let Some(md) = md {
+            let cipher_md = cipher.handshake_digest().unwrap();
+
+            assert_eq!(
+                cipher_md.type_(),
+                md.type_(),
+                "message digest mismatch should be impossible"
+            );
+        }
+
+        let mut session = SslSession::new()?;
+        session.set_cipher(cipher)?;
+        session.set_master_key("junkjunkjunkjunk".as_bytes())?;
+        session.set_protocol_version(SslVersion::TLS1_3)?;
+
+        PSK_USE_SESSION_CALLED_BACK.store(true, Ordering::SeqCst);
+
+        Ok(Some((session, "PSK_id".as_bytes().to_vec())))
+    });
+
+    client.connect();
+
+    assert!(PSK_FIND_SESSION_CALLED_BACK.load(Ordering::SeqCst));
+    assert!(PSK_USE_SESSION_CALLED_BACK.load(Ordering::SeqCst));
+
+    // OpenSSL says:
+    //
+    // > A connection established via a TLSv1.3 PSK will appear as if session resumption has
+    // > occurred so that SSL_session_reused(3) will return true.
+    //
+    // But this does not appear to be true using the sessions created in the above callbacks.
+    //
+    // However, the TLS handshake involves only 1-RTT according to tcpdump.
+}
+
+#[test]
 fn sni_callback_swapped_ctx() {
     static CALLED_BACK: AtomicBool = AtomicBool::new(false);
 


### PR DESCRIPTION
For TLS 1.3 OpenSSL introduced new functions [`SSL_CTX_set_psk_use_session_callback`](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_psk_use_session_callback.html) and [`SSL_CTX_set_psk_find_session_callback`](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_psk_find_session_callback.html) to configure a pre-shared key.  I chose to wrap both the `SSL_CTX_psk…` and `SSL_psk…` versions of these functions.

One thing I am not certain of is `SSL_CTX_set_psk_use_session_callback` says:

> On successful completion the callback must store a pointer to an identifier for the PSK in `*id`. The identifier length in bytes should be stored in `*idlen`. The memory pointed to by `*id` remains owned by the application and should be freed by it as required at any point after the handshake is complete.

I used `ssl.set_ex_data()` to store the ID in the `SslRef`, but I don't know if this is the correct way to do that.

The notes for the new functions state:

> A connection established via a TLSv1.3 PSK will appear as if session resumption has occurred so that [`SSL_session_reused`](https://www.openssl.org/docs/man1.1.1/man3/SSL_session_reused.html) will return true.

But this does not to be true with a minimally-configured session.  Wireshark shows that the PSK is accepted and that only 1 round-trip is required to create a connection.

Output for `ssl::test::psk_tls13_callbacks` (4 total):

```
No.     Src Port Dest Port Info
      5 59642    59641     Client Hello

Frame 5: 334 bytes on wire (2672 bits), 334 bytes captured (2672 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59642, Dst Port: 59641, Seq: 1, Ack: 1, Len: 278
Transport Layer Security

No.     Src Port Dest Port Info
      7 59641    59642     Server Hello, Change Cipher Spec, Application Data, Application Data, Application Data, Application Data

Frame 7: 1411 bytes on wire (11288 bits), 1411 bytes captured (11288 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59641, Dst Port: 59642, Seq: 1, Ack: 279, Len: 1355
Transport Layer Security

No.     Src Port Dest Port Info
      9 59642    59641     Change Cipher Spec, Application Data

Frame 9: 136 bytes on wire (1088 bits), 136 bytes captured (1088 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59642, Dst Port: 59641, Seq: 279, Ack: 1356, Len: 80
Transport Layer Security

No.     Src Port Dest Port Info
     11 59641    59642     Application Data

Frame 11: 79 bytes on wire (632 bits), 79 bytes captured (632 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59641, Dst Port: 59642, Seq: 1356, Ack: 359, Len: 23
Transport Layer Security
```

Output for `ssl::test::ssl_verify_callback` (6 total, Application Data in frames 27 and 29 are the TLS 1.3 handshake):

```
No.     Src Port Dest Port Info
     21 59644    59643     Client Hello

Frame 21: 353 bytes on wire (2824 bits), 353 bytes captured (2824 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59644, Dst Port: 59643, Seq: 1, Ack: 1, Len: 297
Transport Layer Security

No.     Src Port Dest Port Info
     23 59643    59644     Server Hello, Change Cipher Spec, Application Data, Application Data, Application Data, Application Data

Frame 23: 1411 bytes on wire (11288 bits), 1411 bytes captured (11288 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59643, Dst Port: 59644, Seq: 1, Ack: 298, Len: 1355
Transport Layer Security

No.     Src Port Dest Port Info
     25 59644    59643     Change Cipher Spec, Application Data

Frame 25: 136 bytes on wire (1088 bits), 136 bytes captured (1088 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59644, Dst Port: 59643, Seq: 298, Ack: 1356, Len: 80
Transport Layer Security

No.     Src Port Dest Port Info
     27 59643    59644     Application Data

Frame 27: 311 bytes on wire (2488 bits), 311 bytes captured (2488 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59643, Dst Port: 59644, Seq: 1356, Ack: 378, Len: 255
Transport Layer Security

No.     Src Port Dest Port Info
     29 59643    59644     Application Data

Frame 29: 311 bytes on wire (2488 bits), 311 bytes captured (2488 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59643, Dst Port: 59644, Seq: 1611, Ack: 378, Len: 255
Transport Layer Security

No.     Src Port Dest Port Info
     31 59643    59644     Application Data

Frame 31: 79 bytes on wire (632 bits), 79 bytes captured (632 bits) on interface lo0, id 0
Null/Loopback
Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
Transmission Control Protocol, Src Port: 59643, Dst Port: 59644, Seq: 1866, Ack: 378, Len: 23
Transport Layer Security
```

The above output can be reproduced by running Wireshark on the loopback interface then applying the `tls` filter.

Per the description of the above callbacks this also requires wrapping:
* [`SSL_SESSION_new`](https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_new.html)
* [`SSL_SESSION_set1_master_key`](https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_set1_master_key.html)
* [`SSL_SESSION_set_cipher`](https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_set_cipher.html)
* [`SSL_SESSION_set_protocol_version`](https://www.openssl.org/docs/man1.1.1/man3/SSL_SESSION_set_protocol_version.html)
* [`SSL_CIPHER_find`](https://www.openssl.org/docs/man1.1.1/man3/SSL_CIPHER_find.html)