### PR TITLE
Expose Poly1305 bindings on libressl and boringssl

### DIFF
--- a/openssl-sys/CHANGELOG.md
+++ b/openssl-sys/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* Expose `poly1305_state`, `CRYPTO_poly1305_init`, `CRYPTO_poly1305_update`, and `CRYPTO_poly1305_finish` on BoringSSL and LibreSSL.
+
 ## [v0.9.90] - 2023-06-20
 
 ### Fixed

--- a/openssl-sys/build/run_bindgen.rs
+++ b/openssl-sys/build/run_bindgen.rs
@@ -55,6 +55,10 @@ const INCLUDES: &str = "
 #if OPENSSL_VERSION_NUMBER >= 0x30000000
 #include <openssl/provider.h>
 #endif
+
+#if defined(LIBRESSL_VERSION_NUMBER) || defined(OPENSSL_IS_BORINGSSL)
+#include <openssl/poly1305.h>
+#endif
 ";
 
 #[cfg(feature = "bindgen")]

--- a/openssl-sys/src/handwritten/mod.rs
+++ b/openssl-sys/src/handwritten/mod.rs
@@ -18,6 +18,8 @@ pub use self::ocsp::*;
 pub use self::pem::*;
 pub use self::pkcs12::*;
 pub use self::pkcs7::*;
+#[cfg(libressl)]
+pub use self::poly1305::*;
 pub use self::provider::*;
 pub use self::rand::*;
 pub use self::rsa::*;
@@ -52,6 +54,8 @@ mod ocsp;
 mod pem;
 mod pkcs12;
 mod pkcs7;
+#[cfg(libressl)]
+mod poly1305;
 mod provider;
 mod rand;
 mod rsa;

--- a/openssl-sys/src/handwritten/poly1305.rs
+++ b/openssl-sys/src/handwritten/poly1305.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use libc::*;
+
+cfg_if! {
+    if #[cfg(libressl)] {
+        #[repr(C)]
+        #[derive(Debug, Copy, Clone)]
+        pub struct poly1305_context {
+            pub aligner: usize,
+            pub opaque: [::libc::c_uchar; 136usize],
+        }
+        pub type poly1305_state = poly1305_context;
+        extern "C" {
+            pub fn CRYPTO_poly1305_init(ctx: *mut poly1305_context, key: *const ::libc::c_uchar);
+            pub fn CRYPTO_poly1305_update(
+                ctx: *mut poly1305_context,
+                in_: *const ::libc::c_uchar,
+                len: usize,
+            );
+            pub fn CRYPTO_poly1305_finish(ctx: *mut poly1305_context, mac: *mut ::libc::c_uchar);
+        }
+    }
+}

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -69,6 +69,10 @@ fn main() {
         .header("openssl/evp.h")
         .header("openssl/x509_vfy.h");
 
+    if libressl_version.is_some() {
+        cfg.header("openssl/poly1305.h");
+    }
+
     if let Some(version) = openssl_version {
         cfg.header("openssl/cms.h");
         if version >= 0x10100000 {


### PR DESCRIPTION
This PR exposes the Poly1305 API from LibreSSL ([source](https://github.com/libressl/openbsd/blob/master/src/lib/libcrypto/poly1305/poly1305.h)) and BoringSSL ([source](https://github.com/google/boringssl/blob/master/include/openssl/poly1305.h))

The API was already exposed for Boring through `bssl-sys` (when building with the `unstable_boringssl` feature), but was not present in normal (`bindgen`) builds. I did not add a handwritten version for BoringSSL, because from what I could see Boring is either built with `bindgen` or `bssl-sys` bindings, not the manually-written ones.

For LibreSSL, both the handwritten and the `bindgen` bindings should work now.