### PR TITLE
Use osslconf on BoringSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
             - false
           library:
             - name: boringssl
-              version: bcecc7d834fc44ad257b2f23f88e1cf597ab2736
+              version: 8d71d244c0debac4079beeb02b5802fde59b94bd
             - name: openssl
               version: vendored
             - name: openssl
@@ -239,7 +239,7 @@ jobs:
         - uses: actions/cache@v3
           with:
             path: /opt/openssl
-            key: openssl-${{ matrix.target }}-${{ matrix.library.name }}-${{ matrix.library.version }}-2
+            key: openssl-${{ matrix.target }}-${{ matrix.library.name }}-${{ matrix.library.version }}-6
           if: matrix.library.version != 'vendored'
           id: openssl-cache
         - run: |
@@ -313,11 +313,8 @@ jobs:
               make install
 
               # Copy stuff around so it's all as the build system expects.
-              cp -r rust/ "$OPENSSL_DIR/rust"
-              mkdir -p "$OPENSSL_DIR/crypto/"
-              mkdir -p "$OPENSSL_DIR/ssl/"
-              cp "$OPENSSL_DIR/lib/libcrypto.a" "$OPENSSL_DIR/crypto/"
-              cp "$OPENSSL_DIR/lib/libssl.a" "$OPENSSL_DIR/ssl/"
+              cp -r ../rust/ "$OPENSSL_DIR/rust"
+              cp -r ./ "$OPENSSL_DIR/build"
             esac
 
           if: matrix.library.version != 'vendored' && !steps.openssl-cache.outputs.cache-hit
@@ -356,6 +353,7 @@ jobs:
           run: |
             if [[ "${{ matrix.library.name }}" == "boringssl" && "${{ matrix.bindgen }}" != "true" ]]; then
               features="--features unstable_boringssl"
+              BORINGSSL_BUILD_DIR="$OPENSSL_DIR/build/"
             fi
             if [[ "${{ matrix.library.version }}" == "vendored" ]]; then
               features="--features vendored"

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -60,6 +60,14 @@ fn check_ssl_kind() {
     if cfg!(feature = "unstable_boringssl") {
         println!("cargo:rustc-cfg=boringssl");
         println!("cargo:boringssl=true");
+
+        if let Ok(vars) = env::var("DEP_BSSL_CONF") {
+            for var in vars.split(',') {
+                println!("cargo:rustc-cfg=osslconf=\"{}\"", var);
+            }
+            println!("cargo:conf={}", vars);
+        }
+
         // BoringSSL does not have any build logic, exit early
         std::process::exit(0);
     }
@@ -223,6 +231,11 @@ See rust-openssl documentation for more information:
         }
     }
 
+    for enabled in &enabled {
+        println!("cargo:rustc-cfg=osslconf=\"{}\"", enabled);
+    }
+    println!("cargo:conf={}", enabled.join(","));
+
     if is_boringssl {
         println!("cargo:rustc-cfg=boringssl");
         println!("cargo:boringssl=true");
@@ -232,11 +245,6 @@ See rust-openssl documentation for more information:
 
     // We set this for any non-BoringSSL lib.
     println!("cargo:rustc-cfg=openssl");
-
-    for enabled in &enabled {
-        println!("cargo:rustc-cfg=osslconf=\"{}\"", enabled);
-    }
-    println!("cargo:conf={}", enabled.join(","));
 
     for cfg in cfgs::get(openssl_version, libressl_version) {
         println!("cargo:rustc-cfg={}", cfg);

--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -391,37 +391,37 @@ extern "C" {
     #[cfg(all(any(ossl111, libressl291), not(osslconf = "OPENSSL_NO_SM4")))]
     pub fn EVP_sm4_ctr() -> *const EVP_CIPHER;
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn EVP_camellia_128_cfb128() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn EVP_camellia_128_ecb() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn EVP_camellia_128_cbc() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn EVP_camellia_192_cfb128() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn EVP_camellia_192_ecb() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn EVP_camellia_192_cbc() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn EVP_camellia_256_cfb128() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn EVP_camellia_256_ecb() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn EVP_camellia_256_cbc() -> *const EVP_CIPHER;
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAST")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
     pub fn EVP_cast5_cfb64() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAST")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAST")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_IDEA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
     pub fn EVP_idea_cfb64() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_IDEA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
     pub fn EVP_idea_ecb() -> *const EVP_CIPHER;
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_IDEA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
     pub fn EVP_idea_cbc() -> *const EVP_CIPHER;
 
     #[cfg(not(ossl110))]

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -13,7 +13,6 @@ fn main() {
 
     if env::var("DEP_OPENSSL_BORINGSSL").is_ok() {
         println!("cargo:rustc-cfg=boringssl");
-        return;
     }
 
     if let Ok(v) = env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER") {

--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -343,13 +343,11 @@ impl Cipher {
     }
 
     #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
-    #[cfg(not(boringssl))]
     pub fn bf_cfb64() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_bf_cfb64() as *mut _) }
     }
 
     #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
-    #[cfg(not(boringssl))]
     pub fn bf_ofb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_bf_ofb() as *mut _) }
     }
@@ -380,52 +378,52 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_rc4() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia128_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_128_cfb128() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia128_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_128_ecb() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia192_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_192_cfb128() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia192_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_192_ecb() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia256_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_256_cfb128() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia256_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_256_ecb() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAST")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
     pub fn cast5_cfb64() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_cast5_cfb64() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAST")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
     pub fn cast5_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_cast5_ecb() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_IDEA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
     pub fn idea_cfb64() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_idea_cfb64() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_IDEA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
     pub fn idea_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_idea_ecb() as *mut _) }
     }
@@ -441,25 +439,21 @@ impl Cipher {
     }
 
     #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
