### PR TITLE
add security level bindings

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -924,3 +924,17 @@ extern "C" {
     #[cfg(all(ossl111, not(ossl111b)))]
     pub fn SSL_get_num_tickets(s: *mut SSL) -> size_t;
 }
+
+extern "C" {
+    #[cfg(ossl110)]
+    pub fn SSL_CTX_set_security_level(ctx: *mut SSL_CTX, level: c_int);
+
+    #[cfg(ossl110)]
+    pub fn SSL_set_security_level(s: *mut SSL, level: c_int);
+
+    #[cfg(ossl110)]
+    pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> c_int;
+
+    #[cfg(ossl110)]
+    pub fn SSL_get_security_level(s: *const SSL) -> c_int;
+}

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -926,15 +926,15 @@ extern "C" {
 }
 
 extern "C" {
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     pub fn SSL_CTX_set_security_level(ctx: *mut SSL_CTX, level: c_int);
 
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     pub fn SSL_set_security_level(s: *mut SSL, level: c_int);
 
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     pub fn SSL_CTX_get_security_level(ctx: *const SSL_CTX) -> c_int;
 
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     pub fn SSL_get_security_level(s: *const SSL) -> c_int;
 }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1718,6 +1718,16 @@ impl SslContextBuilder {
         unsafe { cvt(ffi::SSL_CTX_set_num_tickets(self.as_ptr(), num_tickets)).map(|_| ()) }
     }
 
+    /// Set the context's security level, which controls the allowed parameters
+    /// and algorithms.
+    ///
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[corresponds(SSL_CTX_set_security_level)]
+    #[cfg(ossl110)]
+    pub fn set_security_level(&mut self, level: u32) {
+        unsafe { ffi::SSL_CTX_set_security_level(self.as_ptr(), level as c_int) }
+    }
+
     /// Consumes the builder, returning a new `SslContext`.
     pub fn build(self) -> SslContext {
         self.0
@@ -1920,6 +1930,16 @@ impl SslContextRef {
     #[cfg(ossl111)]
     pub fn num_tickets(&self) -> usize {
         unsafe { ffi::SSL_CTX_get_num_tickets(self.as_ptr()) }
+    }
+
+    /// Get the context's security level, which controls the allowed parameters
+    /// and algorithms.
+    ///
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[corresponds(SSL_CTX_get_security_level)]
+    #[cfg(ossl110)]
+    pub fn security_level(&self) -> u32 {
+        unsafe { ffi::SSL_CTX_get_security_level(self.as_ptr()) as u32 }
     }
 }
 
@@ -3404,6 +3424,26 @@ impl SslRef {
     #[cfg(ossl111)]
     pub fn num_tickets(&self) -> usize {
         unsafe { ffi::SSL_get_num_tickets(self.as_ptr()) }
+    }
+
+    /// Set the connection's security level, which controls the allowed parameters
+    /// and algorithms.
+    ///
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[corresponds(SSL_set_security_level)]
+    #[cfg(ossl110)]
+    pub fn set_security_level(&mut self, level: u32) {
+        unsafe { ffi::SSL_set_security_level(self.as_ptr(), level as c_int) }
+    }
+
+    /// Get the connection's security level, which controls the allowed parameters
+    /// and algorithms.
+    ///
+    /// Requires OpenSSL 1.1.0 or newer.
+    #[corresponds(SSL_get_security_level)]
+    #[cfg(ossl110)]
+    pub fn security_level(&self) -> u32 {
+        unsafe { ffi::SSL_get_security_level(self.as_ptr()) as u32 }
     }
 }
 

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1718,12 +1718,12 @@ impl SslContextBuilder {
         unsafe { cvt(ffi::SSL_CTX_set_num_tickets(self.as_ptr(), num_tickets)).map(|_| ()) }
     }
 
-    /// Set the context's security level, which controls the allowed parameters
-    /// and algorithms.
+    /// Set the context's security level to a value between 0 and 5, inclusive.
+    /// A security value of 0 allows allows all parameters and algorithms.
     ///
     /// Requires OpenSSL 1.1.0 or newer.
     #[corresponds(SSL_CTX_set_security_level)]
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     pub fn set_security_level(&mut self, level: u32) {
         unsafe { ffi::SSL_CTX_set_security_level(self.as_ptr(), level as c_int) }
     }
@@ -1937,7 +1937,7 @@ impl SslContextRef {
     ///
     /// Requires OpenSSL 1.1.0 or newer.
     #[corresponds(SSL_CTX_get_security_level)]
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     pub fn security_level(&self) -> u32 {
         unsafe { ffi::SSL_CTX_get_security_level(self.as_ptr()) as u32 }
     }
@@ -3426,12 +3426,12 @@ impl SslRef {
         unsafe { ffi::SSL_get_num_tickets(self.as_ptr()) }
     }
 
-    /// Set the connection's security level, which controls the allowed parameters
-    /// and algorithms.
+    /// Set the context's security level to a value between 0 and 5, inclusive.
+    /// A security value of 0 allows allows all parameters and algorithms.
     ///
     /// Requires OpenSSL 1.1.0 or newer.
     #[corresponds(SSL_set_security_level)]
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     pub fn set_security_level(&mut self, level: u32) {
         unsafe { ffi::SSL_set_security_level(self.as_ptr(), level as c_int) }
     }
@@ -3441,7 +3441,7 @@ impl SslRef {
     ///
     /// Requires OpenSSL 1.1.0 or newer.
     #[corresponds(SSL_get_security_level)]
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl360))]
     pub fn security_level(&self) -> u32 {
         unsafe { ffi::SSL_get_security_level(self.as_ptr()) as u32 }
     }

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1574,3 +1574,17 @@ fn set_num_tickets() {
     let ssl = ssl;
     assert_eq!(5, ssl.num_tickets());
 }
+
+#[test]
+#[cfg(ossl110)]
+fn set_security_level() {
+    let mut ctx = SslContext::builder(SslMethod::tls_server()).unwrap();
+    ctx.set_security_level(3);
+    let ctx = ctx.build();
+    assert_eq!(3, ctx.security_level());
+
+    let mut ssl = Ssl::new(&ctx).unwrap();
+    ssl.set_security_level(4);
+    let ssl = ssl;
+    assert_eq!(4, ssl.security_level());
+}


### PR DESCRIPTION
This PR adds bindings for a limited set of the `set_security_level` methods

```
void SSL_CTX_set_security_level(SSL_CTX *ctx, int level);
void SSL_set_security_level(SSL *s, int level);

int SSL_CTX_get_security_level(const SSL_CTX *ctx);
int SSL_get_security_level(const SSL *s);
```

https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_security_level.html

>  These functions were added in OpenSSL 1.1.0. 

>  SSL_CTX_set_security_level() and SSL_set_security_level() do not return values.
> SSL_CTX_get_security_level() and SSL_get_security_level() return a integer that represents the security level with SSL_CTX or SSL, respectively. 

I chose to expose the security level as an unsigned integer, even through the C api uses a signed integer because the only described security levels are 0 - 5 inclusive. This follows the precedent for the `set_verify_depth` bindings which similarly uses a `u32` in the rust bindings even through the C api uses a signed integer. Let me know if you'd prefer the security level to be represented as an `i32` instead.

This PR addresses #1380 