### PR TITLE
Add missing openssl-sys dependency

### DIFF
--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -44,7 +44,7 @@
 //! $ sudo apt-get install pkg-config libssl-dev
 //!
 //! # Fedora
-//! $ sudo dnf install pkg-config perl-FindBin openssl-devel
+//! $ sudo dnf install pkg-config perl-FindBin perl-IPC-Cmd openssl-devel
 //!
 //! # Alpine Linux
 //! $ apk add pkgconfig openssl-dev


### PR DESCRIPTION
This fixes "Can't locate IPC/Cmd.pm in @INC (you may need to install the IPC::Cmd module)" issues in the build.