-    #[cfg(not(boringssl))]
     pub fn seed_cbc() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_seed_cbc() as *mut _) }
     }
 
     #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
-    #[cfg(not(boringssl))]
     pub fn seed_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_seed_cfb128() as *mut _) }
     }
 
     #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
-    #[cfg(not(boringssl))]
     pub fn seed_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_seed_ecb() as *mut _) }
     }
 
     #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
-    #[cfg(not(boringssl))]
     pub fn seed_ofb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_seed_ofb() as *mut _) }
     }

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -475,6 +475,6 @@ mod tests {
         let g = BigNum::from_hex_str("02").unwrap();
         let dh2 = Dh::from_pqg(p, None, g).unwrap();
         assert!(dh1.check_key().unwrap());
-        assert!(!dh2.check_key().unwrap());
+        assert!(matches!(dh2.check_key(), Ok(false) | Err(_)));
     }
 }

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -195,7 +195,7 @@ impl EcGroupRef {
     /// a term in the polynomial.  It will be set to 3 `1`s or 5 `1`s depending on
     /// using a trinomial or pentanomial.
     #[corresponds(EC_GROUP_get_curve_GF2m)]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_EC2M")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn components_gf2m(
         &self,
         p: &mut BigNumRef,
@@ -586,7 +586,7 @@ impl EcPointRef {
     /// Places affine coordinates of a curve over a binary field in the provided
     /// `x` and `y` `BigNum`s
     #[corresponds(EC_POINT_get_affine_coordinates_GF2m)]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_EC2M")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     pub fn affine_coordinates_gf2m(
         &self,
         group: &EcGroupRef,
@@ -1324,7 +1324,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_EC2M")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_EC2M"))]
     fn is_on_curve() {
         let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
         let mut ctx = BigNumContext::new().unwrap();

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -157,7 +157,7 @@ impl MessageDigest {
         unsafe { MessageDigest(ffi::EVP_shake256()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_RMD160")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_RMD160"))]
     pub fn ripemd160() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_ripemd160()) }
     }
@@ -745,7 +745,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(boringssl))]
+    #[cfg(not(osslconf = "OPENSSL_NO_RMD160"))]
     #[cfg_attr(ossl300, ignore)]
     fn test_ripemd160() {
         #[cfg(ossl300)]

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -140,7 +140,7 @@ pub mod base64;
 pub mod bn;
 pub mod cipher;
 pub mod cipher_ctx;
-#[cfg(all(not(boringssl), not(libressl), not(osslconf = "OPENSSL_NO_CMS")))]
+#[cfg(all(not(libressl), not(osslconf = "OPENSSL_NO_CMS")))]
 pub mod cms;
 pub mod conf;
 pub mod derive;
@@ -162,7 +162,7 @@ pub mod md;
 pub mod md_ctx;
 pub mod memcmp;
 pub mod nid;
-#[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_OCSP")))]
+#[cfg(not(osslconf = "OPENSSL_NO_OCSP"))]
 pub mod ocsp;
 pub mod pkcs12;
 pub mod pkcs5;

--- a/openssl/src/md.rs
+++ b/openssl/src/md.rs
@@ -188,14 +188,12 @@ impl Md {
 
     #[cfg(not(osslconf = "OPENSSL_NO_RMD160"))]
     #[inline]
-    #[cfg(not(boringssl))]
     pub fn ripemd160() -> &'static MdRef {
         unsafe { MdRef::from_ptr(ffi::EVP_ripemd160() as *mut _) }
     }
 
     #[cfg(all(any(ossl111, libressl291), not(osslconf = "OPENSSL_NO_SM3")))]
     #[inline]
-    #[cfg(not(boringssl))]
     pub fn sm3() -> &'static MdRef {
         unsafe { MdRef::from_ptr(ffi::EVP_sm3() as *mut _) }
     }

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -252,12 +252,12 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_bf_ecb()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_BF")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
     pub fn bf_cfb64() -> Cipher {
         unsafe { Cipher(ffi::EVP_bf_cfb64()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_BF")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
     pub fn bf_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_bf_ofb()) }
     }
@@ -288,17 +288,17 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_rc4()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia_128_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_128_cbc()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia_192_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_192_cbc()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_CAMELLIA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
     pub fn camellia_256_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_256_cbc()) }
     }
@@ -320,27 +320,27 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_chacha20_poly1305()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_IDEA")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
     pub fn idea_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_idea_cbc()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
     pub fn seed_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_cbc()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
     pub fn seed_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_cfb128()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
     pub fn seed_ecb() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_ecb()) }
     }
 
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED")))]
+    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
     pub fn seed_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_ofb()) }
     }
@@ -1559,7 +1559,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED", ossl300)))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
     fn test_seed_cbc() {
         #[cfg(ossl300)]
         let _provider = crate::provider::Provider::try_load(None, "legacy", true).unwrap();
@@ -1573,7 +1573,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED", ossl300)))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
     fn test_seed_cfb128() {
         #[cfg(ossl300)]
         let _provider = crate::provider::Provider::try_load(None, "legacy", true).unwrap();
@@ -1587,7 +1587,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED", ossl300)))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
     fn test_seed_ecb() {
         #[cfg(ossl300)]
         let _provider = crate::provider::Provider::try_load(None, "legacy", true).unwrap();
@@ -1601,7 +1601,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, osslconf = "OPENSSL_NO_SEED", ossl300)))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", ossl300)))]
     fn test_seed_ofb() {
         #[cfg(ossl300)]
         let _provider = crate::provider::Provider::try_load(None, "legacy", true).unwrap();


### PR DESCRIPTION
This reduces a bunch of special casing. Relies on changes from the latest BoringSSL HEAD.