### PR TITLE
Add binding to NID of Chacha20-Poly1305 cipher

### DIFF
--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -996,3 +996,7 @@ pub const NID_sha3_512: c_int = 1034;
 pub const NID_shake128: c_int = 1100;
 #[cfg(ossl111)]
 pub const NID_shake256: c_int = 1101;
+#[cfg(ossl110)]
+pub const NID_chacha20_poly1305: c_int = 1018;
+#[cfg(libressl271)]
+pub const NID_chacha20_poly1305: c_int = 967;

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -1090,6 +1090,8 @@ impl Nid {
     pub const SHAKE128: Nid = Nid(ffi::NID_shake128);
     #[cfg(ossl111)]
     pub const SHAKE256: Nid = Nid(ffi::NID_shake256);
+    #[cfg(any(ossl110, libressl271))]
+    pub const CHACHA20_POLY1305: Nid = Nid(ffi::NID_chacha20_poly1305);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Ref:
- https://github.com/openssl/openssl/blob/OpenSSL_1_1_0l/include/openssl/obj_mac.h#L4325
- https://github.com/openbsd/src/blob/d781822394e40621101778573b197bbb39bc8d5b/lib/libcrypto/objects/obj_mac.num#L967