### PR TITLE
add signature type retrieval functions

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -951,3 +951,12 @@ extern "C" {
     #[cfg(any(ossl110, libressl360))]
     pub fn SSL_get_security_level(s: *const SSL) -> c_int;
 }
+
+cfg_if! {
+    if #[cfg(ossl111)] {
+        extern "C" {
+            pub fn SSL_get_peer_signature_type_nid(s: *const SSL, pnid: *mut c_int) -> c_int;
+            pub fn SSL_get_signature_type_nid(s: *const SSL, pnid: *mut c_int) -> c_int;
+        }
+    }
+}

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -349,6 +349,8 @@ pub const SSL_CTRL_SET_ECDH_AUTO: c_int = 94;
 pub const SSL_CTRL_SET_SIGALGS_LIST: c_int = 98;
 #[cfg(ossl102)]
 pub const SSL_CTRL_SET_VERIFY_CERT_STORE: c_int = 106;
+#[cfg(ossl102)]
+pub const SSL_CTRL_GET_PEER_SIGNATURE_NID: c_int = 108;
 #[cfg(ossl300)]
 pub const SSL_CTRL_GET_PEER_TMP_KEY: c_int = 109;
 #[cfg(ossl110)]
@@ -361,6 +363,8 @@ pub const SSL_CTRL_SET_MAX_PROTO_VERSION: c_int = 124;
 pub const SSL_CTRL_GET_MIN_PROTO_VERSION: c_int = 130;
 #[cfg(any(ossl110g, libressl270))]
 pub const SSL_CTRL_GET_MAX_PROTO_VERSION: c_int = 131;
+#[cfg(ossl111)]
+pub const SSL_CTRL_GET_SIGNATURE_NID: c_int = 132;
 #[cfg(ossl300)]
 pub const SSL_CTRL_GET_TMP_KEY: c_int = 133;
 
@@ -521,6 +525,16 @@ cfg_if! {
         }
     }
 }
+
+    #[cfg(ossl102)]
+    pub unsafe fn SSL_get_peer_signature_nid(ssl: *mut SSL, psig_nid: *mut c_int) -> c_int {
+        SSL_ctrl(ssl, SSL_CTRL_GET_PEER_SIGNATURE_NID, 0, psig_nid as *mut c_void) as c_int
+    }
+
+    #[cfg(ossl111)]
+    pub unsafe fn SSL_get_signature_nid(ssl: *mut SSL, psig_nid: *mut c_int) -> c_int {
+        SSL_ctrl(ssl, SSL_CTRL_GET_SIGNATURE_NID, 0, psig_nid as *mut c_void) as c_int
+    }
 
 #[cfg(ossl111)]
 pub const SSL_CLIENT_HELLO_SUCCESS: c_int = 1;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3484,6 +3484,60 @@ impl SslRef {
             }
         }
     }
+
+    /// this returns the hash, e.g. SHA1, SHA512
+    #[corresponds(SSL_get_signature_nid)]
+    #[cfg(ossl111)]
+    pub fn signature_nid(&self) -> Result<Nid, ErrorStack> {
+        unsafe {
+            let mut pnid: c_int = 0;
+            match cvt(ffi::SSL_get_signature_nid(self.as_ptr(), &mut pnid)) {
+                Ok(_) => Ok(Nid::from_raw(pnid)),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    /// this returns the hash, e.g. SHA1, SHA512
+    #[corresponds(SSL_get_peer_signature_nid)]
+    #[cfg(ossl102)]
+    pub fn peer_signature_nid(&self) -> Result<Nid, ErrorStack> {
+        unsafe {
+            let mut pnid: c_int = 0;
+            match cvt(ffi::SSL_get_peer_signature_nid(self.as_ptr(), &mut pnid)) {
+                Ok(_) => Ok(Nid::from_raw(pnid)),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    /// this returns the signature algorithm e.g. RSA/RSA_PSS
+    #[corresponds(SSL_get_signature_type_nid)]
+    #[cfg(ossl111)]
+    pub fn signature_type_nid(&self) -> Result<Nid, ErrorStack> {
+        unsafe {
+            let mut pnid: c_int = 0;
+
+            match cvt(ffi::SSL_get_signature_type_nid(self.as_ptr(), &mut pnid)) {
+                Ok(_) => Ok(Nid::from_raw(pnid)),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    /// this returns the signature algorithm e.g. RSA/RSA_PSS
+    #[corresponds(SSL_get_peer_signature_type_nid)]
+    #[cfg(ossl111)]
+    pub fn peer_signature_type_nid(&self) -> Result<Nid, ErrorStack> {
+        unsafe {
+            let mut pnid: c_int = 0;
+
+            match cvt(ffi::SSL_get_peer_signature_type_nid(self.as_ptr(), &mut pnid)) {
+                Ok(_) => Ok(Nid::from_raw(pnid)),
+                Err(e) => Err(e),
+            }
+        }
+    }
 }
 
 /// An SSL stream midway through the handshake process.

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -372,6 +372,28 @@ fn peer_tmp_key_rsa() {
     assert_eq!(local_temp.bits(), 521);
 }
 
+
+#[test]
+#[cfg(ossl111)]
+fn signature_nids() {
+    use crate::nid::Nid;
+
+    let mut server = Server::builder();
+    server.ctx().set_sigalgs_list("RSA-PSS+SHA384").unwrap();
+    let server = server.build();
+
+    let mut client = server.client();
+    client.ctx().set_sigalgs_list("RSA-PSS+SHA384").unwrap();
+
+    let stream = client.connect();
+    assert_eq!(stream.ssl().peer_signature_nid().unwrap(), Nid::SHA384);
+    assert_eq!(stream.ssl().peer_signature_type_nid().unwrap(), Nid::RSASSAPSS);
+
+    // local signature retrievals are invalid for a client using server auth
+    assert!(stream.ssl().signature_nid().is_err());
+    assert!(stream.ssl().signature_type_nid().is_err());
+}
+
 /// Tests that when both the client as well as the server use SRTP and their
 /// lists of supported protocols have an overlap -- with only ONE protocol
 /// being valid for both.


### PR DESCRIPTION
This PR adds bindings for signature retrieval apis. I also added a unit test to make sure that basic functionality is working.

https://www.openssl.org/docs/man1.1.1/man3/SSL_get_peer_signature_type_nid.html

### History

I dug through the git branch to find the first branch that the various APIs appeared in.

