### PR TITLE
Configure OpenSSL data dir on vendored builds.

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -25,7 +25,7 @@ bssl-sys = { version = "0.1.0", optional = true }
 [build-dependencies]
 bindgen = { version = "0.65.0", optional = true, features = ["experimental"] }
 cc = "1.0.61"
-openssl-src = { version = "300.1.2", optional = true, features = ["legacy"] }
+openssl-src = { version = "300.2.0", optional = true, features = ["legacy"] }
 pkg-config = "0.3.9"
 vcpkg = "0.2.8"
 

--- a/openssl-sys/build/find_vendored.rs
+++ b/openssl-sys/build/find_vendored.rs
@@ -1,8 +1,17 @@
 use openssl_src;
 use std::path::PathBuf;
 
+use super::env;
+
 pub fn get_openssl(_target: &str) -> (Vec<PathBuf>, PathBuf) {
-    let artifacts = openssl_src::Build::new().build();
+    let openssl_config_dir = env("OPENSSL_CONFIG_DIR");
+
+    let mut openssl_src_build = openssl_src::Build::new();
+    if let Some(value) = openssl_config_dir {
+        openssl_src_build.openssl_dir(PathBuf::from(value));
+    }
+
+    let artifacts = openssl_src_build.build();
     println!("cargo:vendored=1");
     println!(
         "cargo:root={}",

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -19,8 +19,9 @@
 //! openssl = { version = "0.10", features = ["vendored"] }
 //! ```
 //!
-//! The vendored copy will not be configured to automatically find the system's root certificates, but the
-//! `openssl-probe` crate can be used to do that instead.
+//! The vendored copy will be configured to automatically find a configuration and root certificates at `/usr/local/ssl`.
+//! This path can be overridden with an environment variable (see the manual section below).
+//! Alternatively, the `openssl-probe` crate can be used to find root certificates at runtime.
 //!
 //! ## Automatic
 //!
@@ -66,6 +67,12 @@
 //! * `OPENSSL_LIBS` - If set, a `:`-separated list of library names to link to (e.g. `ssl:crypto`). This can be used
 //!     if nonstandard library names were used for whatever reason.
 //! * `OPENSSL_NO_VENDOR` - If set, always find OpenSSL in the system, even if the `vendored` feature is enabled.
+//!
+//! If the `vendored` Cargo feature is enabled, the following environment variable can also be used to further configure
+//! the OpenSSL build.
+//!
+//! * `OPENSSL_CONFIG_DIR` - If set, the copy of OpenSSL built by the `openssl-src` crate will be configured to look for
+//!     configuration files and root certificates in this directory.
 //!
 //! Additionally, these variables can be prefixed with the upper-cased target architecture (e.g.
 //!     `X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR`), which can be useful when cross compiling.


### PR DESCRIPTION
Currently, any build using Nix fails if it's attempting to build a static binary (musl target) that uses this crate with the `vendored` flag. This happened because the `openssl-src` crate looked for the openssl dir using a hardcoded path, and was recently fixed in https://github.com/alexcrichton/openssl-src-rs/pull/220.

This PR bumps the version of `openssl-src` to get the fix, and propagates the value of the `OPENSSL_DIR` environment variable to `openssl-src` if it's set. This is all that's needed to unblock static musl builds on Nix.