### PR TITLE
Add `rand_priv_bytes`

### DIFF
--- a/openssl-sys/src/handwritten/rand.rs
+++ b/openssl-sys/src/handwritten/rand.rs
@@ -4,6 +4,9 @@ extern "C" {
     pub fn RAND_bytes(buf: *mut u8, num: c_int) -> c_int;
 
     #[cfg(ossl111)]
+    pub fn RAND_priv_bytes(buf: *mut u8, num: c_int) -> c_int;
+
+    #[cfg(ossl111)]
     pub fn RAND_keep_random_devices_open(keep: c_int);
 
     pub fn RAND_status() -> c_int;

--- a/openssl/src/rand.rs
+++ b/openssl/src/rand.rs
@@ -75,18 +75,16 @@ pub fn keep_random_devices_open(keep: bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::{rand_bytes, rand_priv_bytes};
-
     #[test]
     fn test_rand_bytes() {
         let mut buf = [0; 32];
-        rand_bytes(&mut buf).unwrap();
+        super::rand_bytes(&mut buf).unwrap();
     }
 
     #[test]
     #[cfg(ossl111)]
     fn test_rand_priv_bytes() {
         let mut buf = [0; 32];
-        rand_priv_bytes(&mut buf).unwrap();
+        super::rand_priv_bytes(&mut buf).unwrap();
     }
 }

--- a/openssl/src/rand.rs
+++ b/openssl/src/rand.rs
@@ -37,6 +37,31 @@ pub fn rand_bytes(buf: &mut [u8]) -> Result<(), ErrorStack> {
     }
 }
 
+/// Fill buffer with cryptographically strong pseudo-random bytes. It is
+/// intended to be used for generating values that should remain private.
+///
+/// # Examples
+///
+/// To generate a buffer with cryptographically strong random bytes:
+///
+/// ```
+/// use openssl::rand::rand_priv_bytes;
+///
+/// let mut buf = [0; 256];
+/// rand_priv_bytes(&mut buf).unwrap();
+/// ```
+///
+/// Requires OpenSSL 1.1.1 or newer.
+#[corresponds(RAND_priv_bytes)]
+#[cfg(ossl111)]
+pub fn rand_priv_bytes(buf: &mut [u8]) -> Result<(), ErrorStack> {
+    unsafe {
+        ffi::init();
+        assert!(buf.len() <= c_int::max_value() as usize);
+        cvt(ffi::RAND_priv_bytes(buf.as_mut_ptr(), buf.len() as LenType)).map(|_| ())
+    }
+}
+
 /// Controls random device file descriptor behavior.
 ///
 /// Requires OpenSSL 1.1.1 or newer.
@@ -50,11 +75,18 @@ pub fn keep_random_devices_open(keep: bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::rand_bytes;
+    use super::{rand_bytes, rand_priv_bytes};
 
     #[test]
     fn test_rand_bytes() {
         let mut buf = [0; 32];
         rand_bytes(&mut buf).unwrap();
+    }
+
+    #[test]
+    #[cfg(ossl111)]
+    fn test_rand_priv_bytes() {
+        let mut buf = [0; 32];
+        rand_priv_bytes(&mut buf).unwrap();
     }
 }


### PR DESCRIPTION
`rand_priv_bytes` has the same semantics as `rand_bytes`, and it is intended to be used for generating values that should remain private.

See https://www.openssl.org/docs/manmaster/man3/RAND_priv_bytes.html