### PR TITLE
Fix auto-fixable Clippy warnings

### DIFF
--- a/openssl-sys/src/rsa.rs
+++ b/openssl-sys/src/rsa.rs
@@ -76,7 +76,7 @@ pub unsafe fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         EVP_PKEY_OP_TYPE_CRYPT,
         EVP_PKEY_CTRL_RSA_OAEP_LABEL,
         len,
-        label as *mut c_void,
+        label,
     )
 }
 

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -40,7 +40,7 @@
 //! assert_eq!(&*decrypted, data);
 //! ```
 #[cfg(any(ossl102, libressl310))]
-use libc::{c_int, c_void};
+use libc::c_int;
 use std::{marker::PhantomData, ptr};
 
 use crate::error::ErrorStack;
@@ -174,7 +174,7 @@ impl<'a> Encrypter<'a> {
 
             cvt(ffi::EVP_PKEY_CTX_set0_rsa_oaep_label(
                 self.pctx,
-                p as *mut c_void,
+                p,
                 label.len() as c_int,
             ))
             .map(|_| ())
@@ -378,7 +378,7 @@ impl<'a> Decrypter<'a> {
 
             cvt(ffi::EVP_PKEY_CTX_set0_rsa_oaep_label(
                 self.pctx,
-                p as *mut c_void,
+                p,
                 label.len() as c_int,
             ))
             .map(|_| ())

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -86,7 +86,7 @@ where
         };
         // Give the callback mutable slices into which it can write the identity and psk.
         let identity_sl = slice::from_raw_parts_mut(identity as *mut u8, max_identity_len as usize);
-        let psk_sl = slice::from_raw_parts_mut(psk as *mut u8, max_psk_len as usize);
+        let psk_sl = slice::from_raw_parts_mut(psk, max_psk_len as usize);
         match (*callback)(ssl, hint, identity_sl, psk_sl) {
             Ok(psk_len) => psk_len as u32,
             Err(e) => {
@@ -124,7 +124,7 @@ where
             Some(CStr::from_ptr(identity).to_bytes())
         };
         // Give the callback mutable slices into which it can write the psk.
-        let psk_sl = slice::from_raw_parts_mut(psk as *mut u8, max_psk_len as usize);
+        let psk_sl = slice::from_raw_parts_mut(psk, max_psk_len as usize);
         match (*callback)(ssl, identity, psk_sl) {
             Ok(psk_len) => psk_len as u32,
             Err(e) => {
@@ -194,7 +194,7 @@ where
             .ssl_context()
             .ex_data(SslContext::cached_ex_index::<F>())
             .expect("BUG: alpn callback missing") as *const F;
-        let protos = slice::from_raw_parts(inbuf as *const u8, inlen as usize);
+        let protos = slice::from_raw_parts(inbuf, inlen as usize);
 
         match (*callback)(ssl, protos) {
             Ok(proto) => {
@@ -412,7 +412,7 @@ where
         .expect("BUG: session context missing")
         .ex_data(SslContext::cached_ex_index::<F>())
         .expect("BUG: get session callback missing") as *const F;
-    let data = slice::from_raw_parts(data as *const u8, len as usize);
+    let data = slice::from_raw_parts(data, len as usize);
 
     match (*callback)(ssl, data) {
         Some(session) => {
@@ -455,7 +455,7 @@ where
         .ssl_context()
         .ex_data(SslContext::cached_ex_index::<F>())
         .expect("BUG: stateless cookie generate callback missing") as *const F;
-    let slice = slice::from_raw_parts_mut(cookie as *mut u8, ffi::SSL_COOKIE_LENGTH as usize);
+    let slice = slice::from_raw_parts_mut(cookie, ffi::SSL_COOKIE_LENGTH as usize);
     match (*callback)(ssl, slice) {
         Ok(len) => {
             *cookie_len = len as size_t;
@@ -482,7 +482,7 @@ where
         .ssl_context()
         .ex_data(SslContext::cached_ex_index::<F>())
         .expect("BUG: stateless cookie verify callback missing") as *const F;
-    let slice = slice::from_raw_parts(cookie as *const c_uchar as *const u8, cookie_len);
+    let slice = slice::from_raw_parts(cookie as *const c_uchar, cookie_len);
     (*callback)(ssl, slice) as c_int
 }
 
@@ -504,7 +504,7 @@ where
         // We subtract 1 from DTLS1_COOKIE_LENGTH as the ostensible value, 256, is erroneous but retained for
         // compatibility. See comments in dtls1.h.
         let slice =
-            slice::from_raw_parts_mut(cookie as *mut u8, ffi::DTLS1_COOKIE_LENGTH as usize - 1);
+            slice::from_raw_parts_mut(cookie, ffi::DTLS1_COOKIE_LENGTH as usize - 1);
         match (*callback)(ssl, slice) {
             Ok(len) => {
                 *cookie_len = len as c_uint;
@@ -543,7 +543,7 @@ where
             .ex_data(SslContext::cached_ex_index::<F>())
             .expect("BUG: cookie verify callback missing") as *const F;
         let slice =
-            slice::from_raw_parts(cookie as *const c_uchar as *const u8, cookie_len as usize);
+            slice::from_raw_parts(cookie as *const c_uchar, cookie_len as usize);
         (*callback)(ssl, slice) as c_int
     }
 }
@@ -654,7 +654,7 @@ where
             .ex_data(SslContext::cached_ex_index::<F>())
             .expect("BUG: custom ext parse callback missing") as *const F;
         let ectx = ExtensionContext::from_bits_truncate(context);
-        let slice = slice::from_raw_parts(input as *const u8, inlen);
+        let slice = slice::from_raw_parts(input, inlen);
         let cert = if ectx.contains(ExtensionContext::TLS1_3_CERTIFICATE) {
             Some((chainidx, X509Ref::from_ptr(x)))
         } else {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -2122,7 +2122,7 @@ impl SslSessionRef {
         unsafe {
             let mut len = 0;
             let p = ffi::SSL_SESSION_get_id(self.as_ptr(), &mut len);
-            slice::from_raw_parts(p as *const u8, len as usize)
+            slice::from_raw_parts(p, len as usize)
         }
     }
 

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -2102,7 +2102,7 @@ impl GeneralNameRef {
             let ptr = ASN1_STRING_get0_data(d as *mut _);
             let len = ffi::ASN1_STRING_length(d as *mut _);
 
-            let slice = slice::from_raw_parts(ptr as *const u8, len as usize);
+            let slice = slice::from_raw_parts(ptr, len as usize);
             // IA5Strings are stated to be ASCII (specifically IA5). Hopefully
             // OpenSSL checks that when loading a certificate but if not we'll
             // use this instead of from_utf8_unchecked just in case.
@@ -2155,7 +2155,7 @@ impl GeneralNameRef {
             let ptr = ASN1_STRING_get0_data(d as *mut _);
             let len = ffi::ASN1_STRING_length(d as *mut _);
 
-            Some(slice::from_raw_parts(ptr as *const u8, len as usize))
+            Some(slice::from_raw_parts(ptr, len as usize))
         }
     }
 }


### PR DESCRIPTION
(Creating this, as I said I would in #2021)

This does not fix all the new Clippy warnings, assuming the set I see after I ran `rustup` this morning is the same set GitHub sees.  There are four warnings internal to the `bitflags!` macro which Iʼm not sure how to fix.  Clippy doesnʼt seem to have a good option to disable lints inside a macro, and disabling it globally seems excessive.  Bumping the `bitflags` crate to the latest version makes it stop compiling correctly; bumping it to the latest 1.x version compiles and passes all tests but does not get rid of the warning.

Thoughts?  Or should this be merged as-is and the rest handled separately by someone who knows this codebase better?