### PR TITLE
Make X509_PURPOSE opaque for LibreSSL >= 3.9.0

### DIFF
--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -687,16 +687,22 @@ extern "C" {
     pub fn X509_REQ_print(bio: *mut BIO, req: *mut X509_REQ) -> c_int;
 }
 
-#[repr(C)]
-pub struct X509_PURPOSE {
-    pub purpose: c_int,
-    pub trust: c_int, // Default trust ID
-    pub flags: c_int,
-    pub check_purpose:
-        Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
-    pub name: *mut c_char,
-    pub sname: *mut c_char,
-    pub usr_data: *mut c_void,
+cfg_if! {
+    if #[cfg(libressl390)] {
+        pub enum X509_PURPOSE {}
+    } else {
+        #[repr(C)]
+        pub struct X509_PURPOSE {
+            pub purpose: c_int,
+            pub trust: c_int, // Default trust ID
+            pub flags: c_int,
+            pub check_purpose:
+                Option<unsafe extern "C" fn(*const X509_PURPOSE, *const X509, c_int) -> c_int>,
+            pub name: *mut c_char,
+            pub sname: *mut c_char,
+            pub usr_data: *mut c_void,
+        }
+    }
 }
 
 const_ptr_api! {


### PR DESCRIPTION
As discussed in https://github.com/sfackler/rust-openssl/pull/2115