### PR TITLE
Make X509_ALGOR opaque for LibreSSL

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -56,6 +56,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x3_08_01_00_0 {
             cfgs.push("libressl381");
         }
+        if libressl_version >= 0x3_08_02_00_0 {
+            cfgs.push("libressl382");
+        }
     } else {
         let openssl_version = openssl_version.unwrap();
 

--- a/openssl-sys/src/handwritten/types.rs
+++ b/openssl-sys/src/handwritten/types.rs
@@ -329,7 +329,7 @@ cfg_if! {
     }
 }
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl382))] {
         pub enum X509_ALGOR {}
     } else {
         #[repr(C)]


### PR DESCRIPTION
The struct is still public because that is also the case in OpenSSL, but it should no longer be accessed directly.

I have chosen `libressl350` as conditional since that is the one used for the bindings `X509_ALGOR_get0` . If that is not acceptable for semver reasons, it would be nice if that could be done for 3.8.2 (which is the not yet released stable version of the 3.8 branch).