### PR TITLE
add temp key bindings

### DIFF
--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -512,12 +512,12 @@ cfg_if! {
 }
 cfg_if! {
     if #[cfg(ossl300)] {
-        pub unsafe fn SSL_get_peer_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_int {
-            SSL_ctrl(ssl, SSL_CTRL_GET_PEER_TMP_KEY, 0, key as *mut c_void) as c_int
+        pub unsafe fn SSL_get_peer_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_long {
+            SSL_ctrl(ssl, SSL_CTRL_GET_PEER_TMP_KEY, 0, key as *mut c_void)
         }
 
-        pub unsafe fn SSL_get_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_int {
-            SSL_ctrl(ssl, SSL_CTRL_GET_TMP_KEY, 0, key as *mut c_void) as c_int
+        pub unsafe fn SSL_get_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_long {
+            SSL_ctrl(ssl, SSL_CTRL_GET_TMP_KEY, 0, key as *mut c_void)
         }
     }
 }

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -349,6 +349,7 @@ pub const SSL_CTRL_SET_ECDH_AUTO: c_int = 94;
 pub const SSL_CTRL_SET_SIGALGS_LIST: c_int = 98;
 #[cfg(ossl102)]
 pub const SSL_CTRL_SET_VERIFY_CERT_STORE: c_int = 106;
+#[cfg(ossl300)]
 pub const SSL_CTRL_GET_PEER_TMP_KEY: c_int = 109;
 #[cfg(ossl110)]
 pub const SSL_CTRL_GET_EXTMS_SUPPORT: c_int = 122;
@@ -360,6 +361,7 @@ pub const SSL_CTRL_SET_MAX_PROTO_VERSION: c_int = 124;
 pub const SSL_CTRL_GET_MIN_PROTO_VERSION: c_int = 130;
 #[cfg(any(ossl110g, libressl270))]
 pub const SSL_CTRL_GET_MAX_PROTO_VERSION: c_int = 131;
+#[cfg(ossl300)]
 pub const SSL_CTRL_GET_TMP_KEY: c_int = 133;
 
 pub unsafe fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *mut DH) -> c_long {
@@ -508,13 +510,16 @@ cfg_if! {
         }
     }
 }
+cfg_if! {
+    if #[cfg(ossl300)] {
+        pub unsafe fn SSL_get_peer_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_int {
+            SSL_ctrl(ssl, SSL_CTRL_GET_PEER_TMP_KEY, 0, key as *mut c_void) as c_int
+        }
 
-pub unsafe fn SSL_get_peer_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_int {
-    SSL_ctrl(ssl, SSL_CTRL_GET_PEER_TMP_KEY, 0, key as *mut c_void) as c_int
-}
-
-pub unsafe fn SSL_get_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_int {
-    SSL_ctrl(ssl, SSL_CTRL_GET_TMP_KEY, 0, key as *mut c_void) as c_int
+        pub unsafe fn SSL_get_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_int {
+            SSL_ctrl(ssl, SSL_CTRL_GET_TMP_KEY, 0, key as *mut c_void) as c_int
+        }
+    }
 }
 
 #[cfg(ossl111)]

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -349,6 +349,7 @@ pub const SSL_CTRL_SET_ECDH_AUTO: c_int = 94;
 pub const SSL_CTRL_SET_SIGALGS_LIST: c_int = 98;
 #[cfg(ossl102)]
 pub const SSL_CTRL_SET_VERIFY_CERT_STORE: c_int = 106;
+pub const SSL_CTRL_GET_PEER_TMP_KEY: c_int = 109;
 #[cfg(ossl110)]
 pub const SSL_CTRL_GET_EXTMS_SUPPORT: c_int = 122;
 #[cfg(any(ossl110, libressl261))]
@@ -359,6 +360,7 @@ pub const SSL_CTRL_SET_MAX_PROTO_VERSION: c_int = 124;
 pub const SSL_CTRL_GET_MIN_PROTO_VERSION: c_int = 130;
 #[cfg(any(ossl110g, libressl270))]
 pub const SSL_CTRL_GET_MAX_PROTO_VERSION: c_int = 131;
