### PR TITLE
Add X509VerifyParam::set_email

### DIFF
--- a/openssl-sys/src/handwritten/x509_vfy.rs
+++ b/openssl-sys/src/handwritten/x509_vfy.rs
@@ -118,6 +118,12 @@ extern "C" {
     #[cfg(any(ossl102, libressl261))]
     pub fn X509_VERIFY_PARAM_set_hostflags(param: *mut X509_VERIFY_PARAM, flags: c_uint);
     #[cfg(any(ossl102, libressl261))]
+    pub fn X509_VERIFY_PARAM_set1_email(
+        param: *mut X509_VERIFY_PARAM,
+        email: *const c_char,
+        emaillen: size_t,
+    ) -> c_int;
+    #[cfg(any(ossl102, libressl261))]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const c_uchar,

--- a/openssl/CHANGELOG.md
+++ b/openssl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+ * Added `X509VerifyParam::set_email`
+
 ## [v0.10.56] - 2023-08-06
 
 ## Added

--- a/openssl/src/x509/verify.rs
+++ b/openssl/src/x509/verify.rs
@@ -131,6 +131,21 @@ impl X509VerifyParamRef {
         }
     }
 
+    /// Set the expected email address.
+    #[corresponds(X509_VERIFY_PARAM_set1_email)]
+    pub fn set_email(&mut self, email: &str) -> Result<(), ErrorStack> {
+        unsafe {
+            // len == 0 means "run strlen" :(
+            let raw_email = if email.is_empty() { "\0" } else { email };
+            cvt(ffi::X509_VERIFY_PARAM_set1_email(
+                self.as_ptr(),
+                raw_email.as_ptr() as *const _,
+                email.len(),
+            ))
+            .map(|_| ())
+        }
+    }
+
     /// Set the expected IPv4 or IPv6 address.
     #[corresponds(X509_VERIFY_PARAM_set1_ip)]
     pub fn set_ip(&mut self, ip: IpAddr) -> Result<(), ErrorStack> {


### PR DESCRIPTION
This is substantially similar to the other X.509 verification parameter options like host.  I tested manually by building and verifying signatures both with and without the correct email address; I did not add unit tests because I am not very familiar with this crate and the nearest similar code did not have tests I could find.