### PR TITLE
Enable BN_mod_sqrt() for upcoming LibreSSL 3.8.2

### DIFF
--- a/openssl-sys/src/handwritten/bn.rs
+++ b/openssl-sys/src/handwritten/bn.rs
@@ -75,7 +75,7 @@ extern "C" {
         m: *const BIGNUM,
         ctx: *mut BN_CTX,
     ) -> c_int;
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl382))]
     pub fn BN_mod_sqrt(
         ret: *mut BIGNUM,
         a: *const BIGNUM,

--- a/openssl-sys/src/handwritten/bn.rs
+++ b/openssl-sys/src/handwritten/bn.rs
@@ -75,7 +75,6 @@ extern "C" {
         m: *const BIGNUM,
         ctx: *mut BN_CTX,
     ) -> c_int;
-    #[cfg(any(ossl110, libressl382))]
     pub fn BN_mod_sqrt(
         ret: *mut BIGNUM,
         a: *const BIGNUM,

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -655,7 +655,6 @@ impl BigNumRef {
 
     /// Places into `self` the modular square root of `a` such that `self^2 = a (mod p)`
     #[corresponds(BN_mod_sqrt)]
-    #[cfg(any(ossl110, libressl382))]
     pub fn mod_sqrt(
         &mut self,
         a: &BigNumRef,
@@ -1490,7 +1489,6 @@ mod tests {
         assert!(b.is_const_time())
     }
 
-    #[cfg(any(ossl110, libressl382))]
     #[test]
     fn test_mod_sqrt() {
         let mut ctx = BigNumContext::new().unwrap();

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -655,7 +655,7 @@ impl BigNumRef {
 
     /// Places into `self` the modular square root of `a` such that `self^2 = a (mod p)`
     #[corresponds(BN_mod_sqrt)]
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl382))]
     pub fn mod_sqrt(
         &mut self,
         a: &BigNumRef,
@@ -1490,17 +1490,24 @@ mod tests {
         assert!(b.is_const_time())
     }
 
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl382))]
     #[test]
     fn test_mod_sqrt() {
         let mut ctx = BigNumContext::new().unwrap();
 
-        let s = BigNum::from_hex_str("47A8DD7626B9908C80ACD7E0D3344D69").unwrap();
-        let p = BigNum::from_hex_str("81EF47265B58BCE5").unwrap();
+        let s = BigNum::from_hex_str("2").unwrap();
+        let p = BigNum::from_hex_str("7DEB1").unwrap();
+        let mut sqrt = BigNum::new().unwrap();
         let mut out = BigNum::new().unwrap();
 
-        out.mod_sqrt(&s, &p, &mut ctx).unwrap();
-        assert_eq!(out, BigNum::from_hex_str("7C6D179E19B97BDD").unwrap());
+        // Square the root because OpenSSL randomly returns one of 2E42C or 4FA85
+        sqrt.mod_sqrt(&s, &p, &mut ctx).unwrap();
+        out.mod_sqr(&sqrt, &p, &mut ctx).unwrap();
+        assert!(out == s);
+
+        let s = BigNum::from_hex_str("3").unwrap();
+        let p = BigNum::from_hex_str("5").unwrap();
+        assert!(out.mod_sqrt(&s, &p, &mut ctx).is_err());
     }
 
     #[test]


### PR DESCRIPTION
This API was inherited from OpenSSL, so it has always been present. Enable it for the upcoming LibreSSL release.

The test as it was written would fail since LibreSSL returns the other square root. Improve the test to work with all possible implementations with a more interesting test case. Also check for error in the simplest situation where no square root exists.