### PR TITLE
Add perl-FindBin dep for fedora

### DIFF
--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -44,7 +44,7 @@
 //! $ sudo apt-get install pkg-config libssl-dev
 //!
 //! # Fedora
-//! $ sudo dnf install pkg-config openssl-devel
+//! $ sudo dnf install pkg-config perl-FindBin openssl-devel
 //!
 //! # Alpine Linux
 //! $ apk add pkgconfig openssl-dev


### PR DESCRIPTION
Compilation in fedora fails without this installed with message:

```
  --- stderr
  Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC contains: /usr/local/lib64/perl5/5.36 /usr/local/share/perl5/5.36 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ./Configure line 15.
  BEGIN failed--compilation aborted at ./Configure line 15.
  thread 'main' panicked at /home/jade/.cargo/registry/src/index.crates.io-6f17d22bba15001f/openssl-src-111.27.0+1.1.1v/src/lib.rs:506:13:



  Error configuring OpenSSL build:
      Command: cd "/home/jade/.cache/cargo-target/release/build/openssl-sys-e85093adb0ede020/out/openssl-build/build/src" && AR="ar" CC="cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=/home/jade/.cache/cargo-target/release/build/openssl-sys-e85093adb0ede020/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-shared" "no-ssl3" "no-unit-test" "no-comp" "no-zlib" "no-zlib-dynamic" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "linux-x86_64" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64"
      Exit status: exit status: 2
```




