### PR TITLE
brew: add openssl@3.0 (for 3.0.x LTS releases)

### DIFF
--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -32,7 +32,7 @@ pub fn get_openssl(target: &str) -> (Vec<PathBuf>, PathBuf) {
 }
 
 fn resolve_with_wellknown_homebrew_location(dir: &str) -> Option<PathBuf> {
-    let versions = ["openssl@3", "openssl@1.1"];
+    let versions = ["openssl@3", "openssl@3.0", "openssl@1.1"];
 
     // Check up default aarch 64 Homebrew installation location first
     // for quick resolution if possible.


### PR DESCRIPTION
Also, it might be consider deprecating/removing openssl@1.1 (as it is already EOL)

<img width="779" alt="image" src="https://github.com/snort3/snort3/assets/1580956/e0689afb-164b-4482-85ec-bc4885d57404">
