### PR TITLE
Fix tests on macOS

### DIFF
--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -475,14 +475,10 @@ mod test {
         // check verification result - this is an invalid signature
         // defined in openssl crypto/cms/cms.h
         const CMS_R_CERTIFICATE_VERIFY_ERROR: i32 = 100;
-        match res {
-            Err(es) => {
-                let error_array = es.errors();
-                assert_eq!(1, error_array.len());
-                let code = error_array[0].code();
-                assert_eq!(ffi::ERR_GET_REASON(code), CMS_R_CERTIFICATE_VERIFY_ERROR);
-            }
-            _ => panic!("expected CMS verification error, got Ok()"),
-        }
+        let es = res.unwrap_err();
+        let error_array = es.errors();
+        assert_eq!(1, error_array.len());
+        let code = error_array[0].reason_code();
+        assert_eq!(code, CMS_R_CERTIFICATE_VERIFY_ERROR);
     }
 }

--- a/openssl/src/provider.rs
+++ b/openssl/src/provider.rs
@@ -55,6 +55,10 @@ impl Provider {
                 retain_fallbacks as _,
             ))?;
 
+            // OSSL_PROVIDER_try_load seems to leave errors on the stack, even
+            // when it succeeds.
+            let _ = ErrorStack::get();
+
             Ok(Provider::from_ptr(p))
         }
     }


### PR DESCRIPTION
It seems that `OSSL_PROVIDER_try_load` can leave errors on the stack.