+pub const SSL_CTRL_GET_TMP_KEY: c_int = 133;
 
 pub unsafe fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *mut DH) -> c_long {
     SSL_CTX_ctrl(ctx, SSL_CTRL_SET_TMP_DH, 0, dh as *mut c_void)
@@ -505,6 +507,14 @@ cfg_if! {
             SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, ptr::null_mut()) as c_int
         }
     }
+}
+
+pub unsafe fn SSL_get_peer_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_int {
+    SSL_ctrl(ssl, SSL_CTRL_GET_PEER_TMP_KEY, 0, key as *mut c_void) as c_int
+}
+
+pub unsafe fn SSL_get_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_int {
+    SSL_ctrl(ssl, SSL_CTRL_GET_TMP_KEY, 0, key as *mut c_void) as c_int
 }
 
 #[cfg(ossl111)]

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -124,7 +124,7 @@
 #[doc(inline)]
 pub use ffi::init;
 
-use libc::c_int;
+use libc::{c_int, c_long};
 
 use crate::error::ErrorStack;
 
@@ -205,6 +205,15 @@ fn cvt_p<T>(r: *mut T) -> Result<*mut T, ErrorStack> {
 
 #[inline]
 fn cvt(r: c_int) -> Result<c_int, ErrorStack> {
+    if r <= 0 {
+        Err(ErrorStack::get())
+    } else {
+        Ok(r)
+    }
+}
+
+#[inline]
+fn cvt_long(r: c_long) -> Result<c_long, ErrorStack> {
     if r <= 0 {
         Err(ErrorStack::get())
     } else {

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -124,7 +124,9 @@
 #[doc(inline)]
 pub use ffi::init;
 
-use libc::{c_int, c_long};
+use libc::c_int;
+#[cfg(ossl300)]
+use libc::c_long;
 
 use crate::error::ErrorStack;
 
@@ -212,7 +214,11 @@ fn cvt(r: c_int) -> Result<c_int, ErrorStack> {
     }
 }
 
+// cvt_long is currently only used in functions that require openssl >= 3.0.0,
+// so this cfg statement is used to avoid "unused function" errors when
+// compiling with openssl < 3.0.0
 #[inline]
+#[cfg(ossl300)]
 fn cvt_long(r: c_long) -> Result<c_long, ErrorStack> {
     if r <= 0 {
         Err(ErrorStack::get())

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3452,7 +3452,7 @@ impl SslRef {
     // dropped
     #[corresponds(SSL_get_peer_tmp_key)]
     #[cfg(ossl300)]
-    pub fn peer_temp_key(&self) -> Result<PKey<Public>, ErrorStack> {
+    pub fn peer_tmp_key(&self) -> Result<PKey<Public>, ErrorStack> {
         unsafe {
             let mut key = ptr::null_mut();
             match cvt(ffi::SSL_get_peer_tmp_key(self.as_ptr(), &mut key)) {
@@ -3468,7 +3468,7 @@ impl SslRef {
     // dropped
     #[corresponds(SSL_get_tmp_key)]
     #[cfg(ossl300)]
-    pub fn temp_key(&self) -> Result<PKey<Public>, ErrorStack> {
+    pub fn tmp_key(&self) -> Result<PKey<Public>, ErrorStack> {
         unsafe {
             let mut key = ptr::null_mut();
             match cvt(ffi::SSL_get_tmp_key(self.as_ptr(), &mut key)) {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -78,7 +78,7 @@ use crate::x509::store::{X509Store, X509StoreBuilderRef, X509StoreRef};
 #[cfg(any(ossl102, libressl261))]
 use crate::x509::verify::X509VerifyParamRef;
 use crate::x509::{X509Name, X509Ref, X509StoreContextRef, X509VerifyResult, X509};
-use crate::{cvt, cvt_n, cvt_p, init};
+use crate::{cvt, cvt_long, cvt_n, cvt_p, init};
 use bitflags::bitflags;
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
@@ -3455,7 +3455,7 @@ impl SslRef {
     pub fn peer_tmp_key(&self) -> Result<PKey<Public>, ErrorStack> {
         unsafe {
             let mut key = ptr::null_mut();
-            match cvt(ffi::SSL_get_peer_tmp_key(self.as_ptr(), &mut key)) {
+            match cvt_long(ffi::SSL_get_peer_tmp_key(self.as_ptr(), &mut key)) {
                 Ok(_) => Ok(PKey::<Public>::from_ptr(key)),
                 Err(e) => Err(e),
             }
@@ -3471,7 +3471,7 @@ impl SslRef {
     pub fn tmp_key(&self) -> Result<PKey<Public>, ErrorStack> {
         unsafe {
             let mut key = ptr::null_mut();
-            match cvt(ffi::SSL_get_tmp_key(self.as_ptr(), &mut key)) {
+            match cvt_long(ffi::SSL_get_tmp_key(self.as_ptr(), &mut key)) {
                 Ok(_) => Ok(PKey::<Public>::from_ptr(key)),
                 Err(e) => Err(e),
             }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3451,6 +3451,7 @@ impl SslRef {
     // We use an owned value because EVP_KEY free need to be called when it is
     // dropped
     #[corresponds(SSL_get_peer_tmp_key)]
+    #[cfg(ossl300)]
     pub fn peer_temp_key(&self) -> Result<PKey<Public>, ErrorStack> {
         unsafe {
             let mut key = ptr::null_mut();
@@ -3465,7 +3466,8 @@ impl SslRef {
     /// used during key exchange.
     // We use an owned value because EVP_KEY free need to be called when it is
     // dropped
-    #[corresponds(SSL_get_peer_tmp_key)]
+    #[corresponds(SSL_get_tmp_key)]
+    #[cfg(ossl300)]
     pub fn temp_key(&self) -> Result<PKey<Public>, ErrorStack> {
         unsafe {
             let mut key = ptr::null_mut();

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -57,6 +57,8 @@
 //!     }
 //! }
 //! ```
+#[cfg(ossl300)]
+use crate::cvt_long;
 use crate::dh::{Dh, DhRef};
 #[cfg(all(ossl101, not(ossl110)))]
 use crate::ec::EcKey;
@@ -67,7 +69,9 @@ use crate::ex_data::Index;
 use crate::hash::MessageDigest;
 #[cfg(any(ossl110, libressl270))]
 use crate::nid::Nid;
-use crate::pkey::{HasPrivate, PKey, PKeyRef, Params, Private, Public};
+use crate::pkey::{HasPrivate, PKeyRef, Params, Private};
+#[cfg(ossl300)]
+use crate::pkey::{PKey, Public};
 use crate::srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
 use crate::ssl::bio::BioMethod;
 use crate::ssl::callbacks::*;
@@ -78,7 +82,7 @@ use crate::x509::store::{X509Store, X509StoreBuilderRef, X509StoreRef};
 #[cfg(any(ossl102, libressl261))]
 use crate::x509::verify::X509VerifyParamRef;
 use crate::x509::{X509Name, X509Ref, X509StoreContextRef, X509VerifyResult, X509};
-use crate::{cvt, cvt_long, cvt_n, cvt_p, init};
+use crate::{cvt, cvt_n, cvt_p, init};
 use bitflags::bitflags;
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
@@ -3468,16 +3472,15 @@ impl SslRef {
     // dropped
     #[corresponds(SSL_get_tmp_key)]
     #[cfg(ossl300)]
-    pub fn tmp_key(&self) -> Result<PKey<Public>, ErrorStack> {
+    pub fn tmp_key(&self) -> Result<PKey<Private>, ErrorStack> {
         unsafe {
             let mut key = ptr::null_mut();
             match cvt_long(ffi::SSL_get_tmp_key(self.as_ptr(), &mut key)) {
-                Ok(_) => Ok(PKey::<Public>::from_ptr(key)),
+                Ok(_) => Ok(PKey::<Private>::from_ptr(key)),
                 Err(e) => Err(e),
             }
         }
     }
-
 }
 
 /// An SSL stream midway through the handshake process.

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -331,11 +331,11 @@ fn peer_temp_key_p384() {
     server.ctx().set_groups_list("P-384").unwrap();
     let server = server.build();
     let s = server.client().connect();
-    let peer_temp = s.ssl().peer_temp_key().unwrap();
+    let peer_temp = s.ssl().peer_tmp_key().unwrap();
     assert_eq!(peer_temp.id(), Id::EC);
     assert_eq!(peer_temp.bits(), 384);
 
-    let local_temp = s.ssl().temp_key().unwrap();
+    let local_temp = s.ssl().tmp_key().unwrap();
     assert_eq!(local_temp.id(), Id::EC);
     assert_eq!(local_temp.bits(), 384);
 
@@ -360,11 +360,11 @@ fn peer_temp_key_rsa() {
     let mut client = server.client();
     client.ctx().set_groups_list("P-521").unwrap();
     let s = client.connect();
-    let peer_temp = s.ssl().peer_temp_key();
+    let peer_temp = s.ssl().peer_tmp_key();
     assert!(peer_temp.is_err());
 
     // this is the temp key that the client sent in the initial key share
-    let local_temp = s.ssl().temp_key().unwrap();
+    let local_temp = s.ssl().tmp_key().unwrap();
     assert_eq!(local_temp.id(), Id::EC);
     assert_eq!(local_temp.bits(), 521);
 }

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -355,7 +355,10 @@ fn peer_tmp_key_rsa() {
     server.ctx().set_cipher_list("RSA").unwrap();
     // RSA key exchange is not allowed in TLS 1.3, so force the connection
     // to negotiate TLS 1.2
-    server.ctx().set_max_proto_version(Some(SslVersion::TLS1_2)).unwrap();
+    server
+        .ctx()
+        .set_max_proto_version(Some(SslVersion::TLS1_2))
+        .unwrap();
     let server = server.build();
     let mut client = server.client();
     client.ctx().set_groups_list("P-521").unwrap();

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -19,7 +19,7 @@ use crate::error::ErrorStack;
 use crate::hash::MessageDigest;
 #[cfg(not(boringssl))]
 use crate::ocsp::{OcspResponse, OcspResponseStatus};
-use crate::pkey::PKey;
+use crate::pkey::{Id, PKey};
 use crate::srtp::SrtpProfileId;
 use crate::ssl::test::server::Server;
 #[cfg(any(ossl110, ossl111, libressl261))]
@@ -320,6 +320,51 @@ fn state() {
         s.ssl().state_string_long(),
         "SSL negotiation finished successfully"
     );
+}
+
+// when a connection uses ECDHE P-256 key exchange, then the temp key APIs
+// return P-256 keys, and the peer and local keys are different.
+#[test]
+fn peer_temp_key_p384() {
+    let mut server = Server::builder();
+    server.ctx().set_groups_list("P-384").unwrap();
+    let server = server.build();
+    let s = server.client().connect();
+    let peer_temp = s.ssl().peer_temp_key().unwrap();
+    assert_eq!(peer_temp.id(), Id::EC);
+    assert_eq!(peer_temp.bits(), 384);
+
+    let local_temp = s.ssl().temp_key().unwrap();
+    assert_eq!(local_temp.id(), Id::EC);
+    assert_eq!(local_temp.bits(), 384);
+
+    assert_ne!(
+        peer_temp.ec_key().unwrap().public_key_to_der().unwrap(),
+        local_temp.ec_key().unwrap().public_key_to_der().unwrap(),
+    );
+}
+
+// when a connection uses RSA key exchange, then the peer (server) temp key is
+// an Error because there is no temp key, and the local (client) temp key is the
+// temp key sent in the initial key share.
+#[test]
+fn peer_temp_key_rsa() {
+    let mut server = Server::builder();
+    server.ctx().set_cipher_list("RSA").unwrap();
+    // RSA key exchange is not allowed in TLS 1.3, so force the connection
+    // to negotiate TLS 1.2
+    server.ctx().set_max_proto_version(Some(SslVersion::TLS1_2)).unwrap();
+    let server = server.build();
+    let mut client = server.client();
+    client.ctx().set_groups_list("P-521").unwrap();
+    let s = client.connect();
+    let peer_temp = s.ssl().peer_temp_key();
+    assert!(peer_temp.is_err());
+
+    // this is the temp key that the client sent in the initial key share
+    let local_temp = s.ssl().temp_key().unwrap();
+    assert_eq!(local_temp.id(), Id::EC);
+    assert_eq!(local_temp.bits(), 521);
 }
 
 /// Tests that when both the client as well as the server use SRTP and their

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -326,7 +326,7 @@ fn state() {
 // return P-384 keys, and the peer and local keys are different.
 #[test]
 #[cfg(ossl300)]
-fn peer_temp_key_p384() {
+fn peer_tmp_key_p384() {
     let mut server = Server::builder();
     server.ctx().set_groups_list("P-384").unwrap();
     let server = server.build();
@@ -350,7 +350,7 @@ fn peer_temp_key_p384() {
 // temp key sent in the initial key share.
 #[test]
 #[cfg(ossl300)]
-fn peer_temp_key_rsa() {
+fn peer_tmp_key_rsa() {
     let mut server = Server::builder();
     server.ctx().set_cipher_list("RSA").unwrap();
     // RSA key exchange is not allowed in TLS 1.3, so force the connection

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -322,9 +322,10 @@ fn state() {
     );
 }
 
-// when a connection uses ECDHE P-256 key exchange, then the temp key APIs
-// return P-256 keys, and the peer and local keys are different.
+// when a connection uses ECDHE P-384 key exchange, then the temp key APIs
+// return P-384 keys, and the peer and local keys are different.
 #[test]
+#[cfg(ossl300)]
 fn peer_temp_key_p384() {
     let mut server = Server::builder();
     server.ctx().set_groups_list("P-384").unwrap();
@@ -348,6 +349,7 @@ fn peer_temp_key_p384() {
 // an Error because there is no temp key, and the local (client) temp key is the
 // temp key sent in the initial key share.
 #[test]
+#[cfg(ossl300)]
 fn peer_temp_key_rsa() {
     let mut server = Server::builder();
     server.ctx().set_cipher_list("RSA").unwrap();


### PR DESCRIPTION
This PR adds bindings for a selection of the "temp key" apis.

https://www.openssl.org/docs/manmaster/man3/SSL_get_peer_tmp_key.html

These functions are implemented using the `ctrl` macro. Constants are taken from 

https://github.com/openssl/openssl/blob/497a7810bcee48781aa12d4db870f6a565bd0592/include/openssl/ssl.h.in#L1314

https://github.com/openssl/openssl/blob/497a7810bcee48781aa12d4db870f6a565bd0592/include/openssl/ssl.h.in#L1334
### API Shape
The api's return a `Result<PKey>` rather than a `Result<Option<PKey>>`, because it is expected that whenever the function returns a non-error value, the key is valid. This can be seen from the implementation of the function in openssl source:
https://github.com/openssl/openssl/blob/186b3f6a016de8fcf8573be111e3d174ca20f1bc/ssl/s3_lib.c#L3734-L3741

### Macro Return Value
The Openssl `ctrl` macros return `c_long`, but the functions implemented the macros normally downcast this to a `c_int`. The `tmp_key` apis do not downcast this value, and instead return a `c_long`. I added an additional `cvt_long` error function to handle this.

### History
The man pages don't mention anything about the history of the function and I couldn't find anything in the [changelog](https://www.openssl.org/news/changelog.txt) so I dug through the openssl git repository to find the commit that introduced the `tmp_key` apis.

```
commit a51c9f637cdef7926d8a8991365e4b58975346db
Author: Viktor Dukhovni <openssl-users@dukhovni.org>
Date:   Sat Nov 10 01:53:56 2018 -0500

    Added missing signature algorithm reflection functions
    
        SSL_get_signature_nid()      -- local signature algorithm
        SSL_get_signature_type_nid() -- local signature algorithm key type
        SSL_get_peer_tmp_key()       -- Peer key-exchange public key
        SSL_get_tmp_key              -- local key exchange public key
    
    Aliased pre-existing SSL_get_server_tmp_key(), which was formerly
    just for clients, to SSL_get_peer_tmp_key().  Changed internal
    calls to use the new name.
    
    Reviewed-by: Matt Caswell <matt@openssl.org>
```

I then pulled in git branches until I found the ones that contained the feature commit.
```
~/workspace/openssl$ git branch
  OpenSSL_1_0_2-stable
  OpenSSL_1_1_0-stable
  OpenSSL_1_1_1-stable
  master
* openssl-3.0
~/workspace/openssl$ git branch --contains a51c9f637cdef7926d8a8991365e4b58975346db
  master
* openssl-3.0
```

From this, I concluded that the APIs were first available in Openssl 3.0.0
