### PR TITLE
Remove dynamic allocation of atomic

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -130,7 +130,7 @@ fn main() {
             || env::var("CARGO_CFG_TARGET_OS").unwrap() == "android")
         && env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap() == "32"
     {
-        println!("cargo:rustc-link-lib=dylib=atomic");
+        println!("cargo:rustc-link-lib=atomic");
     }
 
     if kind == "static" && target.contains("windows") {


### PR DESCRIPTION
Since #1925 building static binaries fails because of a hardcoded `dylib`. Removing the `dylib` but still let rust search for the dependency it will still link it, but then statically.

This should still keep #1645 fixed but also fixes #2043.

I have tested this by building Vaultwarden for both dynamically linked debian based image, and a statically linked musl/alpine based image. Both are using OpenSSL v3.x.x.

Closes #2058