### PR TITLE
fixes #2096 -- deprecate `X509StoreRef::objects`, it is unsound

### DIFF
--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -644,6 +644,8 @@ const_ptr_api! {
     extern "C" {
         #[cfg(any(ossl110, libressl270))]
         pub fn X509_STORE_get0_objects(ctx: #[const_ptr_if(ossl300)] X509_STORE) -> *mut stack_st_X509_OBJECT;
+        #[cfg(ossl300)]
+        pub fn X509_STORE_get1_all_certs(ctx: *mut X509_STORE) -> *mut stack_st_X509;
     }
 }
 

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -581,7 +581,8 @@ impl CipherCtxRef {
     /// output size check removed. It can be used when the exact
     /// buffer size control is maintained by the caller.
     ///
-    /// SAFETY: The caller is expected to provide `output` buffer
+    /// # Safety
+    /// The caller is expected to provide `output` buffer
     /// large enough to contain correct number of bytes. For streaming
     /// ciphers the output buffer size should be at least as big as
     /// the input buffer. For block ciphers the size of the output
@@ -693,7 +694,8 @@ impl CipherCtxRef {
     /// This function is the same as [`Self::cipher_final`] but with
     /// the output buffer size check removed.
     ///
-    /// SAFETY: The caller is expected to provide `output` buffer
+    /// # Safety
+    /// The caller is expected to provide `output` buffer
     /// large enough to contain correct number of bytes. For streaming
     /// ciphers the output buffer can be empty, for block ciphers the
     /// output buffer should be at least as big as the block.

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -119,7 +119,7 @@
 //! ```
 #![doc(html_root_url = "https://docs.rs/openssl/0.10")]
 #![warn(rust_2018_idioms)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::needless_doctest_main)]
 
 #[doc(inline)]
 pub use ffi::init;

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -1177,3 +1177,18 @@ fn test_dist_point_null() {
     let cert = X509::from_pem(cert).unwrap();
     assert!(cert.crl_distribution_points().is_none());
 }
+
+#[test]
+#[cfg(ossl300)]
+fn test_store_all_certificates() {
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+
+    let store = {
+        let mut b = X509StoreBuilder::new().unwrap();
+        b.add_cert(cert).unwrap();
+        b.build()
+    };
+
+    assert_eq!(store.all_certificates().len(), 1);
+}


### PR DESCRIPTION
Introduce `X509StoreRef::all_certificates` as a replacement.