### PR TITLE
Add two methods to the PKCS7 API

### DIFF
--- a/openssl/CHANGELOG.md
+++ b/openssl/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+* Added `Pkcs7Ref::{type_,signed}`.
+* Added `Pkcs7SignedRef::certificates`.
+
 ## [v0.10.62] - 2023-12-22
 
 ### Added


### PR DESCRIPTION
This PR adds two new methods:
- `Pkcs7Ref::type_` returns the type of the PKCS#7 object (signed, envelope, etc)

- `Pkcs7Ref::signed` returns the PKCS7_SIGNED member of a signed PKCS#7 object (as a `Pkcs7SignedRef`)

It also adds a `Pkcs7SignedRef::certificates` method, to access the stack of certificates of a signed PKCS7 object.

The motivation behind adding these methods is that `cryptography` [is migrating](https://github.com/pyca/cryptography/issues/8770) its PKCS7 backend implementation from Python to Rust.
[Here](https://github.com/pyca/cryptography/blob/6359dc0e0483b123bb81a329e393314786cb7dff/src/cryptography/hazmat/backends/openssl/backend.py#L1104-L1126) is the Python code that would be replaced by Rust, which manually access the data structures that this PR exposes through the API.

One thing I'm not sure about (in `certificates()`) is my handling of the Stack as a reference, and the ownership status of the certificates inside of it, so any suggestions/fixes are welcome.