### PR TITLE
Add engine bindings

### DIFF
--- a/openssl-sys/src/handwritten/engine.rs
+++ b/openssl-sys/src/handwritten/engine.rs
@@ -1,8 +1,6 @@
 use super::super::*;
 use libc::*;
 
-pub enum ENGINE {}
-
 pub enum RSA_METHOD {}
 pub enum DSA_METHOD {}
 pub enum DH_METHOD {}
@@ -16,22 +14,34 @@ pub enum ENGINE_CTRL_FUNC_PTR {}
 pub enum ENGINE_LOAD_KEY_PTR {}
 pub enum UI_METHOD {}
 
+pub const ENGINE_METHOD_RSA: u32 = 0x0001;
+pub const ENGINE_METHOD_DSA: u32 = 0x0002;
+pub const ENGINE_METHOD_DH: u32 = 0x0004;
+pub const ENGINE_METHOD_RAND: u32 = 0x0008;
+pub const ENGINE_METHOD_CIPHERS: u32 = 0x0040;
+pub const ENGINE_METHOD_DIGESTS: u32 = 0x0080;
+pub const ENGINE_METHOD_PKEY_METHS: u32 = 0x0200;
+pub const ENGINE_METHOD_PKEY_ASN1_METHS: u32 = 0x0400;
+pub const ENGINE_METHOD_EC: u32 = 0x0800;
+
+pub const ENGINE_METHOD_ALL: u32 = 0xffff;
+pub const ENGINE_METHOD_NONE: u32 = 0xffff;
+
+#[cfg(ossl110)]
 extern "C" {
-    // NOTE some of these _may_ need to be mutable...
+    pub fn ENGINE_get_first() -> *mut ENGINE;
 
-    pub fn ENGINE_get_first() -> *const ENGINE;
+    pub fn ENGINE_get_last() -> *mut ENGINE;
 
-    pub fn ENGINE_get_last() -> *const ENGINE;
+    pub fn ENGINE_get_next(e: *mut ENGINE) -> *mut ENGINE;
 
-    pub fn ENGINE_get_next(e: *const ENGINE) -> *const ENGINE;
+    pub fn ENGINE_get_prev(e: *mut ENGINE) -> *mut ENGINE;
 
-    pub fn ENGINE_get_prev(e: *const ENGINE) -> *const ENGINE;
+    pub fn ENGINE_add(e: *mut ENGINE) -> c_int;
 
-    pub fn ENGINE_add(e: *const ENGINE) -> c_int;
+    pub fn ENGINE_remove(e: *mut ENGINE) -> c_int;
 
-    pub fn ENGINE_remove(e: *const ENGINE) -> c_int;
-
-    pub fn ENGINE_by_id(id: *const c_char) -> *const ENGINE;
+    pub fn ENGINE_by_id(id: *const c_char) -> *mut ENGINE;
 
     pub fn ENGINE_init(e: *mut ENGINE) -> c_int;
 
@@ -39,12 +49,12 @@ extern "C" {
 
     pub fn ENGINE_load_builtin_engines();
 
-    pub fn ENGINE_get_default_RSA() -> *const ENGINE;
-    pub fn ENGINE_get_default_DSA() -> *const ENGINE;
-    pub fn ENGINE_get_default_DH() -> *const ENGINE;
-    pub fn ENGINE_get_default_RAND() -> *const ENGINE;
-    pub fn ENGINE_get_cipher_engine(nid: c_int) -> *const ENGINE;
-    pub fn ENGINE_get_digest_engine(nid: c_int) -> *const ENGINE;
+    pub fn ENGINE_get_default_RSA() -> *mut ENGINE;
+    pub fn ENGINE_get_default_DSA() -> *mut ENGINE;
+    pub fn ENGINE_get_default_DH() -> *mut ENGINE;
+    pub fn ENGINE_get_default_RAND() -> *mut ENGINE;
+    pub fn ENGINE_get_cipher_engine(nid: c_int) -> *mut ENGINE;
+    pub fn ENGINE_get_digest_engine(nid: c_int) -> *mut ENGINE;
 
     pub fn ENGINE_set_default_RSA(e: *mut ENGINE) -> c_int;
     pub fn ENGINE_set_default_DSA(e: *mut ENGINE) -> c_int;
@@ -84,14 +94,14 @@ extern "C" {
     pub fn ENGINE_register_all_digests();
 
     pub fn ENGINE_register_complete(e: *mut ENGINE) -> c_int;
-    pub fn ENGINE_register_all_complete(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_register_all_complete() -> c_int;
 
     pub fn ENGINE_ctrl(
         e: *mut ENGINE,
         cmd: c_int,
         i: c_long,
-        p: *const c_void,
-        freefunc: i32,
+        p: *mut c_void,
+        f: extern "C" fn (),
     ) -> c_int;
 
     pub fn ENGINE_cmd_is_executable(e: *mut ENGINE, cmd: c_int) -> c_int;
@@ -100,8 +110,8 @@ extern "C" {
         e: *mut ENGINE,
         cmd_name: *const c_char,
         i: c_long,
-        p: *const c_void,
-        freefunc: i32,
+        p: *mut c_void,
+        f: extern "C" fn (),
         cmd_optional: c_int,
     ) -> c_int;
 
@@ -130,46 +140,45 @@ extern "C" {
 
     pub fn ENGINE_set_RAND(e: *mut ENGINE, RAND_meth: *const RAND_METHOD) -> c_int;
 
-    // TODO pass a different function pointer for these!!?!?!?
     pub fn ENGINE_set_destroy_function(
         e: *mut ENGINE,
-        destroy_f: *const ENGINE_GEN_INT_FUNC_PTR,
+        destroy_f: extern "C" fn (*mut ENGINE) -> c_int,
     ) -> c_int;
 
     pub fn ENGINE_set_init_function(
         e: *mut ENGINE,
-        init_f: *const ENGINE_GEN_INT_FUNC_PTR,
+        init_f: extern "C" fn (*mut ENGINE) -> c_int,
     ) -> c_int;
 
     pub fn ENGINE_set_finish_function(
         e: *mut ENGINE,
-        finish_f: *const ENGINE_GEN_INT_FUNC_PTR,
+        finish_f: extern "C" fn (*mut ENGINE) -> c_int,
     ) -> c_int;
 
     pub fn ENGINE_set_ctrl_function(
         e: *mut ENGINE,
-        ctrl_f: *const ENGINE_GEN_INT_FUNC_PTR,
+        ctrl_f: extern "C" fn (*mut ENGINE, c_int, c_long, *mut c_void, extern "C" fn ()) -> c_int,
     ) -> c_int;
 
     pub fn ENGINE_set_load_privkey_function(
         e: *mut ENGINE,
-        loadpriv_f: *const ENGINE_GEN_INT_FUNC_PTR,
+        loadpriv_f: extern "C" fn (*mut ENGINE, *const c_char, *mut UI_METHOD, *mut c_void) -> *mut EVP_PKEY,
     ) -> c_int;
 
     pub fn ENGINE_set_load_pubkey_function(
         e: *mut ENGINE,
-        loadpub_f: *const ENGINE_GEN_INT_FUNC_PTR,
+        loadpub_f: unsafe extern "C" fn (*mut ENGINE, *const c_char, *mut UI_METHOD, *mut c_void) -> *mut EVP_PKEY,
     ) -> c_int;
 
-    pub fn ENGINE_set_ciphers(e: *mut ENGINE, f: *const ENGINE_CIPHERS_PTR) -> c_int;
+    pub fn ENGINE_set_ciphers(e: *mut ENGINE, f: ENGINE_CIPHERS_PTR) -> c_int;
 
-    pub fn ENGINE_set_digests(e: *mut ENGINE, f: *const ENGINE_DIGESTS_PTR) -> c_int;
+    pub fn ENGINE_set_digests(e: *mut ENGINE, f: ENGINE_DIGESTS_PTR) -> c_int;
 
     pub fn ENGINE_set_cmd_defns(e: *mut ENGINE, defns: *const ENGINE_CMD_DEFN) -> c_int;
 
-    pub fn ENGINE_get_id(e: *const ENGINE) -> *mut c_char;
+    pub fn ENGINE_get_id(e: *const ENGINE) -> *const c_char;
 
-    pub fn ENGINE_get_name(e: *const ENGINE) -> *mut c_char;
+    pub fn ENGINE_get_name(e: *const ENGINE) -> *const c_char;
 
     pub fn ENGINE_get_RSA(e: *const ENGINE) -> *const RSA_METHOD;
 
@@ -179,44 +188,47 @@ extern "C" {
 
     pub fn ENGINE_get_RAND(e: *const ENGINE) -> *const RAND_METHOD;
 
-    pub fn ENGINE_get_destroy_function(e: *const ENGINE) -> *const ENGINE_GEN_INT_FUNC_PTR;
+    pub fn ENGINE_get_destroy_function(e: *const ENGINE) -> ENGINE_GEN_INT_FUNC_PTR;
 
-    pub fn ENGINE_get_init_function(e: *const ENGINE) -> *const ENGINE_GEN_INT_FUNC_PTR;
+    pub fn ENGINE_get_init_function(e: *const ENGINE) -> ENGINE_GEN_INT_FUNC_PTR;
 
-    pub fn ENGINE_get_finish_function(e: *const ENGINE) -> *const ENGINE_GEN_INT_FUNC_PTR;
+    pub fn ENGINE_get_finish_function(e: *const ENGINE) -> ENGINE_GEN_INT_FUNC_PTR;
 
-    pub fn ENGINE_get_ctrl_function(e: *const ENGINE) -> *const ENGINE_CTRL_FUNC_PTR;
+    pub fn ENGINE_get_ctrl_function(e: *const ENGINE) -> ENGINE_CTRL_FUNC_PTR;
 
-    pub fn ENGINE_get_load_privkey_function(e: *const ENGINE) -> *const ENGINE_LOAD_KEY_PTR;
+    pub fn ENGINE_get_load_privkey_function(e: *const ENGINE) -> ENGINE_LOAD_KEY_PTR;
 
-    pub fn ENGINE_get_load_pubkey_function(e: *const ENGINE) -> *const ENGINE_LOAD_KEY_PTR;
+    pub fn ENGINE_get_load_pubkey_function(e: *const ENGINE) -> ENGINE_LOAD_KEY_PTR;
 
-    pub fn ENGINE_get_ciphers(e: *const ENGINE) -> *const ENGINE_CIPHERS_PTR;
+    pub fn ENGINE_get_ciphers(e: *const ENGINE) -> ENGINE_CIPHERS_PTR;
 
-    pub fn ENGINE_get_digests(e: *const ENGINE) -> *const ENGINE_DIGESTS_PTR;
+    pub fn ENGINE_get_digests(e: *const ENGINE) -> ENGINE_DIGESTS_PTR;
 
-    pub fn ENGINE_get_cipher(e: *const ENGINE, nid: c_int) -> *const EVP_CIPHER;
+    pub fn ENGINE_get_cipher(e: *mut ENGINE, nid: c_int) -> *const EVP_CIPHER;
 
-    pub fn ENGINE_get_digest(e: *const ENGINE, nid: c_int) -> *const EVP_MD;
+    pub fn ENGINE_get_digest(e: *mut ENGINE, nid: c_int) -> *const EVP_MD;
 
     pub fn ENGINE_get_flags(e: *const ENGINE) -> c_int;
 
     pub fn ENGINE_get_cmd_defns(e: *const ENGINE) -> *const ENGINE_CMD_DEFN;
 
     pub fn ENGINE_load_private_key(
-        e: *const ENGINE,
+        e: *mut ENGINE,
         key_id: *const c_char,
-        ui_method: *const UI_METHOD,
-        callback_data: *const c_void,
-    ) -> *const EVP_PKEY;
+        ui_method: *mut UI_METHOD,
+        callback_data: *mut c_void,
+    ) -> *mut EVP_PKEY;
 
     pub fn ENGINE_load_public_key(
-        e: *const ENGINE,
+        e: *mut ENGINE,
         key_id: *const c_char,
-        ui_method: *const UI_METHOD,
-        callback_data: *const c_void,
-    ) -> *const EVP_PKEY;
+        ui_method: *mut UI_METHOD,
+        callback_data: *mut c_void,
+    ) -> *mut EVP_PKEY;
 
-    #[cfg(ossl110)]
-    pub fn ENGINE_cleanup();
 }
+
+// extern "C" {
+//     #[cfg(not(any(ossl100)))]
+//     pub fn ENGINE_cleanup();
+// }

--- a/openssl-sys/src/handwritten/engine.rs
+++ b/openssl-sys/src/handwritten/engine.rs
@@ -1,0 +1,222 @@
+use super::super::*;
+use libc::*;
+
+pub enum ENGINE {}
+
+pub enum RSA_METHOD {}
+pub enum DSA_METHOD {}
+pub enum DH_METHOD {}
+pub enum RAND_METHOD {}
+
+pub enum ENGINE_GEN_INT_FUNC_PTR {}
+pub enum ENGINE_CIPHERS_PTR {}
+pub enum ENGINE_DIGESTS_PTR {}
+pub enum ENGINE_CMD_DEFN {}
+pub enum ENGINE_CTRL_FUNC_PTR {}
+pub enum ENGINE_LOAD_KEY_PTR {}
+pub enum UI_METHOD {}
+
+extern "C" {
+    // NOTE some of these _may_ need to be mutable...
+
+    pub fn ENGINE_get_first() -> *const ENGINE;
+
+    pub fn ENGINE_get_last() -> *const ENGINE;
+
+    pub fn ENGINE_get_next(e: *const ENGINE) -> *const ENGINE;
+
+    pub fn ENGINE_get_prev(e: *const ENGINE) -> *const ENGINE;
+
+    pub fn ENGINE_add(e: *const ENGINE) -> c_int;
+
+    pub fn ENGINE_remove(e: *const ENGINE) -> c_int;
+
+    pub fn ENGINE_by_id(id: *const c_char) -> *const ENGINE;
+
+    pub fn ENGINE_init(e: *mut ENGINE) -> c_int;
+
+    pub fn ENGINE_finish(e: *mut ENGINE) -> c_int;
+
+    pub fn ENGINE_load_builtin_engines();
+
+    pub fn ENGINE_get_default_RSA() -> *const ENGINE;
+    pub fn ENGINE_get_default_DSA() -> *const ENGINE;
+    pub fn ENGINE_get_default_DH() -> *const ENGINE;
+    pub fn ENGINE_get_default_RAND() -> *const ENGINE;
+    pub fn ENGINE_get_cipher_engine(nid: c_int) -> *const ENGINE;
+    pub fn ENGINE_get_digest_engine(nid: c_int) -> *const ENGINE;
+
+    pub fn ENGINE_set_default_RSA(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_set_default_DSA(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_set_default_DH(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_set_default_RAND(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_set_default_ciphers(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_set_default_digests(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_set_default_string(e: *mut ENGINE, list: *const c_char) -> c_int;
+
+    pub fn ENGINE_set_default(e: *mut ENGINE, flags: c_uint) -> c_int;
+
+    pub fn ENGINE_get_table_flags() -> c_uint;
+    pub fn ENGINE_set_table_flags(flags: c_uint);
+
+    pub fn ENGINE_register_RSA(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_unregister_RSA(e: *mut ENGINE);
+    pub fn ENGINE_register_all_RSA();
+
+    pub fn ENGINE_register_DSA(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_unregister_DSA(e: *mut ENGINE);
+    pub fn ENGINE_register_all_DSA();
+
+    pub fn ENGINE_register_DH(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_unregister_DH(e: *mut ENGINE);
+    pub fn ENGINE_register_all_DH();
+
+    pub fn ENGINE_register_RAND(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_unregister_RAND(e: *mut ENGINE);
+    pub fn ENGINE_register_all_RAND();
+
+    pub fn ENGINE_register_ciphers(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_unregister_ciphers(e: *mut ENGINE);
+    pub fn ENGINE_register_all_ciphers();
+
+    pub fn ENGINE_register_digests(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_unregister_digests(e: *mut ENGINE);
+    pub fn ENGINE_register_all_digests();
+
+    pub fn ENGINE_register_complete(e: *mut ENGINE) -> c_int;
+    pub fn ENGINE_register_all_complete(e: *mut ENGINE) -> c_int;
+
+    pub fn ENGINE_ctrl(
+        e: *mut ENGINE,
+        cmd: c_int,
+        i: c_long,
+        p: *const c_void,
+        freefunc: i32,
+    ) -> c_int;
+
+    pub fn ENGINE_cmd_is_executable(e: *mut ENGINE, cmd: c_int) -> c_int;
+
+    pub fn ENGINE_ctrl_cmd(
+        e: *mut ENGINE,
+        cmd_name: *const c_char,
+        i: c_long,
+        p: *const c_void,
+        freefunc: i32,
+        cmd_optional: c_int,
+    ) -> c_int;
+
+    pub fn ENGINE_ctrl_cmd_string(
+        e: *mut ENGINE,
+        cmd_name: *const c_char,
+        arg: *const c_char,
+        cmd_optional: c_int,
+    ) -> c_int;
+
+    pub fn ENGINE_new() -> *mut ENGINE;
+
+    pub fn ENGINE_free(e: *mut ENGINE) -> c_int;
+
+    pub fn ENGINE_up_ref(e: *mut ENGINE) -> c_int;
+
+    pub fn ENGINE_set_id(e: *mut ENGINE, id: *const c_char) -> c_int;
+
+    pub fn ENGINE_set_name(e: *mut ENGINE, name: *const c_char) -> c_int;
+
+    pub fn ENGINE_set_RSA(e: *mut ENGINE, rsa_meth: *const RSA_METHOD) -> c_int;
+
+    pub fn ENGINE_set_DSA(e: *mut ENGINE, DSA_meth: *const DSA_METHOD) -> c_int;
+
+    pub fn ENGINE_set_DH(e: *mut ENGINE, DH_meth: *const DH_METHOD) -> c_int;
+
+    pub fn ENGINE_set_RAND(e: *mut ENGINE, RAND_meth: *const RAND_METHOD) -> c_int;
+
+    // TODO pass a different function pointer for these!!?!?!?
+    pub fn ENGINE_set_destroy_function(
+        e: *mut ENGINE,
+        destroy_f: *const ENGINE_GEN_INT_FUNC_PTR,
+    ) -> c_int;
+
+    pub fn ENGINE_set_init_function(
+        e: *mut ENGINE,
+        init_f: *const ENGINE_GEN_INT_FUNC_PTR,
+    ) -> c_int;
+
+    pub fn ENGINE_set_finish_function(
+        e: *mut ENGINE,
+        finish_f: *const ENGINE_GEN_INT_FUNC_PTR,
+    ) -> c_int;
+
+    pub fn ENGINE_set_ctrl_function(
+        e: *mut ENGINE,
+        ctrl_f: *const ENGINE_GEN_INT_FUNC_PTR,
+    ) -> c_int;
+
+    pub fn ENGINE_set_load_privkey_function(
+        e: *mut ENGINE,
+        loadpriv_f: *const ENGINE_GEN_INT_FUNC_PTR,
+    ) -> c_int;
+
+    pub fn ENGINE_set_load_pubkey_function(
+        e: *mut ENGINE,
+        loadpub_f: *const ENGINE_GEN_INT_FUNC_PTR,
+    ) -> c_int;
+
+    pub fn ENGINE_set_ciphers(e: *mut ENGINE, f: *const ENGINE_CIPHERS_PTR) -> c_int;
+
+    pub fn ENGINE_set_digests(e: *mut ENGINE, f: *const ENGINE_DIGESTS_PTR) -> c_int;
+
+    pub fn ENGINE_set_cmd_defns(e: *mut ENGINE, defns: *const ENGINE_CMD_DEFN) -> c_int;
+
+    pub fn ENGINE_get_id(e: *const ENGINE) -> *mut c_char;
+
+    pub fn ENGINE_get_name(e: *const ENGINE) -> *mut c_char;
+
+    pub fn ENGINE_get_RSA(e: *const ENGINE) -> *const RSA_METHOD;
+
+    pub fn ENGINE_get_DSA(e: *const ENGINE) -> *const DSA_METHOD;
+
+    pub fn ENGINE_get_DH(e: *const ENGINE) -> *const DH_METHOD;
+
+    pub fn ENGINE_get_RAND(e: *const ENGINE) -> *const RAND_METHOD;
+
+    pub fn ENGINE_get_destroy_function(e: *const ENGINE) -> *const ENGINE_GEN_INT_FUNC_PTR;
+
+    pub fn ENGINE_get_init_function(e: *const ENGINE) -> *const ENGINE_GEN_INT_FUNC_PTR;
+
+    pub fn ENGINE_get_finish_function(e: *const ENGINE) -> *const ENGINE_GEN_INT_FUNC_PTR;
+
+    pub fn ENGINE_get_ctrl_function(e: *const ENGINE) -> *const ENGINE_CTRL_FUNC_PTR;
+
+    pub fn ENGINE_get_load_privkey_function(e: *const ENGINE) -> *const ENGINE_LOAD_KEY_PTR;
+
+    pub fn ENGINE_get_load_pubkey_function(e: *const ENGINE) -> *const ENGINE_LOAD_KEY_PTR;
+
+    pub fn ENGINE_get_ciphers(e: *const ENGINE) -> *const ENGINE_CIPHERS_PTR;
+
+    pub fn ENGINE_get_digests(e: *const ENGINE) -> *const ENGINE_DIGESTS_PTR;
+
+    pub fn ENGINE_get_cipher(e: *const ENGINE, nid: c_int) -> *const EVP_CIPHER;
+
+    pub fn ENGINE_get_digest(e: *const ENGINE, nid: c_int) -> *const EVP_MD;
+
+    pub fn ENGINE_get_flags(e: *const ENGINE) -> c_int;
+
+    pub fn ENGINE_get_cmd_defns(e: *const ENGINE) -> *const ENGINE_CMD_DEFN;
+
+    pub fn ENGINE_load_private_key(
+        e: *const ENGINE,
+        key_id: *const c_char,
+        ui_method: *const UI_METHOD,
+        callback_data: *const c_void,
+    ) -> *const EVP_PKEY;
+
+    pub fn ENGINE_load_public_key(
+        e: *const ENGINE,
+        key_id: *const c_char,
+        ui_method: *const UI_METHOD,
+        callback_data: *const c_void,
+    ) -> *const EVP_PKEY;
+
+    #[cfg(ossl110)]
+    pub fn ENGINE_cleanup();
+}

--- a/openssl-sys/src/handwritten/engine.rs
+++ b/openssl-sys/src/handwritten/engine.rs
@@ -101,7 +101,7 @@ extern "C" {
         cmd: c_int,
         i: c_long,
         p: *mut c_void,
-        f: extern "C" fn (),
+        f: extern "C" fn(),
     ) -> c_int;
 
     pub fn ENGINE_cmd_is_executable(e: *mut ENGINE, cmd: c_int) -> c_int;
@@ -111,7 +111,7 @@ extern "C" {
         cmd_name: *const c_char,
         i: c_long,
         p: *mut c_void,
-        f: extern "C" fn (),
+        f: extern "C" fn(),
         cmd_optional: c_int,
     ) -> c_int;
 
@@ -142,32 +142,42 @@ extern "C" {
 
     pub fn ENGINE_set_destroy_function(
         e: *mut ENGINE,
-        destroy_f: extern "C" fn (*mut ENGINE) -> c_int,
+        destroy_f: extern "C" fn(*mut ENGINE) -> c_int,
     ) -> c_int;
 
     pub fn ENGINE_set_init_function(
         e: *mut ENGINE,
-        init_f: extern "C" fn (*mut ENGINE) -> c_int,
+        init_f: extern "C" fn(*mut ENGINE) -> c_int,
     ) -> c_int;
 
     pub fn ENGINE_set_finish_function(
         e: *mut ENGINE,
-        finish_f: extern "C" fn (*mut ENGINE) -> c_int,
+        finish_f: extern "C" fn(*mut ENGINE) -> c_int,
     ) -> c_int;
 
     pub fn ENGINE_set_ctrl_function(
         e: *mut ENGINE,
-        ctrl_f: extern "C" fn (*mut ENGINE, c_int, c_long, *mut c_void, extern "C" fn ()) -> c_int,
+        ctrl_f: extern "C" fn(*mut ENGINE, c_int, c_long, *mut c_void, extern "C" fn()) -> c_int,
     ) -> c_int;
 
     pub fn ENGINE_set_load_privkey_function(
         e: *mut ENGINE,
-        loadpriv_f: extern "C" fn (*mut ENGINE, *const c_char, *mut UI_METHOD, *mut c_void) -> *mut EVP_PKEY,
+        loadpriv_f: extern "C" fn(
+            *mut ENGINE,
+            *const c_char,
+            *mut UI_METHOD,
+            *mut c_void,
+        ) -> *mut EVP_PKEY,
     ) -> c_int;
 
     pub fn ENGINE_set_load_pubkey_function(
         e: *mut ENGINE,
-        loadpub_f: unsafe extern "C" fn (*mut ENGINE, *const c_char, *mut UI_METHOD, *mut c_void) -> *mut EVP_PKEY,
+        loadpub_f: unsafe extern "C" fn(
+            *mut ENGINE,
+            *const c_char,
+            *mut UI_METHOD,
+            *mut c_void,
+        ) -> *mut EVP_PKEY,
     ) -> c_int;
 
     pub fn ENGINE_set_ciphers(e: *mut ENGINE, f: ENGINE_CIPHERS_PTR) -> c_int;

--- a/openssl-sys/src/handwritten/mod.rs
+++ b/openssl-sys/src/handwritten/mod.rs
@@ -9,6 +9,7 @@ pub use self::crypto::*;
 pub use self::dh::*;
 pub use self::dsa::*;
 pub use self::ec::*;
+pub use self::engine::*;
 pub use self::err::*;
 pub use self::evp::*;
 pub use self::hmac::*;
@@ -46,6 +47,7 @@ mod crypto;
 mod dh;
 mod dsa;
 mod ec;
+#[cfg(all(ossl110))]
 mod engine;
 mod err;
 mod evp;

--- a/openssl-sys/src/handwritten/mod.rs
+++ b/openssl-sys/src/handwritten/mod.rs
@@ -46,6 +46,7 @@ mod crypto;
 mod dh;
 mod dsa;
 mod ec;
+mod engine;
 mod err;
 mod evp;
 mod hmac;

--- a/openssl-sys/src/handwritten/mod.rs
+++ b/openssl-sys/src/handwritten/mod.rs
@@ -47,7 +47,7 @@ mod crypto;
 mod dh;
 mod dsa;
 mod ec;
-#[cfg(all(ossl110))]
+#[cfg(ossl110)]
 mod engine;
 mod err;
 mod evp;

--- a/openssl-sys/src/handwritten/mod.rs
+++ b/openssl-sys/src/handwritten/mod.rs
@@ -9,6 +9,7 @@ pub use self::crypto::*;
 pub use self::dh::*;
 pub use self::dsa::*;
 pub use self::ec::*;
+#[cfg(ossl110)]
 pub use self::engine::*;
 pub use self::err::*;
 pub use self::evp::*;

--- a/openssl/src/engine.rs
+++ b/openssl/src/engine.rs
@@ -1,6 +1,4 @@
 use crate::error::ErrorStack;
-use crate::pkey::{HasPrivate, HasPublic, PKeyRef};
-use crate::pkey_ctx::PkeyCtxRef;
 use crate::{cvt, cvt_n, cvt_p};
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
@@ -187,9 +185,9 @@ impl Engine {
     /// Sets the default RSA engine.
     #[corresponds(ENGINE_set_default_RSA)]
     #[inline]
-    pub fn set_default_rsa(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_default_rsa(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_RSA(e.as_ptr()))?;
+            cvt(ffi::ENGINE_set_default_RSA(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -197,9 +195,9 @@ impl Engine {
     /// Sets the default DSA engine.
     #[corresponds(ENGINE_set_default_DSA)]
     #[inline]
-    pub fn set_default_dsa(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_default_dsa(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_DSA(e.as_ptr()))?;
+            cvt(ffi::ENGINE_set_default_DSA(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -207,9 +205,9 @@ impl Engine {
     /// Sets the default DH engine.
     #[corresponds(ENGINE_set_default_DH)]
     #[inline]
-    pub fn set_default_dh(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_default_dh(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_DH(e.as_ptr()))?;
+            cvt(ffi::ENGINE_set_default_DH(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -217,9 +215,9 @@ impl Engine {
     /// Sets the default RAND engine.
     #[corresponds(ENGINE_set_default_RAND)]
     #[inline]
-    pub fn set_default_rand(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_default_rand(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_RAND(e.as_ptr()))?;
+            cvt(ffi::ENGINE_set_default_RAND(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -227,9 +225,9 @@ impl Engine {
     /// Sets the default ciphers engine.
     #[corresponds(ENGINE_set_default_ciphers)]
     #[inline]
-    pub fn set_default_ciphers(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_default_ciphers(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_ciphers(e.as_ptr()))?;
+            cvt(ffi::ENGINE_set_default_ciphers(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -237,9 +235,9 @@ impl Engine {
     /// Sets the default digests engine.
     #[corresponds(ENGINE_set_default_digests)]
     #[inline]
-    pub fn set_default_digests(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_default_digests(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_digests(e.as_ptr()))?;
+            cvt(ffi::ENGINE_set_default_digests(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -247,10 +245,10 @@ impl Engine {
     /// Sets the default string for the engine.
     #[corresponds(ENGINE_set_default_string)]
     #[inline]
-    pub fn set_default_string(e: Engine, list: &str) -> Result<(), ErrorStack> {
+    pub fn set_default_string(&mut self, list: &str) -> Result<(), ErrorStack> {
         let list = CString::new(list).unwrap();
         unsafe {
-            cvt(ffi::ENGINE_set_default_string(e.as_ptr(), list.as_ptr()))?;
+            cvt(ffi::ENGINE_set_default_string(self.as_ptr(), list.as_ptr()))?;
         }
         Ok(())
     }
@@ -258,9 +256,9 @@ impl Engine {
     /// Sets the default engine.
     #[corresponds(ENGINE_set_default)]
     #[inline]
-    pub fn set_default(e: Engine, flags: u32) -> Result<(), ErrorStack> {
+    pub fn set_default(&mut self, flags: u32) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default(e.as_ptr(), c_uint::from(flags)))?;
+            cvt(ffi::ENGINE_set_default(self.as_ptr(), c_uint::from(flags)))?;
         }
         Ok(())
     }
@@ -287,9 +285,9 @@ impl Engine {
     /// Registers the input engine as the RSA engine.
     #[corresponds(ENGINE_register_RSA)]
     #[inline]
-    pub fn register_rsa(e: Engine) -> Result<(), ErrorStack> {
+    pub fn register_rsa(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_RSA(e.as_ptr()))?;
+            cvt(ffi::ENGINE_register_RSA(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -297,16 +295,16 @@ impl Engine {
     /// Unregisters the input engine as the RSA engine.
     #[corresponds(ENGINE_unregister_RSA)]
     #[inline]
-    pub fn unregister_rsa(e: Engine) {
+    pub fn unregister_rsa(&mut self) {
         unsafe {
-            ffi::ENGINE_unregister_RSA(e.as_ptr());
+            ffi::ENGINE_unregister_RSA(self.as_ptr());
         }
     }
 
     /// Registers all of the engines as RSA.
     #[corresponds(ENGINE_register_all_RSA)]
     #[inline]
-    pub fn register_all_rsa(e: Engine) {
+    pub fn register_all_rsa(&mut self) {
         unsafe {
             ffi::ENGINE_register_all_RSA();
         }
@@ -315,9 +313,9 @@ impl Engine {
     /// Registers the input engine as the DSA engine.
     #[corresponds(ENGINE_register_DSA)]
     #[inline]
-    pub fn register_dsa(e: Engine) -> Result<(), ErrorStack> {
+    pub fn register_dsa(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_DSA(e.as_ptr()))?;
+            cvt(ffi::ENGINE_register_DSA(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -325,9 +323,9 @@ impl Engine {
     /// Unregisters the input engine as the DSA engine.
     #[corresponds(ENGINE_unregister_DSA)]
     #[inline]
-    pub fn unregister_dsa(e: Engine) {
+    pub fn unregister_dsa(&mut self) {
         unsafe {
-            ffi::ENGINE_unregister_DSA(e.as_ptr());
+            ffi::ENGINE_unregister_DSA(self.as_ptr());
         }
     }
 
@@ -343,9 +341,9 @@ impl Engine {
     /// Registers the input engine as the DH engine.
     #[corresponds(ENGINE_register_DH)]
     #[inline]
-    pub fn register_dh(e: Engine) -> Result<(), ErrorStack> {
+    pub fn register_dh(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_DH(e.as_ptr()))?;
+            cvt(ffi::ENGINE_register_DH(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -353,9 +351,9 @@ impl Engine {
     /// Unregisters the input engine as the DH engine.
     #[corresponds(ENGINE_unregister_DH)]
     #[inline]
-    pub fn unregister_dh(e: Engine) {
+    pub fn unregister_dh(&mut self) {
         unsafe {
-            ffi::ENGINE_unregister_DH(e.as_ptr());
+            ffi::ENGINE_unregister_DH(self.as_ptr());
         }
     }
 
@@ -371,9 +369,9 @@ impl Engine {
     /// Registers the input engine as the RAND engine.
     #[corresponds(ENGINE_register_RAND)]
     #[inline]
-    pub fn register_rand(e: Engine) -> Result<(), ErrorStack> {
+    pub fn register_rand(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_RAND(e.as_ptr()))?;
+            cvt(ffi::ENGINE_register_RAND(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -381,9 +379,9 @@ impl Engine {
     /// Unregisters the input engine as the RAND engine.
     #[corresponds(ENGINE_unregister_RAND)]
     #[inline]
-    pub fn unregister_rand(e: Engine) {
+    pub fn unregister_rand(&mut self) {
         unsafe {
-            ffi::ENGINE_unregister_RAND(e.as_ptr());
+            ffi::ENGINE_unregister_RAND(self.as_ptr());
         }
     }
 
@@ -399,9 +397,9 @@ impl Engine {
     /// Registers ciphers from the input engine.
     #[corresponds(ENGINE_register_ciphers)]
     #[inline]
-    pub fn register_ciphers(e: Engine) -> Result<(), ErrorStack> {
+    pub fn register_ciphers(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_ciphers(e.as_ptr()))?;
+            cvt(ffi::ENGINE_register_ciphers(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -409,9 +407,9 @@ impl Engine {
     /// Unregisters the ciphers from the input engine.
     #[corresponds(ENGINE_unregister_ciphers)]
     #[inline]
-    pub fn unregister_ciphers(e: Engine) {
+    pub fn unregister_ciphers(&mut self) {
         unsafe {
-            ffi::ENGINE_unregister_ciphers(e.as_ptr());
+            ffi::ENGINE_unregister_ciphers(self.as_ptr());
         }
     }
 
@@ -427,9 +425,9 @@ impl Engine {
     /// Registers digests from the input engine.
     #[corresponds(ENGINE_register_digests)]
     #[inline]
-    pub fn register_digests(e: Engine) -> Result<(), ErrorStack> {
+    pub fn register_digests(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_digests(e.as_ptr()))?;
+            cvt(ffi::ENGINE_register_digests(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -437,9 +435,9 @@ impl Engine {
     /// Unregisters the digests from the input engine.
     #[corresponds(ENGINE_unregister_digests)]
     #[inline]
-    pub fn unregister_digests(e: Engine) {
+    pub fn unregister_digests(&mut self) {
         unsafe {
-            ffi::ENGINE_unregister_digests(e.as_ptr());
+            ffi::ENGINE_unregister_digests(self.as_ptr());
         }
     }
 
@@ -452,9 +450,9 @@ impl Engine {
         }
     }
 
-    pub fn register_complete(e: Engine) -> Result<(), ErrorStack> {
+    pub fn register_complete(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_complete(e.as_ptr()))?;
+            cvt(ffi::ENGINE_register_complete(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -467,7 +465,7 @@ impl Engine {
     }
 
     pub fn ctrl(
-        e: Engine,
+        &mut self,
         cmd: i32,
         i: i64,
         p: *mut c_void,
@@ -476,19 +474,19 @@ impl Engine {
         todo!();
     }
 
-    pub fn cmd_is_executable(e: Engine, cmd: i32) -> Result<(), ErrorStack> {
+    pub fn cmd_is_executable(&mut self, cmd: i32) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_cmd_is_executable(e.as_ptr(), c_int::from(cmd)))?;
+            cvt(ffi::ENGINE_cmd_is_executable(self.as_ptr(), c_int::from(cmd)))?;
         }
         Ok(())
     }
 
-    pub fn ctrl_cmd(e: Engine, cmd: &str, arg: &str, param: i32) -> Result<(), ErrorStack> {
+    pub fn ctrl_cmd(&mut self, cmd: &str, arg: &str, param: i32) -> Result<(), ErrorStack> {
         todo!();
     }
 
     pub fn ctrl_cmd_string(
-        e: Engine,
+        &mut self,
         cmd: &str,
         arg: &str,
         optional: i32,
@@ -496,9 +494,9 @@ impl Engine {
         todo!();
     }
 
-    pub fn up_ref(e: Engine) -> Result<(), ErrorStack> {
+    pub fn up_ref(&mut self) -> Result<(), ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_up_ref(e.as_ptr()))?;
+            cvt(ffi::ENGINE_up_ref(self.as_ptr()))?;
         }
         Ok(())
     }
@@ -528,91 +526,91 @@ impl Engine {
     /// Sets the RSA method on the engine.
     #[corresponds(ENGINE_set_RSA)]
     #[inline]
-    pub fn set_rsa(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_rsa(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the DSA method on the engine.
     #[corresponds(ENGINE_set_DSA)]
     #[inline]
-    pub fn set_dsa(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_dsa(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the DH method on the engine.
     #[corresponds(ENGINE_set_DH)]
     #[inline]
-    pub fn set_dh(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_dh(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the RAND method on the engine.
     #[corresponds(ENGINE_set_RAND)]
     #[inline]
-    pub fn set_rand(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_rand(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the destroy function on the engine.
     #[corresponds(ENGINE_set_destroy_function)]
     #[inline]
-    pub fn set_destroy_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_destroy_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the init function on the engine.
     #[corresponds(ENGINE_set_init_function)]
     #[inline]
-    pub fn set_init_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_init_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the finish function on the engine.
     #[corresponds(ENGINE_set_finish_function)]
     #[inline]
-    pub fn set_finish_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_finish_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the ctrl function on the engine.
     #[corresponds(ENGINE_set_ctrl_function)]
     #[inline]
-    pub fn set_ctrl_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_ctrl_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the `load_privkey` function on the engine.
     #[corresponds(ENGINE_set_load_privkey_function)]
     #[inline]
-    pub fn set_load_privkey_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_load_privkey_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the `load_pubkey` function on the engine.
     #[corresponds(ENGINE_set_load_pubkey_function)]
     #[inline]
-    pub fn set_load_pubkey_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_load_pubkey_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the ciphers pointer on the engine.
     #[corresponds(ENGINE_set_ciphers)]
     #[inline]
-    pub fn set_ciphers(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_ciphers(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the digests pointer on the engine.
     #[corresponds(ENGINE_set_digests)]
     #[inline]
-    pub fn set_digests(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_digests(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets command definitions on the engine.
     #[corresponds(ENGINE_set_cmd_defns)]
     #[inline]
-    pub fn set_cmd_defns(e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_cmd_defns(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
@@ -653,127 +651,127 @@ impl Engine {
     /// Returns the engine's currently set RSA method.
     #[corresponds(ENGINE_get_RSA)]
     #[inline]
-    pub fn get_rsa(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_rsa(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set DSA method.
     #[corresponds(ENGINE_get_DSA)]
     #[inline]
-    pub fn get_dsa(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_dsa(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set DH method.
     #[corresponds(ENGINE_get_DH)]
     #[inline]
-    pub fn get_dh(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_dh(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set RAND method.
     #[corresponds(ENGINE_get_RAND)]
     #[inline]
-    pub fn get_rand(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_rand(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set destroy function.
     #[corresponds(ENGINE_get_destroy_function)]
     #[inline]
-    pub fn get_destroy_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_destroy_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set init function.
     #[corresponds(ENGINE_get_init_function)]
     #[inline]
-    pub fn get_init_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_init_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set finish function.
     #[corresponds(ENGINE_get_finish_function)]
     #[inline]
-    pub fn get_finish_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_finish_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set ctrl function.
     #[corresponds(ENGINE_get_ctrl_function)]
     #[inline]
-    pub fn get_ctrl_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_ctrl_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set `load_privkey_function` function.
     #[corresponds(ENGINE_get_load_privkey_function)]
     #[inline]
-    pub fn get_load_privkey_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_load_privkey_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set `load_pubkey_function` function.
     #[corresponds(ENGINE_get_load_pubkey_function)]
     #[inline]
-    pub fn get_load_pubkey_function(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_load_pubkey_function(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's currently set ciphers.
     #[corresponds(ENGINE_get_ciphers)]
     #[inline]
-    pub fn get_ciphers(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_ciphers(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's current set digests.
     #[corresponds(ENGINE_get_digests)]
     #[inline]
-    pub fn get_digests(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_digests(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the cipher for the passed `nid` value.
     #[corresponds(ENGINE_get_cipher)]
     #[inline]
-    pub fn get_cipher(e: Engine, nid: i32) -> Result<(), ErrorStack> {
+    pub fn get_cipher(&mut self, nid: i32) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the digest for the passed `nid` value.
     #[corresponds(ENGINE_get_digest)]
     #[inline]
-    pub fn get_digest(e: Engine, nid: i32) -> Result<(), ErrorStack> {
+    pub fn get_digest(&mut self, nid: i32) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Returns the engine's flags.
     #[corresponds(ENGINE_get_flags)]
     #[inline]
-    pub fn get_flags(e: Engine) -> i32 {
+    pub fn get_flags(&mut self) -> i32 {
         // TODO should these flags be a different type?
-        unsafe { ffi::ENGINE_get_flags(e.as_ptr()) }
+        unsafe { ffi::ENGINE_get_flags(self.as_ptr()) }
     }
 
     /// Returns the command definitions.
     #[corresponds(ENGINE_get_cmd_defns)]
     #[inline]
-    pub fn get_cmd_defns(e: Engine) -> Result<(), ErrorStack> {
+    pub fn get_cmd_defns(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Load a private key into the engine.
     #[corresponds(ENGINE_load_private_key)]
     #[inline]
-    pub fn load_private_key(e: Engine) -> Result<(), ErrorStack> {
+    pub fn load_private_key(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Load a public key into the engine.
     #[corresponds(ENGINE_load_public_key)]
     #[inline]
-    pub fn load_public_key(e: Engine) -> Result<(), ErrorStack> {
+    pub fn load_public_key(&mut self) -> Result<(), ErrorStack> {
         todo!();
     }
 }

--- a/openssl/src/engine.rs
+++ b/openssl/src/engine.rs
@@ -1,7 +1,6 @@
 use crate::error::ErrorStack;
 use crate::{cvt, cvt_n, cvt_p};
 use cfg_if::cfg_if;
-use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::strlen;
 use openssl_macros::corresponds;
 use std::convert::TryFrom;

--- a/openssl/src/engine.rs
+++ b/openssl/src/engine.rs
@@ -4,7 +4,7 @@ use libc::strlen;
 use openssl_macros::corresponds;
 use std::ffi::{c_void, CString};
 
-struct Engine(*mut ffi::ENGINE);
+pub struct Engine(*mut ffi::ENGINE);
 
 impl Engine {
     /// Creates a new Engine.
@@ -71,21 +71,19 @@ impl Engine {
     /// Adds the engine to OpenSSL's internal engine list.
     #[corresponds(ENGINE_add)]
     #[inline]
-    pub fn add(&mut self) -> Result<(), ErrorStack> {
+    pub fn add(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_add(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_add(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Removes the engine from OpenSSL's internal engine list.
     #[corresponds(ENGINE_remove)]
     #[inline]
-    pub fn remove(&mut self) -> Result<(), ErrorStack> {
+    pub fn remove(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_remove(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_remove(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Returns an engine with the passed in `id`.
@@ -102,11 +100,10 @@ impl Engine {
     /// Remove all references to the passed in engine.
     #[corresponds(ENGINE_finish)]
     #[inline]
-    pub fn finish(&mut self) -> Result<(), ErrorStack> {
+    pub fn finish(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_finish(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_finish(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Loads the builtin engines.
@@ -181,82 +178,83 @@ impl Engine {
     /// Sets the default RSA engine.
     #[corresponds(ENGINE_set_default_RSA)]
     #[inline]
-    pub fn set_default_rsa(&mut self) -> Result<(), ErrorStack> {
+    pub fn set_default_rsa(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_RSA(self.as_ptr()))?;
+            let result = cvt(ffi::ENGINE_set_default_RSA(self.as_ptr()))?;
+            Ok(result)
         }
-        Ok(())
     }
 
     /// Sets the default DSA engine.
     #[corresponds(ENGINE_set_default_DSA)]
     #[inline]
-    pub fn set_default_dsa(&mut self) -> Result<(), ErrorStack> {
+    pub fn set_default_dsa(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_DSA(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_set_default_DSA(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Sets the default DH engine.
     #[corresponds(ENGINE_set_default_DH)]
     #[inline]
-    pub fn set_default_dh(&mut self) -> Result<(), ErrorStack> {
+    pub fn set_default_dh(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_DH(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_set_default_DH(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Sets the default RAND engine.
     #[corresponds(ENGINE_set_default_RAND)]
     #[inline]
-    pub fn set_default_rand(&mut self) -> Result<(), ErrorStack> {
+    pub fn set_default_rand(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_RAND(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_set_default_RAND(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Sets the default ciphers engine.
     #[corresponds(ENGINE_set_default_ciphers)]
     #[inline]
-    pub fn set_default_ciphers(&mut self) -> Result<(), ErrorStack> {
+    pub fn set_default_ciphers(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_ciphers(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_set_default_ciphers(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Sets the default digests engine.
     #[corresponds(ENGINE_set_default_digests)]
     #[inline]
-    pub fn set_default_digests(&mut self) -> Result<(), ErrorStack> {
+    pub fn set_default_digests(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default_digests(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_set_default_digests(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Sets the default string for the engine.
     #[corresponds(ENGINE_set_default_string)]
     #[inline]
-    pub fn set_default_string(&mut self, list: &str) -> Result<(), ErrorStack> {
+    pub fn set_default_string(&mut self, list: &str) -> Result<i32, ErrorStack> {
         let list = CString::new(list).unwrap();
         unsafe {
-            cvt(ffi::ENGINE_set_default_string(self.as_ptr(), list.as_ptr()))?;
+            return cvt(ffi::ENGINE_set_default_string(self.as_ptr(), list.as_ptr()));
         }
-        Ok(())
+    }
+    /// Sets the default engine.
+    #[corresponds(ENGINE_init)]
+    #[inline]
+    pub fn init(&mut self) -> Result<i32, ErrorStack> {
+        unsafe {
+            return cvt(ffi::ENGINE_init(self.as_ptr()));
+        }
     }
 
     /// Sets the default engine.
     #[corresponds(ENGINE_set_default)]
     #[inline]
-    pub fn set_default(&mut self, flags: u32) -> Result<(), ErrorStack> {
+    pub fn set_default(&mut self, flags: u32) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_set_default(self.as_ptr(), flags))?;
+            return cvt(ffi::ENGINE_set_default(self.as_ptr(), flags));
         }
-        Ok(())
     }
 
     /// Returns the (global?) engine table flags.
@@ -280,11 +278,10 @@ impl Engine {
     /// Registers the input engine as the RSA engine.
     #[corresponds(ENGINE_register_RSA)]
     #[inline]
-    pub fn register_rsa(&mut self) -> Result<(), ErrorStack> {
+    pub fn register_rsa(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_RSA(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_register_RSA(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Unregisters the input engine as the RSA engine.
@@ -308,11 +305,10 @@ impl Engine {
     /// Registers the input engine as the DSA engine.
     #[corresponds(ENGINE_register_DSA)]
     #[inline]
-    pub fn register_dsa(&mut self) -> Result<(), ErrorStack> {
+    pub fn register_dsa(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_DSA(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_register_DSA(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Unregisters the input engine as the DSA engine.
@@ -336,11 +332,10 @@ impl Engine {
     /// Registers the input engine as the DH engine.
     #[corresponds(ENGINE_register_DH)]
     #[inline]
-    pub fn register_dh(&mut self) -> Result<(), ErrorStack> {
+    pub fn register_dh(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_DH(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_register_DH(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Unregisters the input engine as the DH engine.
@@ -364,11 +359,10 @@ impl Engine {
     /// Registers the input engine as the RAND engine.
     #[corresponds(ENGINE_register_RAND)]
     #[inline]
-    pub fn register_rand(&mut self) -> Result<(), ErrorStack> {
+    pub fn register_rand(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_RAND(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_register_RAND(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Unregisters the input engine as the RAND engine.
@@ -392,11 +386,10 @@ impl Engine {
     /// Registers ciphers from the input engine.
     #[corresponds(ENGINE_register_ciphers)]
     #[inline]
-    pub fn register_ciphers(&mut self) -> Result<(), ErrorStack> {
+    pub fn register_ciphers(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_ciphers(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_register_ciphers(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Unregisters the ciphers from the input engine.
@@ -420,11 +413,10 @@ impl Engine {
     /// Registers digests from the input engine.
     #[corresponds(ENGINE_register_digests)]
     #[inline]
-    pub fn register_digests(&mut self) -> Result<(), ErrorStack> {
+    pub fn register_digests(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_digests(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_register_digests(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Unregisters the digests from the input engine.
@@ -447,20 +439,18 @@ impl Engine {
 
     #[corresponds(ENGINE_register_complete)]
     #[inline]
-    pub fn register_complete(&mut self) -> Result<(), ErrorStack> {
+    pub fn register_complete(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_complete(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_register_complete(self.as_ptr()));
         }
-        Ok(())
     }
 
     #[corresponds(ENGINE_register_all_complete)]
     #[inline]
-    pub fn register_all_complete() -> Result<(), ErrorStack> {
+    pub fn register_all_complete() -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_register_all_complete())?;
+            return cvt(ffi::ENGINE_register_all_complete());
         }
-        Ok(())
     }
 
     #[corresponds(ENGINE_ctrl)]
@@ -477,11 +467,10 @@ impl Engine {
 
     #[corresponds(ENGINE_cmd_is_executable)]
     #[inline]
-    pub fn cmd_is_executable(&mut self, cmd: i32) -> Result<(), ErrorStack> {
+    pub fn cmd_is_executable(&mut self, cmd: i32) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_cmd_is_executable(self.as_ptr(), cmd))?;
+            return cvt(ffi::ENGINE_cmd_is_executable(self.as_ptr(), cmd));
         }
-        Ok(())
     }
 
     #[corresponds(ENGINE_ctrl_cmd)]
@@ -497,39 +486,49 @@ impl Engine {
         _cmd: &str,
         _arg: &str,
         _optional: i32,
-    ) -> Result<(), ErrorStack> {
-        todo!();
+    ) -> Result<i32, ErrorStack> {
+        let cmd = CString::new(_cmd).unwrap();
+        let arg = CString::new(_arg).unwrap();
+        unsafe {
+            return cvt(ffi::ENGINE_ctrl_cmd_string(self.as_ptr(), cmd.as_ptr(), arg.as_ptr(), 0));
+        }
     }
-
+    #[corresponds(ENGINE_ctrl_cmd_string)]
+    #[inline]
+    pub fn load(
+        &mut self
+    ) -> Result<i32, ErrorStack> {
+        let cmd = CString::new("LOAD").unwrap();
+        unsafe {
+            return cvt(ffi::ENGINE_ctrl_cmd_string(self.as_ptr(), cmd.as_ptr(), std::ptr::null(), 0));
+        }
+    }
     #[corresponds(ENGINE_up_ref)]
     #[inline]
-    pub fn up_ref(&mut self) -> Result<(), ErrorStack> {
+    pub fn up_ref(&mut self) -> Result<i32, ErrorStack> {
         unsafe {
-            cvt(ffi::ENGINE_up_ref(self.as_ptr()))?;
+            return cvt(ffi::ENGINE_up_ref(self.as_ptr()));
         }
-        Ok(())
     }
 
     /// Sets the ID on the engine.
     #[corresponds(ENGINE_set_id)]
     #[inline]
-    pub fn set_id(&mut self, id: &str) -> Result<(), ErrorStack> {
+    pub fn set_id(&mut self, id: &str) -> Result<i32, ErrorStack> {
         let id = CString::new(id).unwrap();
         unsafe {
-            cvt(ffi::ENGINE_set_id(self.as_ptr(), id.as_ptr()))?;
+            return cvt(ffi::ENGINE_set_id(self.as_ptr(), id.as_ptr()));
         }
-        Ok(())
     }
 
     /// Sets the name on the engine.
     #[corresponds(ENGINE_set_name)]
     #[inline]
-    pub fn set_name(&mut self, name: &str) -> Result<(), ErrorStack> {
+    pub fn set_name(&mut self, name: &str) -> Result<i32, ErrorStack> {
         let name = CString::new(name).unwrap();
         unsafe {
-            cvt(ffi::ENGINE_set_name(self.as_ptr(), name.as_ptr()))?;
+            return cvt(ffi::ENGINE_set_name(self.as_ptr(), name.as_ptr()));
         }
-        Ok(())
     }
 
     /// Sets the RSA method on the engine.

--- a/openssl/src/engine.rs
+++ b/openssl/src/engine.rs
@@ -4,11 +4,11 @@ use crate::pkey_ctx::PkeyCtxRef;
 use crate::{cvt, cvt_n, cvt_p};
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef};
+use libc::strlen;
 use openssl_macros::corresponds;
 use std::convert::TryFrom;
+use std::ffi::{c_int, c_uint, c_void, CString};
 use std::ptr;
-use std::ffi::{CString, c_int, c_uint, c_void};
-use libc::{strlen};
 
 struct Engine(*mut ffi::ENGINE);
 
@@ -466,7 +466,13 @@ impl Engine {
         Ok(())
     }
 
-    pub fn ctrl(e: Engine, cmd: i32, i: i64, p: *mut c_void, f: extern "C" fn ()) -> Result<(), ErrorStack> {
+    pub fn ctrl(
+        e: Engine,
+        cmd: i32,
+        i: i64,
+        p: *mut c_void,
+        f: extern "C" fn(),
+    ) -> Result<(), ErrorStack> {
         todo!();
     }
 
@@ -481,7 +487,12 @@ impl Engine {
         todo!();
     }
 
-    pub fn ctrl_cmd_string(e: Engine, cmd: &str, arg: &str, optional: i32) -> Result<(), ErrorStack> {
+    pub fn ctrl_cmd_string(
+        e: Engine,
+        cmd: &str,
+        arg: &str,
+        optional: i32,
+    ) -> Result<(), ErrorStack> {
         todo!();
     }
 
@@ -552,35 +563,35 @@ impl Engine {
     /// Sets the init function on the engine.
     #[corresponds(ENGINE_set_init_function)]
     #[inline]
-    pub fn set_init_function (e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_init_function(e: Engine) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the finish function on the engine.
     #[corresponds(ENGINE_set_finish_function)]
     #[inline]
-    pub fn set_finish_function (e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_finish_function(e: Engine) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the ctrl function on the engine.
     #[corresponds(ENGINE_set_ctrl_function)]
     #[inline]
-    pub fn set_ctrl_function (e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_ctrl_function(e: Engine) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the `load_privkey` function on the engine.
     #[corresponds(ENGINE_set_load_privkey_function)]
     #[inline]
-    pub fn set_load_privkey_function (e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_load_privkey_function(e: Engine) -> Result<(), ErrorStack> {
         todo!();
     }
 
     /// Sets the `load_pubkey` function on the engine.
     #[corresponds(ENGINE_set_load_pubkey_function)]
     #[inline]
-    pub fn set_load_pubkey_function (e: Engine) -> Result<(), ErrorStack> {
+    pub fn set_load_pubkey_function(e: Engine) -> Result<(), ErrorStack> {
         todo!();
     }
 
@@ -742,9 +753,7 @@ impl Engine {
     #[inline]
     pub fn get_flags(e: Engine) -> i32 {
         // TODO should these flags be a different type?
-        unsafe {
-            ffi::ENGINE_get_flags(e.as_ptr())
-        }
+        unsafe { ffi::ENGINE_get_flags(e.as_ptr()) }
     }
 
     /// Returns the command definitions.
@@ -767,7 +776,6 @@ impl Engine {
     pub fn load_public_key(e: Engine) -> Result<(), ErrorStack> {
         todo!();
     }
-
 }
 
 impl Drop for Engine {
@@ -807,12 +815,15 @@ mod test {
         println!("Engines:");
 
         while has_engines {
-            println!("  {}, name={}, id={}",
-                engine_cnt, engine.get_name().unwrap(), engine.get_id().unwrap()
+            println!(
+                "  {}, name={}, id={}",
+                engine_cnt,
+                engine.get_name().unwrap(),
+                engine.get_id().unwrap()
             );
             match engine.get_next() {
                 Ok(e) => engine = e,
-                Err(m) => has_engines = false
+                Err(m) => has_engines = false,
             }
 
             engine_cnt += 1;

--- a/openssl/src/engine.rs
+++ b/openssl/src/engine.rs
@@ -445,6 +445,8 @@ impl Engine {
         }
     }
 
+    #[corresponds(ENGINE_register_complete)]
+    #[inline]
     pub fn register_complete(&mut self) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::ENGINE_register_complete(self.as_ptr()))?;
@@ -452,6 +454,8 @@ impl Engine {
         Ok(())
     }
 
+    #[corresponds(ENGINE_register_all_complete)]
+    #[inline]
     pub fn register_all_complete() -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::ENGINE_register_all_complete())?;
@@ -459,6 +463,8 @@ impl Engine {
         Ok(())
     }
 
+    #[corresponds(ENGINE_ctrl)]
+    #[inline]
     pub fn ctrl(
         &mut self,
         _cmd: i32,
@@ -469,6 +475,8 @@ impl Engine {
         todo!();
     }
 
+    #[corresponds(ENGINE_cmd_is_executable)]
+    #[inline]
     pub fn cmd_is_executable(&mut self, cmd: i32) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::ENGINE_cmd_is_executable(self.as_ptr(), cmd))?;
@@ -476,10 +484,14 @@ impl Engine {
         Ok(())
     }
 
+    #[corresponds(ENGINE_ctrl_cmd)]
+    #[inline]
     pub fn ctrl_cmd(&mut self, _cmd: &str, _arg: &str, _param: i32) -> Result<(), ErrorStack> {
         todo!();
     }
 
+    #[corresponds(ENGINE_ctrl_cmd_string)]
+    #[inline]
     pub fn ctrl_cmd_string(
         &mut self,
         _cmd: &str,
@@ -489,6 +501,8 @@ impl Engine {
         todo!();
     }
 
+    #[corresponds(ENGINE_up_ref)]
+    #[inline]
     pub fn up_ref(&mut self) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::ENGINE_up_ref(self.as_ptr()))?;

--- a/openssl/src/engine.rs
+++ b/openssl/src/engine.rs
@@ -1,0 +1,768 @@
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, HasPublic, PKeyRef};
+use crate::pkey_ctx::PkeyCtxRef;
+use crate::{cvt, cvt_n, cvt_p};
+use cfg_if::cfg_if;
+use foreign_types::{ForeignType, ForeignTypeRef};
+use openssl_macros::corresponds;
+use std::convert::TryFrom;
+use std::ptr;
+use std::ffi::{CString, c_int, c_uint, c_void};
+use libc::{strlen};
+
+struct Engine(*mut ffi::ENGINE);
+
+impl Engine {
+    /// Creates a new Engine.
+    #[corresponds(ENGINE_new)]
+    #[inline]
+    pub fn new() -> Result<Self, ErrorStack> {
+        ffi::init();
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_new())?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    pub fn as_ptr(&self) -> *mut ffi::ENGINE {
+        self.0
+    }
+
+    pub fn from_ptr(ptr: *mut ffi::ENGINE) -> Engine {
+        Engine(ptr)
+    }
+
+    /// Returns the "first" ENGINE type available.
+    #[corresponds(ENGINE_get_first)]
+    #[inline]
+    pub fn get_first() -> Result<Self, ErrorStack> {
+        ffi::init();
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_first())?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the "last" ENGINE type available.
+    #[corresponds(ENGINE_get_last)]
+    #[inline]
+    pub fn get_last() -> Result<Self, ErrorStack> {
+        ffi::init();
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_last())?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the "next" ENGINE type available, after the passed in ENGINE.
+    #[corresponds(ENGINE_get_next)]
+    #[inline]
+    pub fn get_next(e: Engine) -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_next(e.as_ptr()))?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the "previous" ENGINE type available, before the passed in ENGINE.
+    #[corresponds(ENGINE_get_prev)]
+    #[inline]
+    pub fn get_prev(e: Engine) -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_prev(e.as_ptr()))?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Adds the engine to OpenSSL's internal engine list.
+    #[corresponds(ENGINE_add)]
+    #[inline]
+    pub fn add(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_add(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Removes the engine from OpenSSL's internal engine list.
+    #[corresponds(ENGINE_remove)]
+    #[inline]
+    pub fn remove(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_remove(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Returns an engine with the passed in `id`.
+    #[corresponds(ENGINE_by_id)]
+    #[inline]
+    pub fn by_id(id: &str) -> Result<Self, ErrorStack> {
+        let id = CString::new(id).unwrap();
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_by_id(id.as_ptr()))?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Remove all references to the passed in engine.
+    #[corresponds(ENGINE_finish)]
+    #[inline]
+    pub fn finish(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_finish(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Loads the builtin engines.
+    #[corresponds(ENGINE_load_builtin_engines)]
+    #[inline]
+    pub fn load_builtin_engines() {
+        unsafe {
+            ffi::ENGINE_load_builtin_engines();
+        }
+    }
+
+    /// Returns the default engine for the "RSA" algorithm.
+    #[corresponds(ENGINE_get_default_RSA)]
+    #[inline]
+    pub fn get_default_rsa() -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_default_RSA())?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the default engine for the "DSA" algorithm.
+    #[corresponds(ENGINE_get_default_DSA)]
+    #[inline]
+    pub fn get_default_dsa() -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_default_DSA())?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the default engine for the "DH" algorithm.
+    #[corresponds(ENGINE_get_default_DH)]
+    #[inline]
+    pub fn get_default_dh() -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_default_DH())?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the default engine for the "RAND" algorithm.
+    #[corresponds(ENGINE_get_default_RAND)]
+    #[inline]
+    pub fn get_default_rand() -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_default_RAND())?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the default cipher engine.
+    #[corresponds(ENGINE_get_default_cipher_engine)]
+    #[inline]
+    pub fn get_cipher_engine(nid: i32) -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_cipher_engine(c_int::from(nid)))?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Returns the default digest engine.
+    #[corresponds(ENGINE_get_digest_engine)]
+    #[inline]
+    pub fn get_digest_engine(nid: i32) -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::ENGINE_get_digest_engine(c_int::from(nid)))?;
+            Ok(Engine::from_ptr(ptr))
+        }
+    }
+
+    /// Sets the default RSA engine.
+    #[corresponds(ENGINE_set_default_RSA)]
+    #[inline]
+    pub fn set_default_rsa(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_set_default_RSA(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the default DSA engine.
+    #[corresponds(ENGINE_set_default_DSA)]
+    #[inline]
+    pub fn set_default_dsa(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_set_default_DSA(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the default DH engine.
+    #[corresponds(ENGINE_set_default_DH)]
+    #[inline]
+    pub fn set_default_dh(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_set_default_DH(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the default RAND engine.
+    #[corresponds(ENGINE_set_default_RAND)]
+    #[inline]
+    pub fn set_default_rand(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_set_default_RAND(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the default ciphers engine.
+    #[corresponds(ENGINE_set_default_ciphers)]
+    #[inline]
+    pub fn set_default_ciphers(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_set_default_ciphers(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the default digests engine.
+    #[corresponds(ENGINE_set_default_digests)]
+    #[inline]
+    pub fn set_default_digests(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_set_default_digests(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the default string for the engine.
+    #[corresponds(ENGINE_set_default_string)]
+    #[inline]
+    pub fn set_default_string(e: Engine, list: &str) -> Result<(), ErrorStack> {
+        let list = CString::new(list).unwrap();
+        unsafe {
+            cvt(ffi::ENGINE_set_default_string(e.as_ptr(), list.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the default engine.
+    #[corresponds(ENGINE_set_default)]
+    #[inline]
+    pub fn set_default(e: Engine, flags: u32) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_set_default(e.as_ptr(), c_uint::from(flags)))?;
+        }
+        Ok(())
+    }
+
+    /// Returns the (global?) engine table flags.
+    #[corresponds(ENGINE_get_table_flags)]
+    #[inline]
+    pub fn get_table_flags() -> u32 {
+        unsafe {
+            let rc = ffi::ENGINE_get_table_flags();
+            return u32::from(rc);
+        }
+    }
+
+    /// Sets the (global?) engine table flags.
+    #[corresponds(ENGINE_set_table_flags)]
+    #[inline]
+    pub fn set_table_flags(flags: u32) {
+        unsafe {
+            ffi::ENGINE_set_table_flags(c_uint::from(flags));
+        }
+    }
+
+    /// Registers the input engine as the RSA engine.
+    #[corresponds(ENGINE_register_RSA)]
+    #[inline]
+    pub fn register_rsa(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_register_RSA(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Unregisters the input engine as the RSA engine.
+    #[corresponds(ENGINE_unregister_RSA)]
+    #[inline]
+    pub fn unregister_rsa(e: Engine) {
+        unsafe {
+            ffi::ENGINE_unregister_RSA(e.as_ptr());
+        }
+    }
+
+    /// Registers all of the engines as RSA.
+    #[corresponds(ENGINE_register_all_RSA)]
+    #[inline]
+    pub fn register_all_rsa(e: Engine) {
+        unsafe {
+            ffi::ENGINE_register_all_RSA();
+        }
+    }
+
+    /// Registers the input engine as the DSA engine.
+    #[corresponds(ENGINE_register_DSA)]
+    #[inline]
+    pub fn register_dsa(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_register_DSA(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Unregisters the input engine as the DSA engine.
+    #[corresponds(ENGINE_unregister_DSA)]
+    #[inline]
+    pub fn unregister_dsa(e: Engine) {
+        unsafe {
+            ffi::ENGINE_unregister_DSA(e.as_ptr());
+        }
+    }
+
+    /// Registers all of the engines as DSA.
+    #[corresponds(ENGINE_unregister_DSA)]
+    #[inline]
+    pub fn register_all_dsa() {
+        unsafe {
+            ffi::ENGINE_register_all_DSA();
+        }
+    }
+
+    /// Registers the input engine as the DH engine.
+    #[corresponds(ENGINE_register_DH)]
+    #[inline]
+    pub fn register_dh(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_register_DH(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Unregisters the input engine as the DH engine.
+    #[corresponds(ENGINE_unregister_DH)]
+    #[inline]
+    pub fn unregister_dh(e: Engine) {
+        unsafe {
+            ffi::ENGINE_unregister_DH(e.as_ptr());
+        }
+    }
+
+    /// Registers all of the engines as DH.
+    #[corresponds(ENGINE_unregister_DH)]
+    #[inline]
+    pub fn register_all_dh() {
+        unsafe {
+            ffi::ENGINE_register_all_DH();
+        }
+    }
+
+    /// Registers the input engine as the RAND engine.
+    #[corresponds(ENGINE_register_RAND)]
+    #[inline]
+    pub fn register_rand(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_register_RAND(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Unregisters the input engine as the RAND engine.
+    #[corresponds(ENGINE_unregister_RAND)]
+    #[inline]
+    pub fn unregister_rand(e: Engine) {
+        unsafe {
+            ffi::ENGINE_unregister_RAND(e.as_ptr());
+        }
+    }
+
+    /// Registers all of the engines as RAND.
+    #[corresponds(ENGINE_unregister_RAND)]
+    #[inline]
+    pub fn register_all_rand() {
+        unsafe {
+            ffi::ENGINE_register_all_RAND();
+        }
+    }
+
+    /// Registers ciphers from the input engine.
+    #[corresponds(ENGINE_register_ciphers)]
+    #[inline]
+    pub fn register_ciphers(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_register_ciphers(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Unregisters the ciphers from the input engine.
+    #[corresponds(ENGINE_unregister_ciphers)]
+    #[inline]
+    pub fn unregister_ciphers(e: Engine) {
+        unsafe {
+            ffi::ENGINE_unregister_ciphers(e.as_ptr());
+        }
+    }
+
+    /// Registers all ciphers from the input engine.
+    #[corresponds(ENGINE_unregister_ciphers)]
+    #[inline]
+    pub fn register_all_ciphers() {
+        unsafe {
+            ffi::ENGINE_register_all_ciphers();
+        }
+    }
+
+    /// Registers digests from the input engine.
+    #[corresponds(ENGINE_register_digests)]
+    #[inline]
+    pub fn register_digests(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_register_digests(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Unregisters the digests from the input engine.
+    #[corresponds(ENGINE_unregister_digests)]
+    #[inline]
+    pub fn unregister_digests(e: Engine) {
+        unsafe {
+            ffi::ENGINE_unregister_digests(e.as_ptr());
+        }
+    }
+
+    /// Registers all digests from the input engine.
+    #[corresponds(ENGINE_unregister_digests)]
+    #[inline]
+    pub fn register_all_digests() {
+        unsafe {
+            ffi::ENGINE_register_all_digests();
+        }
+    }
+
+    pub fn register_complete(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_register_complete(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    pub fn register_all_complete() -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_register_all_complete())?;
+        }
+        Ok(())
+    }
+
+    pub fn ctrl(e: Engine, cmd: i32, i: i64, p: *mut c_void, f: extern "C" fn ()) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    pub fn cmd_is_executable(e: Engine, cmd: i32) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_cmd_is_executable(e.as_ptr(), c_int::from(cmd)))?;
+        }
+        Ok(())
+    }
+
+    pub fn ctrl_cmd(e: Engine, cmd: &str, arg: &str, param: i32) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    pub fn ctrl_cmd_string(e: Engine, cmd: &str, arg: &str, optional: i32) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    pub fn up_ref(e: Engine) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::ENGINE_up_ref(e.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the ID on the engine.
+    #[corresponds(ENGINE_set_id)]
+    #[inline]
+    pub fn set_id(e: Engine, id: &str) -> Result<(), ErrorStack> {
+        let id = CString::new(id).unwrap();
+        unsafe {
+            cvt(ffi::ENGINE_set_id(e.as_ptr(), id.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the name on the engine.
+    #[corresponds(ENGINE_set_name)]
+    #[inline]
+    pub fn set_name(e: Engine, name: &str) -> Result<(), ErrorStack> {
+        let name = CString::new(name).unwrap();
+        unsafe {
+            cvt(ffi::ENGINE_set_name(e.as_ptr(), name.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    /// Sets the RSA method on the engine.
+    #[corresponds(ENGINE_set_RSA)]
+    #[inline]
+    pub fn set_rsa(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the DSA method on the engine.
+    #[corresponds(ENGINE_set_DSA)]
+    #[inline]
+    pub fn set_dsa(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the DH method on the engine.
+    #[corresponds(ENGINE_set_DH)]
+    #[inline]
+    pub fn set_dh(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the RAND method on the engine.
+    #[corresponds(ENGINE_set_RAND)]
+    #[inline]
+    pub fn set_rand(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the destroy function on the engine.
+    #[corresponds(ENGINE_set_destroy_function)]
+    #[inline]
+    pub fn set_destroy_function(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the init function on the engine.
+    #[corresponds(ENGINE_set_init_function)]
+    #[inline]
+    pub fn set_init_function (e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the finish function on the engine.
+    #[corresponds(ENGINE_set_finish_function)]
+    #[inline]
+    pub fn set_finish_function (e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the ctrl function on the engine.
+    #[corresponds(ENGINE_set_ctrl_function)]
+    #[inline]
+    pub fn set_ctrl_function (e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the `load_privkey` function on the engine.
+    #[corresponds(ENGINE_set_load_privkey_function)]
+    #[inline]
+    pub fn set_load_privkey_function (e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the `load_pubkey` function on the engine.
+    #[corresponds(ENGINE_set_load_pubkey_function)]
+    #[inline]
+    pub fn set_load_pubkey_function (e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the ciphers pointer on the engine.
+    #[corresponds(ENGINE_set_ciphers)]
+    #[inline]
+    pub fn set_ciphers(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets the digests pointer on the engine.
+    #[corresponds(ENGINE_set_digests)]
+    #[inline]
+    pub fn set_digests(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Sets command definitions on the engine.
+    #[corresponds(ENGINE_set_cmd_defns)]
+    #[inline]
+    pub fn set_cmd_defns(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's ID.
+    #[corresponds(ENGINE_get_id)]
+    #[inline]
+    pub fn get_id(e: Engine) -> Result<String, ErrorStack> {
+        unsafe {
+            let ptr = ffi::ENGINE_get_id(e.as_ptr());
+            let slice = std::slice::from_raw_parts(ptr as *const u8, strlen(ptr) + 1 as usize);
+            Ok(std::str::from_utf8_unchecked(slice).to_string())
+        }
+    }
+
+    /// Returns the engine's name.
+    #[corresponds(ENGINE_get_name)]
+    #[inline]
+    pub fn get_name(e: Engine) -> Result<String, ErrorStack> {
+        unsafe {
+            let ptr = ffi::ENGINE_get_name(e.as_ptr());
+            let slice = std::slice::from_raw_parts(ptr as *const u8, strlen(ptr) + 1 as usize);
+            Ok(std::str::from_utf8_unchecked(slice).to_string())
+        }
+    }
+
+    /// Returns the engine's currently set RSA method.
+    #[corresponds(ENGINE_get_RSA)]
+    #[inline]
+    pub fn get_rsa(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set DSA method.
+    #[corresponds(ENGINE_get_DSA)]
+    #[inline]
+    pub fn get_dsa(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set DH method.
+    #[corresponds(ENGINE_get_DH)]
+    #[inline]
+    pub fn get_dh(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set RAND method.
+    #[corresponds(ENGINE_get_RAND)]
+    #[inline]
+    pub fn get_rand(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set destroy function.
+    #[corresponds(ENGINE_get_destroy_function)]
+    #[inline]
+    pub fn get_destroy_function(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set init function.
+    #[corresponds(ENGINE_get_init_function)]
+    #[inline]
+    pub fn get_init_function(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set finish function.
+    #[corresponds(ENGINE_get_finish_function)]
+    #[inline]
+    pub fn get_finish_function(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set ctrl function.
+    #[corresponds(ENGINE_get_ctrl_function)]
+    #[inline]
+    pub fn get_ctrl_function(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set `load_privkey_function` function.
+    #[corresponds(ENGINE_get_load_privkey_function)]
+    #[inline]
+    pub fn get_load_privkey_function(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set `load_pubkey_function` function.
+    #[corresponds(ENGINE_get_load_pubkey_function)]
+    #[inline]
+    pub fn get_load_pubkey_function(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's currently set ciphers.
+    #[corresponds(ENGINE_get_ciphers)]
+    #[inline]
+    pub fn get_ciphers(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's current set digests.
+    #[corresponds(ENGINE_get_digests)]
+    #[inline]
+    pub fn get_digests(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the cipher for the passed `nid` value.
+    #[corresponds(ENGINE_get_cipher)]
+    #[inline]
+    pub fn get_cipher(e: Engine, nid: i32) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the digest for the passed `nid` value.
+    #[corresponds(ENGINE_get_digest)]
+    #[inline]
+    pub fn get_digest(e: Engine, nid: i32) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Returns the engine's flags.
+    #[corresponds(ENGINE_get_flags)]
+    #[inline]
+    pub fn get_flags(e: Engine) -> i32 {
+        // TODO should these flags be a different type?
+        unsafe {
+            ffi::ENGINE_get_flags(e.as_ptr())
+        }
+    }
+
+    /// Returns the command definitions.
+    #[corresponds(ENGINE_get_cmd_defns)]
+    #[inline]
+    pub fn get_cmd_defns(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Load a private key into the engine.
+    #[corresponds(ENGINE_load_private_key)]
+    #[inline]
+    pub fn load_private_key(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+    /// Load a public key into the engine.
+    #[corresponds(ENGINE_load_public_key)]
+    #[inline]
+    pub fn load_public_key(e: Engine) -> Result<(), ErrorStack> {
+        todo!();
+    }
+
+}
+
+impl Drop for Engine {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            ffi::ENGINE_free(self.as_ptr());
+        }
+    }
+}

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -154,6 +154,7 @@ pub mod dsa;
 pub mod ec;
 pub mod ecdsa;
 pub mod encrypt;
+#[cfg(all(not(boringssl), not(libressl), all(ossl110)))]
 pub mod engine;
 #[cfg(not(boringssl))]
 pub mod envelope;

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -154,6 +154,7 @@ pub mod dsa;
 pub mod ec;
 pub mod ecdsa;
 pub mod encrypt;
+pub mod engine;
 #[cfg(not(boringssl))]
 pub mod envelope;
 pub mod error;

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -154,7 +154,7 @@ pub mod dsa;
 pub mod ec;
 pub mod ecdsa;
 pub mod encrypt;
-#[cfg(all(not(boringssl), not(libressl), all(ossl110)))]
+#[cfg(all(not(boringssl), not(libressl), ossl110))]
 pub mod engine;
 #[cfg(not(boringssl))]
 pub mod envelope;

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -82,6 +82,10 @@ fn main() {
             cfg.header("openssl/kdf.h");
         }
 
+        if 0x10100000 <= version && version < 0x30000000 {
+            cfg.header("openssl/engine.h");
+        }
+
         if version >= 0x30000000 {
             cfg.header("openssl/provider.h");
         }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -82,7 +82,6 @@ fn main() {
             cfg.header("openssl/kdf.h");
         }
 
-
         if (0x10100000..0x30000000).contains(&version) {
             cfg.header("openssl/engine.h");
         }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -82,7 +82,8 @@ fn main() {
             cfg.header("openssl/kdf.h");
         }
 
-        if 0x10100000 <= version && version < 0x30000000 {
+
+        if (0x10100000..0x30000000).contains(&version) {
             cfg.header("openssl/engine.h");
         }
 


### PR DESCRIPTION
Draft GitHub PR for adding OpenSSL engine support:

Allow using OpenSSL engines

This PR adds the ability to load and use OpenSSL engines for hardware acceleration and offloading of crypto operations.

Some of the key functionality we want to implement is:
- Load builtin OpenSSL engines
- Register all engines
- Load an engine by ID (e.g. "dynamic")
- Control the engine by passing command strings
- Set engine parameters (e.g. SO path)  
- Initialize and add the engine
- Set as the default engine
- Get engine name and ID

Benefits:
    Hardware acceleration of crypto workloads
    Leverage optimizations in OpenSSL engines
    Improve performance of cryptography

This enables tapping into OpenSSL engines like the QuickAssist engine for hardware accelerated cryptography.

Usage example:
```

let _ = Engine::load_builtin_engines(); 
let _ = Engine::register_all_complete();
let mut e = Engine::by_id("dynamic").unwrap();
println!("cmd so path: {}", e.ctrl_cmd_string("SO_PATH", "/opt/openssl/1.1.1e/lib/engines-1.1/qatengine.so", 0).unwrap());
println!("cmd load {}", e.load().unwrap());
println!("init = {}", e.init().unwrap());
println!("add = {}", e.add().unwrap());
println!("cmd set default {}", e.set_default(0xFFFF).unwrap());
println!("name={}, id={}", e.get_name().unwrap(), e.get_id().unwrap());

```