### PR TITLE
Remove DH_generate_parameters for LibreSSL 3.8.2

### DIFF
--- a/openssl-sys/src/handwritten/dh.rs
+++ b/openssl-sys/src/handwritten/dh.rs
@@ -5,6 +5,7 @@ extern "C" {
     pub fn DH_free(dh: *mut DH);
     pub fn DH_check(dh: *const DH, codes: *mut c_int) -> c_int;
 
+    #[cfg(not(libressl382))]
     pub fn DH_generate_parameters(
         prime_len: c_int,
         generator: c_int,


### PR DESCRIPTION
OpenSSL 0.9.8 deprecated DH_generate_parameters nearly 20 years ago. In 62acbe3a3ed internals switched to using the _ex version. Let's remove it from the API surface consumed from LibreSSL so we can eventually remove it on our side and finally make some long overdue internal simplifications.