### PR TITLE
Bindings for config loading, add_builtin for statically linked provider

### DIFF
--- a/openssl-sys/src/handwritten/conf.rs
+++ b/openssl-sys/src/handwritten/conf.rs
@@ -1,7 +1,19 @@
 use super::super::*;
 
+pub const CONF_MFLAGS_IGNORE_ERRORS: c_ulong = 0x1;
+pub const CONF_MFLAGS_IGNORE_RETURN_CODES: c_ulong = 0x2;
+pub const CONF_MFLAGS_SILENT: c_ulong = 0x4;
+pub const CONF_MFLAGS_NO_DSO: c_ulong = 0x8;
+pub const CONF_MFLAGS_IGNORE_MISSING_FILE: c_ulong = 0x10;
+pub const CONF_MFLAGS_DEFAULT_SECTION: c_ulong = 0x20;
+
 extern "C" {
     pub fn NCONF_new(meth: *mut CONF_METHOD) -> *mut CONF;
     pub fn NCONF_default() -> *mut CONF_METHOD;
     pub fn NCONF_free(conf: *mut CONF);
+    pub fn CONF_modules_load_file(
+        filename: *const c_char,
+        appname: *const c_char,
+        flags: c_ulong,
+    ) -> c_int;
 }

--- a/openssl-sys/src/handwritten/provider.rs
+++ b/openssl-sys/src/handwritten/provider.rs
@@ -17,4 +17,10 @@ extern "C" {
         ctx: *mut OSSL_LIB_CTX,
         path: *const c_char,
     ) -> c_int;
+    #[cfg(ossl300)]
+    pub fn OSSL_PROVIDER_add_builtin(
+        ctx: *mut OSSL_LIB_CTX,
+        provider: *const c_char,
+        builtin_pointer: unsafe extern "C" fn(),
+    ) -> c_int;
 }

--- a/openssl/src/conf.rs
+++ b/openssl/src/conf.rs
@@ -11,10 +11,43 @@ foreign_type_and_impl_send_sync! {
 #[cfg(not(boringssl))]
 mod methods {
     use super::Conf;
+    use crate::cvt;
     use crate::cvt_p;
     use crate::error::ErrorStack;
+    use libc::{c_int, c_ulong};
     use openssl_macros::corresponds;
+    use std::ffi::CString;
+    use std::path::Path;
+    use std::ptr;
 
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct ConfMflags(c_ulong);
+
+    impl ConfMflags {
+        pub const IGNORE_ERRORS: ConfMflags = ConfMflags(ffi::CONF_MFLAGS_IGNORE_ERRORS);
+        pub const IGNORE_RETURN_CODES: ConfMflags =
+            ConfMflags(ffi::CONF_MFLAGS_IGNORE_RETURN_CODES);
+        pub const SILENT: ConfMflags = ConfMflags(ffi::CONF_MFLAGS_SILENT);
+        pub const NO_DSO: ConfMflags = ConfMflags(ffi::CONF_MFLAGS_NO_DSO);
+        pub const IGNORE_MISSING_FILE: ConfMflags =
+            ConfMflags(ffi::CONF_MFLAGS_IGNORE_MISSING_FILE);
+        pub const DEFAULT_SECTION: ConfMflags = ConfMflags(ffi::CONF_MFLAGS_DEFAULT_SECTION);
+        pub const DEFAULT_CONF_MFLAGS: ConfMflags = ConfMflags(
+            ffi::CONF_MFLAGS_DEFAULT_SECTION
+                | ffi::CONF_MFLAGS_IGNORE_MISSING_FILE
+                | ffi::CONF_MFLAGS_IGNORE_RETURN_CODES,
+        );
+
+        /// Constructs an `ConfMflags` from a raw OpenSSL value.
+        pub fn from_raw(id: c_ulong) -> Self {
+            ConfMflags(id)
+        }
+
+        /// Returns the raw OpenSSL value represented by this type.
+        pub fn as_raw(&self) -> c_ulong {
+            self.0
+        }
+    }
     pub struct ConfMethod(*mut ffi::CONF_METHOD);
 
     impl ConfMethod {
@@ -58,6 +91,29 @@ mod methods {
         #[corresponds(NCONF_new)]
         pub fn new(method: ConfMethod) -> Result<Conf, ErrorStack> {
             unsafe { cvt_p(ffi::NCONF_new(method.as_ptr())).map(Conf) }
+        }
+    }
+
+    /// configures OpenSSL using file filename and application name appname.
+    /// If filename is None the standard OpenSSL configuration file is used
+    /// If appname is None the standard OpenSSL application name openssl_conf is used.
+    /// The behaviour can be customized using flags.
+    #[corresponds(CONF_modules_load_file)]
+    pub fn modules_load_file<P: AsRef<Path>>(
+        filename: Option<P>,
+        appname: Option<String>,
+        flags: ConfMflags,
+    ) -> Result<c_int, ErrorStack> {
+        let filename =
+            filename.map(|f| CString::new(f.as_ref().as_os_str().to_str().unwrap()).unwrap());
+        let appname = appname.map(|a| CString::new(a).unwrap());
+
+        unsafe {
+            cvt(ffi::CONF_modules_load_file(
+                filename.as_ref().map_or(ptr::null(), |f| f.as_ptr()),
+                appname.as_ref().map_or(ptr::null(), |a| a.as_ptr()),
+                flags.as_raw() as _,
+            ))
         }
     }
 }

--- a/openssl/src/provider.rs
+++ b/openssl/src/provider.rs
@@ -74,4 +74,20 @@ impl Provider {
             .map(|_| ())
         }
     }
+    #[corresponds(OSSL_PROVIDER_add_builtin)]
+    pub fn add_builtin(
+        ctx: Option<&LibCtxRef>,
+        provider: &str,
+        init_func: unsafe extern "C" fn(),
+    ) -> Result<(), ErrorStack> {
+        let provider_name = CString::new(provider).unwrap();
+        unsafe {
+            cvt(ffi::OSSL_PROVIDER_add_builtin(
+                ctx.map_or(ptr::null_mut(), ForeignTypeRef::as_ptr),
+                provider_name.as_ptr(),
+                init_func,
+            ))
+            .map(|_| ())
+        }
+    }
 }


### PR DESCRIPTION
This exposes bindings for dealing with loading config files in runtime as well as for exposing statically linked providers to openssl.