### PR TITLE
Add support for SSL_group_to_name and SSL_get_negotiated_group

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -951,3 +951,8 @@ extern "C" {
     #[cfg(any(ossl110, libressl360))]
     pub fn SSL_get_security_level(s: *const SSL) -> c_int;
 }
+
+extern "C" {
+    #[cfg(ossl300)]
+    pub fn SSL_group_to_name(ssl: *const SSL, id: c_int) -> *const c_char;
+}

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -363,6 +363,8 @@ pub const SSL_CTRL_GET_MIN_PROTO_VERSION: c_int = 130;
 pub const SSL_CTRL_GET_MAX_PROTO_VERSION: c_int = 131;
 #[cfg(ossl300)]
 pub const SSL_CTRL_GET_TMP_KEY: c_int = 133;
+#[cfg(ossl300)]
+pub const SSL_CTRL_GET_NEGOTIATED_GROUP: c_int = 134;
 
 pub unsafe fn SSL_CTX_set_tmp_dh(ctx: *mut SSL_CTX, dh: *mut DH) -> c_long {
     SSL_CTX_ctrl(ctx, SSL_CTRL_SET_TMP_DH, 0, dh as *mut c_void)
@@ -518,6 +520,10 @@ cfg_if! {
 
         pub unsafe fn SSL_get_tmp_key(ssl: *mut SSL, key: *mut *mut EVP_PKEY) -> c_long {
             SSL_ctrl(ssl, SSL_CTRL_GET_TMP_KEY, 0, key as *mut c_void)
+        }
+
+        pub unsafe fn SSL_get_negotiated_group(ssl: *mut SSL) -> c_int {
+            SSL_ctrl(ssl, SSL_CTRL_GET_NEGOTIATED_GROUP, 0, ptr::null_mut()) as c_int
         }
     }
 }


### PR DESCRIPTION
This PR adds support for OpenSSL 3.0 functions to retrieve information about the effective group negotiated in the TLS handshake from an `SSL*` object.

Marked as draft as I need more guidance from maintainers:
- [ ] `cargo test` fails with
  ```
  error: returning ‘const char * (*)(SSL *, int)’ {aka ‘const char * (*)(struct ssl_st *, int)’} from a function with incompatible 
         return type ‘const char * (*)(const SSL *, int)’ {aka ‘const char * (*)(const struct ssl_st *, int)’}
         [-Werror=incompatible-pointer-types]
  ```
  so I must be doing something wrong with the declaration, but I am struggling to see it

- [ ] in `openssl/src/ssl/mod.rs:3523` I currently have an `.expect()` which is probably undesirable, but I'd like guidance on the proper way to handle that error to be consistent with the rest of the crate.