### PR TITLE
[openssl-sys] Add X509_check_{host,email,ip,ip_asc} fns

### DIFF
--- a/openssl-sys/src/handwritten/x509v3.rs
+++ b/openssl-sys/src/handwritten/x509v3.rs
@@ -146,6 +146,7 @@ extern "C" {
     pub fn DIST_POINT_NAME_free(dist_point: *mut DIST_POINT_NAME);
 }
 
+#[cfg(ossl102)]
 extern "C" {
     pub fn X509_check_host(
         x: *mut X509,

--- a/openssl-sys/src/handwritten/x509v3.rs
+++ b/openssl-sys/src/handwritten/x509v3.rs
@@ -145,3 +145,21 @@ extern "C" {
     pub fn DIST_POINT_free(dist_point: *mut DIST_POINT);
     pub fn DIST_POINT_NAME_free(dist_point: *mut DIST_POINT_NAME);
 }
+
+extern "C" {
+    pub fn X509_check_host(
+        x: *mut X509,
+        chk: *const c_char,
+        chklen: usize,
+        flags: c_uint,
+        peername: *mut *mut c_char,
+    ) -> c_int;
+    pub fn X509_check_email(
+        x: *mut X509,
+        chk: *const c_char,
+        chklen: usize,
+        flags: c_uint,
+    ) -> c_int;
+    pub fn X509_check_ip(x: *mut X509, chk: *const c_uchar, chklen: usize, flags: c_uint) -> c_int;
+    pub fn X509_check_ip_asc(x: *mut X509, ipasc: *const c_char, flags: c_uint) -> c_int;
+}


### PR DESCRIPTION
I took these definitions from `bindgen` output and double-checked them against https://www.openssl.org/docs/man1.0.2/man3/X509_check_host.html. The constants needed for `flags` are already defined (https://docs.rs/openssl-sys/latest/openssl_sys/?search=check_flag).