### PR TITLE
rustc: bump min version to 1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       # Remember to also update `--rust-target` in `openssl-sys/build/run_bindgen.rs`
       - uses: sfackler/actions/rustup@master
         with:
-          version: 1.56.0
+          version: 1.60.0
       - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
         id: rust-version
       - uses: actions/cache@v3

--- a/openssl-sys/build/run_bindgen.rs
+++ b/openssl-sys/build/run_bindgen.rs
@@ -173,7 +173,7 @@ pub fn run_boringssl(include_dirs: &[PathBuf]) {
         .arg(out_dir.join("bindgen.rs"))
         // Must be a valid version from
         // https://docs.rs/bindgen/latest/bindgen/enum.RustTarget.html
-        .arg("--rust-target=1.47")
+        .arg("--rust-target=1.59")
         .arg("--ctypes-prefix=::libc")
         .arg("--raw-line=use libc::*;")
         .arg("--no-derive-default")


### PR DESCRIPTION
The currently tested min version of 1.56 does no longer compile. Due to the transitive dependency log, set the min version to 1.60. The most recent bindgen target <= is 1.59.

$ cargo +1.56.0 build --release
error: package `log v0.4.20` cannot be built because it requires rustc 1.60.0 or newer, while the currently active rustc version is 1.56.0