### PR TITLE
Add nid constant for curve brainpoolP320r1

### DIFF
--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -97,6 +97,8 @@ pub const NID_sect571r1: c_int = 734;
 #[cfg(ossl110)]
 pub const NID_brainpoolP256r1: c_int = 927;
 #[cfg(ossl110)]
+pub const NID_brainpoolP320r1: c_int = 929;
+#[cfg(ossl110)]
 pub const NID_brainpoolP384r1: c_int = 931;
 #[cfg(ossl110)]
 pub const NID_brainpoolP512r1: c_int = 933;

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -218,6 +218,8 @@ impl Nid {
     #[cfg(ossl110)]
     pub const BRAINPOOL_P256R1: Nid = Nid(ffi::NID_brainpoolP256r1);
     #[cfg(ossl110)]
+    pub const BRAINPOOL_P320R1: Nid = Nid(ffi::NID_brainpoolP320r1);
+    #[cfg(ossl110)]
     pub const BRAINPOOL_P384R1: Nid = Nid(ffi::NID_brainpoolP384r1);
     #[cfg(ossl110)]
     pub const BRAINPOOL_P512R1: Nid = Nid(ffi::NID_brainpoolP512r1);


### PR DESCRIPTION
For the same reasons and approach taking in PR #1714 but I've added the NID constant for `brainpoolP320r1` too.
There are more variants of `brainpoolP*` left, but I didn't want to add them if nobody is using them (but I can if you want me to).