### PR TITLE
Add openssl::cipher_ctx::CipherCtx::clone

### DIFF
--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -271,6 +271,8 @@ const_ptr_api! {
 extern "C" {
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
+    pub fn EVP_CIPHER_CTX_copy(dst: *mut EVP_CIPHER_CTX, src: *const EVP_CIPHER_CTX) -> c_int;
+
     pub fn EVP_MD_CTX_copy_ex(dst: *mut EVP_MD_CTX, src: *const EVP_MD_CTX) -> c_int;
     #[cfg(ossl111)]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> c_int;

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -106,7 +106,7 @@ impl CipherCtx {
 
 impl CipherCtxRef {
     #[corresponds(EVP_CIPHER_CTX_copy)]
-    pub fn copy(&mut self, src: &CipherCtx) -> Result<(), ErrorStack> {
+    pub fn copy(&mut self, src: &CipherCtxRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_CIPHER_CTX_copy(self.as_ptr(), src.as_ptr()))?;
             Ok(())

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -102,18 +102,17 @@ impl CipherCtx {
             Ok(CipherCtx::from_ptr(ptr))
         }
     }
-
-    #[corresponds(EVP_CIPHER_CTX_copy)]
-    pub fn clone(&self) -> Result<Self, ErrorStack> {
-        let n = CipherCtx::new()?;
-        unsafe {
-            cvt(ffi::EVP_CIPHER_CTX_copy(n.as_ptr(), self.as_ptr()))?;
-        }
-        Ok(n)
-    }
 }
 
 impl CipherCtxRef {
+    #[corresponds(EVP_CIPHER_CTX_copy)]
+    pub fn copy(&mut self, src: &CipherCtx) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_CIPHER_CTX_copy(self.as_ptr(), src.as_ptr()))?;
+            Ok(())
+        }
+    }
+
     /// Initializes the context for encryption.
     ///
     /// Normally this is called once to set all of the cipher, key, and IV. However, this process can be split up

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -102,6 +102,15 @@ impl CipherCtx {
             Ok(CipherCtx::from_ptr(ptr))
         }
     }
+
+    #[corresponds(EVP_CIPHER_CTX_copy)]
+    pub fn clone(&self) -> Result<Self, ErrorStack> {
+        let n = CipherCtx::new()?;
+        unsafe {
+            cvt(ffi::EVP_CIPHER_CTX_copy(n.as_ptr(), self.as_ptr()))?;
+        }
+        Ok(n)
+    }
 }
 
 impl CipherCtxRef {


### PR DESCRIPTION
I have a use case that benefits (speed-wise) from being able to set/expand the key once in the context and then reuse the context via copies for multiple encryptions. This change adds the `clone()` function on the CipherCtx object which calls `EVP_CIPHER_CTX_copy()` behind the scenes.