### PR TITLE
Updating openssl-sys build error to inform the user about version incompatibilities.

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -190,9 +190,12 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
 Header expansion error:
 {:?}
 
-Failed to find OpenSSL development headers.
+Failed to find OpenSSL development headers.  Note: openssl-sys is compatible
+only with OpenSSL versions: 1.0.1, 1.0.2, 1.1.0, 1.1.1, and 3.0.0.  Please
+ensure that the OpenSSL installation being linked is one of the supported
+versions.
 
-You can try fixing this setting the `OPENSSL_DIR` environment variable
+You can try fixing this by setting the `OPENSSL_DIR` environment variable
 pointing to your OpenSSL installation or installing OpenSSL headers package
 specific to your distribution:
 


### PR DESCRIPTION
I lost a couple of hours trying to figure out why openssl-sys wouldn't compile, even though I had a local system installation of OpenSSL.  Turns out I was using 3.0.7, which is unsupported.  When I downgrade to 3.0.0 and update my pkg-config path for the new installation, everything compiles correctly.  

The current error message is too implicit, since the reader is left to assume that by simply installing OpenSSL that the error should be resolved.  The new error message makes it explicit that only specific OpenSSL versions are supported.