### PR TITLE
Remove broken link for Windows MSVC build failures, and put the exact command for vcpkg

### DIFF
--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -177,15 +177,24 @@ and try building this crate again.
         msg.push_str(
             "
 It looks like you're compiling for MSVC but we couldn't detect an OpenSSL
-installation. If there isn't one installed then you can try the rust-openssl
-README for more information about how to download precompiled binaries of
-OpenSSL:
+installation with vcpkg. Make sure you've installed the `openssl` package with
+a triplet ending in `-windows-static-md`.
 
-https://github.com/sfackler/rust-openssl#windows
+See the error output above for which triplet `vcpkg` tried to use.
 
 ",
         );
     }
+
+    msg.push_str(
+        "
+See the `rust-openssl` documentation for more information on how to provide a
+compatible version of OpenSSL to link against:
+
+https://docs.rs/openssl/latest/openssl/#building
+
+",
+    );
 
     panic!("{}", msg);
 }

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -37,6 +37,12 @@
 //! # macOS (pkgsrc)
 //! $ sudo pkgin install openssl
 //!
+//! # Windows (vcpkg) for static MSVC targets, install the architecture(s) you need
+//! > vcpkg install openssl:x64-windows-static-md openssl:x86-windows-static-md openssl:arm64-windows-static-md
+//!
+//! # Windows (MSYS2) for MinGW targets
+//! $ pacman -S openssl-devel pkg-config
+//!
 //! # Arch Linux
 //! $ sudo pacman -S pkg-config openssl
 //!


### PR DESCRIPTION
This adds `vcpkg` (MSVC) and `pacman` (MSYS2) commands to the generic build instructions, removes the broken link to `#windows` in the `README`, and links to the generic build instructions for everyone on build failures.

Sadly there's no architecture-agnostic `vcpkg install` command, but those seem to work on `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`, even cross-compiling.

Windows build issues keep coming up:

* https://github.com/sfackler/rust-openssl/issues/1062
* https://github.com/sfackler/rust-openssl/issues/1861
* https://github.com/sfackler/rust-openssl/issues/2125

Fixes #1062 #1861 #2125
