### PR TITLE
Use X509_PURPOSE_get_id instead of struct access

### DIFF
--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -687,21 +687,12 @@ extern "C" {
     pub fn X509_REQ_print(bio: *mut BIO, req: *mut X509_REQ) -> c_int;
 }
 
-#[repr(C)]
-pub struct X509_PURPOSE {
-    pub purpose: c_int,
-    pub trust: c_int, // Default trust ID
-    pub flags: c_int,
-    pub check_purpose:
-        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
-    pub name: *mut c_char,
-    pub sname: *mut c_char,
-    pub usr_data: *mut c_void,
-}
+pub enum X509_PURPOSE {}
 
 const_ptr_api! {
     extern "C" {
         pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
+        pub fn X509_PURPOSE_get_id(purpose: #[const_ptr_if(any(ossl110, libressl280))] X509_PURPOSE) -> c_int;
     }
 }
 extern "C" {

--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -687,7 +687,17 @@ extern "C" {
     pub fn X509_REQ_print(bio: *mut BIO, req: *mut X509_REQ) -> c_int;
 }
 
-pub enum X509_PURPOSE {}
+#[repr(C)]
+pub struct X509_PURPOSE {
+    pub purpose: c_int,
+    pub trust: c_int, // Default trust ID
+    pub flags: c_int,
+    pub check_purpose:
+        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
+    pub name: *mut c_char,
+    pub sname: *mut c_char,
+    pub usr_data: *mut c_void,
+}
 
 const_ptr_api! {
     extern "C" {


### PR DESCRIPTION
The accessor was added at the same version as the struct, so better to just use it. As with X509_PURPOSE_get_by_sname, it was const-corrected later on.