### PR TITLE
Use EVP_MD_CTX_{new,free}() in LibreSSL 3.8.2

### DIFF
--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -52,7 +52,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl382))] {
         extern "C" {
             pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
             pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -43,7 +43,7 @@ use crate::nid::Nid;
 use crate::{cvt, cvt_p};
 
 cfg_if! {
-    if #[cfg(any(ossl110, boringssl))] {
+    if #[cfg(any(ossl110, boringssl, libressl382))] {
         use ffi::{EVP_MD_CTX_free, EVP_MD_CTX_new};
     } else {
         use ffi::{EVP_MD_CTX_create as EVP_MD_CTX_new, EVP_MD_CTX_destroy as EVP_MD_CTX_free};

--- a/openssl/src/md_ctx.rs
+++ b/openssl/src/md_ctx.rs
@@ -93,7 +93,7 @@ use std::convert::TryFrom;
 use std::ptr;
 
 cfg_if! {
-    if #[cfg(any(ossl110, boringssl))] {
+    if #[cfg(any(ossl110, boringssl, libressl382))] {
         use ffi::{EVP_MD_CTX_free, EVP_MD_CTX_new};
     } else {
         use ffi::{EVP_MD_CTX_create as EVP_MD_CTX_new, EVP_MD_CTX_destroy as EVP_MD_CTX_free};

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -81,7 +81,7 @@ use crate::rsa::Padding;
 use crate::{cvt, cvt_p};
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl382))] {
         use ffi::{EVP_MD_CTX_free, EVP_MD_CTX_new};
     } else {
         use ffi::{EVP_MD_CTX_create as EVP_MD_CTX_new, EVP_MD_CTX_destroy as EVP_MD_CTX_free};


### PR DESCRIPTION
These functions have been available since LibreSSL 2.7.2.

I am unsure if it would be possible (and if so preferable) to use an earlier version so the code can be simplified once support for old libressl versions is removed.