### PR TITLE
Don't leak when overwriting ex data

### DIFF
--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -581,7 +581,9 @@ impl CipherCtxRef {
     /// output size check removed. It can be used when the exact
     /// buffer size control is maintained by the caller.
     ///
-    /// SAFETY: The caller is expected to provide `output` buffer
+    /// # Safety
+    ///
+    /// The caller is expected to provide `output` buffer
     /// large enough to contain correct number of bytes. For streaming
     /// ciphers the output buffer size should be at least as big as
     /// the input buffer. For block ciphers the size of the output
@@ -693,7 +695,9 @@ impl CipherCtxRef {
     /// This function is the same as [`Self::cipher_final`] but with
     /// the output buffer size check removed.
     ///
-    /// SAFETY: The caller is expected to provide `output` buffer
+    /// # Safety
+    ///
+    /// The caller is expected to provide `output` buffer
     /// large enough to contain correct number of bytes. For streaming
     /// ciphers the output buffer can be empty, for block ciphers the
     /// output buffer should be at least as big as the block.

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -119,7 +119,7 @@
 //! ```
 #![doc(html_root_url = "https://docs.rs/openssl/0.10")]
 #![warn(rust_2018_idioms)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::needless_doctest_main)]
 
 #[doc(inline)]
 pub use ffi::init;


### PR DESCRIPTION
The `_set_ex_data` OpenSSL functions don't drop a previously set value when overwriting it. We now only call that function the first time a value for an index is set, avoiding the leak.