### PR TITLE
Added RSA_METHOD Bindings

### DIFF
--- a/openssl-sys/src/handwritten/mod.rs
+++ b/openssl-sys/src/handwritten/mod.rs
@@ -24,6 +24,8 @@ pub use self::poly1305::*;
 pub use self::provider::*;
 pub use self::rand::*;
 pub use self::rsa::*;
+#[cfg(ossl110)]
+pub use self::rsa_meth::*;
 pub use self::safestack::*;
 pub use self::sha::*;
 pub use self::srtp::*;
@@ -61,6 +63,8 @@ mod poly1305;
 mod provider;
 mod rand;
 mod rsa;
+#[cfg(ossl110)]
+mod rsa_meth;
 mod safestack;
 mod sha;
 mod srtp;

--- a/openssl-sys/src/handwritten/rsa_meth.rs
+++ b/openssl-sys/src/handwritten/rsa_meth.rs
@@ -18,29 +18,126 @@ extern "C" {
     pub fn RSA_meth_get0_app_data(meth: *const RSA_METHOD) -> *mut c_void;
     pub fn RSA_meth_set0_app_data(meth: *mut RSA_METHOD, app_data: *mut c_void) -> c_int;
 
-    pub fn RSA_meth_set_pub_enc(rsa: *mut RSA_METHOD, pub_enc: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> c_int;
-    pub fn RSA_meth_set_pub_dec(rsa: *mut RSA_METHOD, pub_dec: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> c_int;
+    pub fn RSA_meth_set_pub_enc(
+        rsa: *mut RSA_METHOD,
+        pub_enc: extern "C" fn(
+            flen: c_int,
+            from: *const c_uchar,
+            to: *mut c_uchar,
+            rsa: *mut RSA,
+            padding: c_int,
+        ) -> c_int,
+    ) -> c_int;
+    pub fn RSA_meth_set_pub_dec(
+        rsa: *mut RSA_METHOD,
+        pub_dec: extern "C" fn(
+            flen: c_int,
+            from: *const c_uchar,
+            to: *mut c_uchar,
+            rsa: *mut RSA,
+            padding: c_int,
+        ) -> c_int,
+    ) -> c_int;
 
-    pub fn RSA_meth_set_priv_enc(rsa: *mut RSA_METHOD, priv_enc: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> c_int;
-    pub fn RSA_meth_set_priv_dec(rsa: *mut RSA_METHOD, priv_dec: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> c_int;
+    pub fn RSA_meth_set_priv_enc(
+        rsa: *mut RSA_METHOD,
+        priv_enc: extern "C" fn(
+            flen: c_int,
+            from: *const c_uchar,
+            to: *mut c_uchar,
+            rsa: *mut RSA,
+            padding: c_int,
+        ) -> c_int,
+    ) -> c_int;
+    pub fn RSA_meth_set_priv_dec(
+        rsa: *mut RSA_METHOD,
+        priv_dec: extern "C" fn(
+            flen: c_int,
+            from: *const c_uchar,
+            to: *mut c_uchar,
+            rsa: *mut RSA,
+            padding: c_int,
+        ) -> c_int,
+    ) -> c_int;
 
     /// Notes from OpenSSL documentation: Can be null.
-    pub fn RSA_meth_set_mod_exp(rsa: *mut RSA_METHOD, mod_exp: extern "C" fn(r0: *mut BIGNUM, i: *const BIGNUM, rsa: *mut RSA, ctx: *mut BN_CTX) -> c_int) -> c_int;
+    pub fn RSA_meth_set_mod_exp(
+        rsa: *mut RSA_METHOD,
+        mod_exp: extern "C" fn(
+            r0: *mut BIGNUM,
+            i: *const BIGNUM,
+            rsa: *mut RSA,
+            ctx: *mut BN_CTX,
+        ) -> c_int,
+    ) -> c_int;
 
     /// Notes from OpenSSL documentation: Can be null.
-    pub fn RSA_meth_set_bn_mod_exp(rsa: *mut RSA_METHOD, bn_mod_exp: extern "C" fn(r: *mut BIGNUM, a: *const BIGNUM, p: *const BIGNUM, m: *const BIGNUM, ctx: *mut BN_CTX, m_ctx: *mut BN_MONT_CTX) -> c_int) -> c_int;
+    pub fn RSA_meth_set_bn_mod_exp(
+        rsa: *mut RSA_METHOD,
+        bn_mod_exp: extern "C" fn(
+            r: *mut BIGNUM,
+            a: *const BIGNUM,
+            p: *const BIGNUM,
+            m: *const BIGNUM,
+            ctx: *mut BN_CTX,
+            m_ctx: *mut BN_MONT_CTX,
+        ) -> c_int,
+    ) -> c_int;
 
     /// Notes from OpenSSL documentation: Can be null.
-    pub fn RSA_meth_set_init(rsa: *mut RSA_METHOD, init: extern "C" fn(rsa: *mut RSA) -> c_int) -> c_int;
+    pub fn RSA_meth_set_init(
+        rsa: *mut RSA_METHOD,
+        init: extern "C" fn(rsa: *mut RSA) -> c_int,
+    ) -> c_int;
 
     /// Notes from OpenSSL documentation: Can be null.
-    pub fn RSA_meth_set_finish(rsa: *mut RSA_METHOD, finish: extern "C" fn(rsa: *mut RSA) -> c_int) -> c_int;
+    pub fn RSA_meth_set_finish(
+        rsa: *mut RSA_METHOD,
+        finish: extern "C" fn(rsa: *mut RSA) -> c_int,
+    ) -> c_int;
 
-    pub fn RSA_meth_set_sign(rsa: *mut RSA_METHOD, sign: extern "C" fn(_type: c_int, m: *const c_uchar, m_length: c_uint, sigret: *mut c_uchar, siglen: *mut c_uint, rsa: *const RSA) -> c_int) -> c_int;
+    pub fn RSA_meth_set_sign(
+        rsa: *mut RSA_METHOD,
+        sign: extern "C" fn(
+            _type: c_int,
+            m: *const c_uchar,
+            m_length: c_uint,
+            sigret: *mut c_uchar,
+            siglen: *mut c_uint,
+            rsa: *const RSA,
+        ) -> c_int,
+    ) -> c_int;
 
-    pub fn RSA_meth_set_verify(rsa: *mut RSA_METHOD, verify: extern "C" fn(dtype: c_int, m: *const c_uchar, m_length: c_uint, sigbuf: *const c_uchar, siglen: c_uint, rsa: *const RSA) -> c_int) -> c_int;
+    pub fn RSA_meth_set_verify(
+        rsa: *mut RSA_METHOD,
+        verify: extern "C" fn(
+            dtype: c_int,
+            m: *const c_uchar,
+            m_length: c_uint,
+            sigbuf: *const c_uchar,
+            siglen: c_uint,
+            rsa: *const RSA,
+        ) -> c_int,
+    ) -> c_int;
 
-    pub fn RSA_meth_set_keygen(rsa: *mut RSA_METHOD, keygen: extern "C" fn(rsa: *mut RSA, bits: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int) -> c_int;
+    pub fn RSA_meth_set_keygen(
+        rsa: *mut RSA_METHOD,
+        keygen: extern "C" fn(
+            rsa: *mut RSA,
+            bits: c_int,
+            e: *mut BIGNUM,
+            cb: *mut BN_GENCB,
+        ) -> c_int,
+    ) -> c_int;
 
-    pub fn RSA_meth_set_multi_prime_keygen(meth: *mut RSA_METHOD, keygen: extern "C" fn(rsa: *mut RSA, bits: c_int, primes: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int) -> c_int;
+    pub fn RSA_meth_set_multi_prime_keygen(
+        meth: *mut RSA_METHOD,
+        keygen: extern "C" fn(
+            rsa: *mut RSA,
+            bits: c_int,
+            primes: c_int,
+            e: *mut BIGNUM,
+            cb: *mut BN_GENCB,
+        ) -> c_int,
+    ) -> c_int;
 }

--- a/openssl-sys/src/handwritten/rsa_meth.rs
+++ b/openssl-sys/src/handwritten/rsa_meth.rs
@@ -1,0 +1,46 @@
+use super::super::*;
+use libc::*;
+
+#[cfg(ossl110)]
+extern "C" {
+    pub fn RSA_meth_new(name: *const c_char, flags: c_int) -> *mut RSA_METHOD;
+
+    pub fn RSA_meth_free(meth: *mut RSA_METHOD);
+
+    pub fn RSA_meth_dup(meth: *const RSA_METHOD) -> *mut RSA_METHOD;
+
+    pub fn RSA_meth_get0_name(meth: *const RSA_METHOD) -> *const c_char;
+    pub fn RSA_meth_set1_name(meth: *mut RSA_METHOD, name: *const c_char) -> c_int;
+
+    pub fn RSA_meth_get_flags(meth: *const RSA_METHOD) -> c_int;
+    pub fn RSA_meth_set_flags(meth: *mut RSA_METHOD, flags: c_int) -> c_int;
+
+    pub fn RSA_meth_get0_app_data(meth: *const RSA_METHOD) -> *mut c_void;
+    pub fn RSA_meth_set0_app_data(meth: *mut RSA_METHOD, app_data: *mut c_void) -> c_int;
+
+    pub fn RSA_meth_set_pub_enc(rsa: *mut RSA_METHOD, pub_enc: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> c_int;
+    pub fn RSA_meth_set_pub_dec(rsa: *mut RSA_METHOD, pub_dec: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> c_int;
+
+    pub fn RSA_meth_set_priv_enc(rsa: *mut RSA_METHOD, priv_enc: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> c_int;
+    pub fn RSA_meth_set_priv_dec(rsa: *mut RSA_METHOD, priv_dec: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> c_int;
+
+    /// Notes from OpenSSL documentation: Can be null.
+    pub fn RSA_meth_set_mod_exp(rsa: *mut RSA_METHOD, mod_exp: extern "C" fn(r0: *mut BIGNUM, i: *const BIGNUM, rsa: *mut RSA, ctx: *mut BN_CTX) -> c_int) -> c_int;
+
+    /// Notes from OpenSSL documentation: Can be null.
+    pub fn RSA_meth_set_bn_mod_exp(rsa: *mut RSA_METHOD, bn_mod_exp: extern "C" fn(r: *mut BIGNUM, a: *const BIGNUM, p: *const BIGNUM, m: *const BIGNUM, ctx: *mut BN_CTX, m_ctx: *mut BN_MONT_CTX) -> c_int) -> c_int;
+
+    /// Notes from OpenSSL documentation: Can be null.
+    pub fn RSA_meth_set_init(rsa: *mut RSA_METHOD, init: extern "C" fn(rsa: *mut RSA) -> c_int) -> c_int;
+
+    /// Notes from OpenSSL documentation: Can be null.
+    pub fn RSA_meth_set_finish(rsa: *mut RSA_METHOD, finish: extern "C" fn(rsa: *mut RSA) -> c_int) -> c_int;
+
+    pub fn RSA_meth_set_sign(rsa: *mut RSA_METHOD, sign: extern "C" fn(_type: c_int, m: *const c_uchar, m_length: c_uint, sigret: *mut c_uchar, siglen: *mut c_uint, rsa: *const RSA) -> c_int) -> c_int;
+
+    pub fn RSA_meth_set_verify(rsa: *mut RSA_METHOD, verify: extern "C" fn(dtype: c_int, m: *const c_uchar, m_length: c_uint, sigbuf: *const c_uchar, siglen: c_uint, rsa: *const RSA) -> c_int) -> c_int;
+
+    pub fn RSA_meth_set_keygen(rsa: *mut RSA_METHOD, keygen: extern "C" fn(rsa: *mut RSA, bits: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int) -> c_int;
+
+    pub fn RSA_meth_set_multi_prime_keygen(meth: *mut RSA_METHOD, keygen: extern "C" fn(rsa: *mut RSA, bits: c_int, primes: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int) -> c_int;
+}

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -179,6 +179,8 @@ pub mod pkey_ctx;
 pub mod provider;
 pub mod rand;
 pub mod rsa;
+#[cfg(ossl110)]
+pub mod rsa_meth;
 pub mod sha;
 pub mod sign;
 pub mod srtp;

--- a/openssl/src/rsa_meth.rs
+++ b/openssl/src/rsa_meth.rs
@@ -1,8 +1,8 @@
 use crate::error::ErrorStack;
 use crate::{cvt, cvt_p, cvt_p_const};
+use ffi::{BIGNUM, BN_CTX, BN_GENCB, BN_MONT_CTX, RSA};
 use openssl_macros::corresponds;
-use std::ffi::{c_void, c_int, c_uint, c_uchar, CString, CStr};
-use ffi::{BIGNUM, BN_CTX, BN_MONT_CTX, BN_GENCB, RSA};
+use std::ffi::{c_int, c_uchar, c_uint, c_void, CStr, CString};
 
 struct RsaMethod(*mut ffi::RSA_METHOD);
 
@@ -57,9 +57,7 @@ impl RsaMethod {
     #[corresponds(RSA_meth_get_flags)]
     #[inline]
     pub fn get_flags(&self) -> Result<i32, ErrorStack> {
-        let flags = unsafe {
-            cvt(ffi::RSA_meth_get_flags(self.as_ptr()))?
-        };
+        let flags = unsafe { cvt(ffi::RSA_meth_get_flags(self.as_ptr()))? };
         Ok(flags)
     }
 
@@ -75,9 +73,7 @@ impl RsaMethod {
     #[corresponds(RSA_meth_get0_app_data)]
     #[inline]
     pub fn get_app_data(&self) -> Result<*mut c_void, ErrorStack> {
-        let app_data: *mut c_void = unsafe {
-            ffi::RSA_meth_get0_app_data(self.as_ptr())
-        };
+        let app_data: *mut c_void = unsafe { ffi::RSA_meth_get0_app_data(self.as_ptr()) };
         Ok(app_data)
     }
 
@@ -92,7 +88,16 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_pub_enc)]
     #[inline]
-    pub fn set_pub_enc(&self, pub_enc: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_pub_enc(
+        &self,
+        pub_enc: extern "C" fn(
+            flen: c_int,
+            from: *const c_uchar,
+            to: *mut c_uchar,
+            rsa: *mut RSA,
+            padding: c_int,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_pub_enc(self.as_ptr(), pub_enc))?;
         }
@@ -101,7 +106,16 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_pub_dec)]
     #[inline]
-    pub fn set_pub_dec(&self, pub_dec: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_pub_dec(
+        &self,
+        pub_dec: extern "C" fn(
+            flen: c_int,
+            from: *const c_uchar,
+            to: *mut c_uchar,
+            rsa: *mut RSA,
+            padding: c_int,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_pub_dec(self.as_ptr(), pub_dec))?;
         }
@@ -110,7 +124,16 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_priv_enc)]
     #[inline]
-    pub fn set_priv_enc(&self, priv_enc: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_priv_enc(
+        &self,
+        priv_enc: extern "C" fn(
+            flen: c_int,
+            from: *const c_uchar,
+            to: *mut c_uchar,
+            rsa: *mut RSA,
+            padding: c_int,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_priv_enc(self.as_ptr(), priv_enc))?;
         }
@@ -119,7 +142,16 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_priv_dec)]
     #[inline]
-    pub fn set_priv_dec(&self, priv_dec: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_priv_dec(
+        &self,
+        priv_dec: extern "C" fn(
+            flen: c_int,
+            from: *const c_uchar,
+            to: *mut c_uchar,
+            rsa: *mut RSA,
+            padding: c_int,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_priv_dec(self.as_ptr(), priv_dec))?;
         }
@@ -128,7 +160,15 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_mod_exp)]
     #[inline]
-    pub fn set_mod_exp(&self, mod_exp: extern "C" fn(r0: *mut BIGNUM, i: *const BIGNUM, rsa: *mut RSA, ctx: *mut BN_CTX) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_mod_exp(
+        &self,
+        mod_exp: extern "C" fn(
+            r0: *mut BIGNUM,
+            i: *const BIGNUM,
+            rsa: *mut RSA,
+            ctx: *mut BN_CTX,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_mod_exp(self.as_ptr(), mod_exp))?;
         }
@@ -137,7 +177,17 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_bn_mod_exp)]
     #[inline]
-    pub fn set_bn_mod_exp(&self, bn_mod_exp: extern "C" fn(r: *mut BIGNUM, a: *const BIGNUM, p: *const BIGNUM, m: *const BIGNUM, ctx: *mut BN_CTX, m_ctx: *mut BN_MONT_CTX) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_bn_mod_exp(
+        &self,
+        bn_mod_exp: extern "C" fn(
+            r: *mut BIGNUM,
+            a: *const BIGNUM,
+            p: *const BIGNUM,
+            m: *const BIGNUM,
+            ctx: *mut BN_CTX,
+            m_ctx: *mut BN_MONT_CTX,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_bn_mod_exp(self.as_ptr(), bn_mod_exp))?;
         }
@@ -155,7 +205,10 @@ impl RsaMethod {
 
     #[corresponds(RSA_met_set_finish)]
     #[inline]
-    pub fn set_finish(&self, finish: extern "C" fn(rsa: *mut RSA) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_finish(
+        &self,
+        finish: extern "C" fn(rsa: *mut RSA) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_finish(self.as_ptr(), finish))?;
         }
@@ -164,7 +217,17 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_sign)]
     #[inline]
-    pub fn set_sign(&self, sign: extern "C" fn(_type: c_int, m: *const c_uchar, m_length: c_uint, sigret: *mut c_uchar, siglen: *mut c_uint, rsa: *const RSA) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_sign(
+        &self,
+        sign: extern "C" fn(
+            _type: c_int,
+            m: *const c_uchar,
+            m_length: c_uint,
+            sigret: *mut c_uchar,
+            siglen: *mut c_uint,
+            rsa: *const RSA,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_sign(self.as_ptr(), sign))?;
         }
@@ -173,7 +236,17 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_verify)]
     #[inline]
-    pub fn set_verify(&self, verify: extern "C" fn(dtype: c_int, m: *const c_uchar, m_length: c_uint, sigbuf: *const c_uchar, siglen: c_uint, rsa: *const RSA) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_verify(
+        &self,
+        verify: extern "C" fn(
+            dtype: c_int,
+            m: *const c_uchar,
+            m_length: c_uint,
+            sigbuf: *const c_uchar,
+            siglen: c_uint,
+            rsa: *const RSA,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_verify(self.as_ptr(), verify))?;
         }
@@ -182,7 +255,15 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_keygen)]
     #[inline]
-    pub fn set_keygen(&self, keygen: extern "C" fn(rsa: *mut RSA, bits: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_keygen(
+        &self,
+        keygen: extern "C" fn(
+            rsa: *mut RSA,
+            bits: c_int,
+            e: *mut BIGNUM,
+            cb: *mut BN_GENCB,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_keygen(self.as_ptr(), keygen))?;
         }
@@ -191,7 +272,16 @@ impl RsaMethod {
 
     #[corresponds(RSA_meth_set_multi_prime_keygen)]
     #[inline]
-    pub fn set_multi_prime_keygen(&self, keygen: extern "C" fn(rsa: *mut RSA, bits: c_int, primes: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int) -> Result<(), ErrorStack> {
+    pub fn set_multi_prime_keygen(
+        &self,
+        keygen: extern "C" fn(
+            rsa: *mut RSA,
+            bits: c_int,
+            primes: c_int,
+            e: *mut BIGNUM,
+            cb: *mut BN_GENCB,
+        ) -> c_int,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::RSA_meth_set_multi_prime_keygen(self.as_ptr(), keygen))?;
         }
@@ -272,63 +362,123 @@ mod test {
     }
 
     #[no_mangle]
-    extern fn test_pub_enc(_flen: c_int, _from: *const c_uchar, _to: *mut c_uchar, _rsa: *mut RSA, _padding: c_int) -> c_int {
+    extern "C" fn test_pub_enc(
+        _flen: c_int,
+        _from: *const c_uchar,
+        _to: *mut c_uchar,
+        _rsa: *mut RSA,
+        _padding: c_int,
+    ) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_pub_dec(_flen: c_int, _from: *const c_uchar, _to: *mut c_uchar, _rsa: *mut RSA, _padding: c_int) -> c_int {
+    extern "C" fn test_pub_dec(
+        _flen: c_int,
+        _from: *const c_uchar,
+        _to: *mut c_uchar,
+        _rsa: *mut RSA,
+        _padding: c_int,
+    ) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_priv_enc(_flen: c_int, _from: *const c_uchar, _to: *mut c_uchar, _rsa: *mut RSA, _padding: c_int) -> c_int {
+    extern "C" fn test_priv_enc(
+        _flen: c_int,
+        _from: *const c_uchar,
+        _to: *mut c_uchar,
+        _rsa: *mut RSA,
+        _padding: c_int,
+    ) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_priv_dec(_flen: c_int, _from: *const c_uchar, _to: *mut c_uchar, _rsa: *mut RSA, _padding: c_int) -> c_int {
+    extern "C" fn test_priv_dec(
+        _flen: c_int,
+        _from: *const c_uchar,
+        _to: *mut c_uchar,
+        _rsa: *mut RSA,
+        _padding: c_int,
+    ) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_mod_exp(_r0: *mut BIGNUM, _i: *const BIGNUM, _rsa: *mut RSA, _ctx: *mut BN_CTX) -> c_int {
+    extern "C" fn test_mod_exp(
+        _r0: *mut BIGNUM,
+        _i: *const BIGNUM,
+        _rsa: *mut RSA,
+        _ctx: *mut BN_CTX,
+    ) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_bn_mod_exp(_r: *mut BIGNUM, _a: *const BIGNUM, _p: *const BIGNUM, _m: *const BIGNUM, _ctx: *mut BN_CTX, _m_ctx: *mut BN_MONT_CTX) -> c_int {
+    extern "C" fn test_bn_mod_exp(
+        _r: *mut BIGNUM,
+        _a: *const BIGNUM,
+        _p: *const BIGNUM,
+        _m: *const BIGNUM,
+        _ctx: *mut BN_CTX,
+        _m_ctx: *mut BN_MONT_CTX,
+    ) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_init(_rsa: *mut RSA) -> c_int {
+    extern "C" fn test_init(_rsa: *mut RSA) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_finish(_rsa: *mut RSA) -> c_int {
+    extern "C" fn test_finish(_rsa: *mut RSA) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_sign(_type: c_int, _m: *const c_uchar, _m_length: c_uint, _sigret: *mut c_uchar, _siglen: *mut c_uint, _rsa: *const RSA) -> c_int {
+    extern "C" fn test_sign(
+        _type: c_int,
+        _m: *const c_uchar,
+        _m_length: c_uint,
+        _sigret: *mut c_uchar,
+        _siglen: *mut c_uint,
+        _rsa: *const RSA,
+    ) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_verify(_dtype: c_int, _m: *const c_uchar, _m_length: c_uint, _sigbuf: *const c_uchar, _siglen: c_uint, _rsa: *const RSA) -> c_int {
+    extern "C" fn test_verify(
+        _dtype: c_int,
+        _m: *const c_uchar,
+        _m_length: c_uint,
+        _sigbuf: *const c_uchar,
+        _siglen: c_uint,
+        _rsa: *const RSA,
+    ) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_keygen(_rsa: *mut RSA, _bits: c_int, _e: *mut BIGNUM, _cb: *mut BN_GENCB) -> c_int {
+    extern "C" fn test_keygen(
+        _rsa: *mut RSA,
+        _bits: c_int,
+        _e: *mut BIGNUM,
+        _cb: *mut BN_GENCB,
+    ) -> c_int {
         0
     }
 
     #[no_mangle]
-    extern fn test_multi_prime_keygen(_rsa: *mut RSA, _bits: c_int, _primes: c_int, _e: *mut BIGNUM, _cb: *mut BN_GENCB) -> c_int {
+    extern "C" fn test_multi_prime_keygen(
+        _rsa: *mut RSA,
+        _bits: c_int,
+        _primes: c_int,
+        _e: *mut BIGNUM,
+        _cb: *mut BN_GENCB,
+    ) -> c_int {
         0
     }
 }
-

--- a/openssl/src/rsa_meth.rs
+++ b/openssl/src/rsa_meth.rs
@@ -1,0 +1,334 @@
+use crate::error::ErrorStack;
+use crate::{cvt, cvt_p, cvt_p_const};
+use openssl_macros::corresponds;
+use std::ffi::{c_void, c_int, c_uint, c_uchar, CString, CStr};
+use ffi::{BIGNUM, BN_CTX, BN_MONT_CTX, BN_GENCB, RSA};
+
+struct RsaMethod(*mut ffi::RSA_METHOD);
+
+impl RsaMethod {
+    /// Creates a new `RSA_METHOD` structure.
+    #[corresponds(RSA_meth_new)]
+    #[inline]
+    pub fn new(name: &str, flags: i32) -> Result<Self, ErrorStack> {
+        let name = CString::new(name).unwrap();
+        unsafe {
+            let ptr = cvt_p(ffi::RSA_meth_new(name.as_ptr(), flags))?;
+            Ok(RsaMethod::from_ptr(ptr))
+        }
+    }
+
+    pub fn as_ptr(&self) -> *mut ffi::RSA_METHOD {
+        self.0
+    }
+
+    pub fn from_ptr(ptr: *mut ffi::RSA_METHOD) -> RsaMethod {
+        RsaMethod(ptr)
+    }
+
+    #[corresponds(RSA_meth_dup)]
+    #[inline]
+    fn duplicate(&self) -> Result<Self, ErrorStack> {
+        unsafe {
+            let ptr = cvt_p(ffi::RSA_meth_dup(self.as_ptr()))?;
+            Ok(RsaMethod::from_ptr(ptr))
+        }
+    }
+
+    #[corresponds(RSA_meth_get0_name)]
+    #[inline]
+    pub fn get_name(&self) -> Result<String, ErrorStack> {
+        unsafe {
+            let name: *const i8 = cvt_p_const(ffi::RSA_meth_get0_name(self.as_ptr()))?;
+            Ok(CStr::from_ptr(name).to_str().unwrap().to_owned())
+        }
+    }
+
+    #[corresponds(RSA_meth_set1_name)]
+    #[inline]
+    pub fn set_name(&self, name: &str) -> Result<(), ErrorStack> {
+        let name = CString::new(name).unwrap();
+        unsafe {
+            cvt(ffi::RSA_meth_set1_name(self.as_ptr(), name.as_ptr()))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_get_flags)]
+    #[inline]
+    pub fn get_flags(&self) -> Result<i32, ErrorStack> {
+        let flags = unsafe {
+            cvt(ffi::RSA_meth_get_flags(self.as_ptr()))?
+        };
+        Ok(flags)
+    }
+
+    #[corresponds(RSA_meth_set_flags)]
+    #[inline]
+    pub fn set_flags(&self, flags: i32) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_flags(self.as_ptr(), flags))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_get0_app_data)]
+    #[inline]
+    pub fn get_app_data(&self) -> Result<*mut c_void, ErrorStack> {
+        let app_data: *mut c_void = unsafe {
+            ffi::RSA_meth_get0_app_data(self.as_ptr())
+        };
+        Ok(app_data)
+    }
+
+    #[corresponds(RSA_meth_set0_app_data)]
+    #[inline]
+    pub fn set_app_data(&self, app_data: *mut c_void) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set0_app_data(self.as_ptr(), app_data))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_pub_enc)]
+    #[inline]
+    pub fn set_pub_enc(&self, pub_enc: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_pub_enc(self.as_ptr(), pub_enc))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_pub_dec)]
+    #[inline]
+    pub fn set_pub_dec(&self, pub_dec: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_pub_dec(self.as_ptr(), pub_dec))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_priv_enc)]
+    #[inline]
+    pub fn set_priv_enc(&self, priv_enc: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_priv_enc(self.as_ptr(), priv_enc))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_priv_dec)]
+    #[inline]
+    pub fn set_priv_dec(&self, priv_dec: extern "C" fn(flen: c_int, from: *const c_uchar, to: *mut c_uchar, rsa: *mut RSA, padding: c_int) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_priv_dec(self.as_ptr(), priv_dec))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_mod_exp)]
+    #[inline]
+    pub fn set_mod_exp(&self, mod_exp: extern "C" fn(r0: *mut BIGNUM, i: *const BIGNUM, rsa: *mut RSA, ctx: *mut BN_CTX) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_mod_exp(self.as_ptr(), mod_exp))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_bn_mod_exp)]
+    #[inline]
+    pub fn set_bn_mod_exp(&self, bn_mod_exp: extern "C" fn(r: *mut BIGNUM, a: *const BIGNUM, p: *const BIGNUM, m: *const BIGNUM, ctx: *mut BN_CTX, m_ctx: *mut BN_MONT_CTX) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_bn_mod_exp(self.as_ptr(), bn_mod_exp))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_met_set_init)]
+    #[inline]
+    pub fn set_init(&self, init: extern "C" fn(rsa: *mut RSA) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_init(self.as_ptr(), init))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_met_set_finish)]
+    #[inline]
+    pub fn set_finish(&self, finish: extern "C" fn(rsa: *mut RSA) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_finish(self.as_ptr(), finish))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_sign)]
+    #[inline]
+    pub fn set_sign(&self, sign: extern "C" fn(_type: c_int, m: *const c_uchar, m_length: c_uint, sigret: *mut c_uchar, siglen: *mut c_uint, rsa: *const RSA) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_sign(self.as_ptr(), sign))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_verify)]
+    #[inline]
+    pub fn set_verify(&self, verify: extern "C" fn(dtype: c_int, m: *const c_uchar, m_length: c_uint, sigbuf: *const c_uchar, siglen: c_uint, rsa: *const RSA) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_verify(self.as_ptr(), verify))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_keygen)]
+    #[inline]
+    pub fn set_keygen(&self, keygen: extern "C" fn(rsa: *mut RSA, bits: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_keygen(self.as_ptr(), keygen))?;
+        }
+        Ok(())
+    }
+
+    #[corresponds(RSA_meth_set_multi_prime_keygen)]
+    #[inline]
+    pub fn set_multi_prime_keygen(&self, keygen: extern "C" fn(rsa: *mut RSA, bits: c_int, primes: c_int, e: *mut BIGNUM, cb: *mut BN_GENCB) -> c_int) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::RSA_meth_set_multi_prime_keygen(self.as_ptr(), keygen))?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RsaMethod {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::RSA_meth_free(self.as_ptr());
+        }
+    }
+}
+
+impl Clone for RsaMethod {
+    fn clone(&self) -> Self {
+        self.duplicate().unwrap()
+    }
+}
+
+mod test {
+    use super::*;
+
+    #[cfg(test)]
+    fn rsa_method_test() {
+        // Because there isn't a great way to test all of this RSA_METHOD functionality, what we
+        // do here is setup function pointers in this test module, and we call all of the
+        // RSA_METHOD functions as implemented above, simply to assert that everything
+        // (getters/setters) work as expected.
+
+        let name: &str = "TESTING RSA METHOD";
+
+        let mut rsa_method = RsaMethod::new(name, 0);
+        assert!(rsa_method.is_ok());
+        let mut rsa_method = rsa_method.unwrap();
+
+        rsa_method.clone();
+
+        let expected_name = rsa_method.get_name().unwrap();
+        assert_eq!(name, expected_name);
+
+        {
+            let new_name: &str = "NEW TESTING NAME";
+            rsa_method.set_name(new_name).unwrap();
+            let actual_new_name = rsa_method.get_name().unwrap();
+            assert_eq!(new_name, actual_new_name);
+        }
+
+        {
+            let new_flags: i32 = 0x00ff;
+            rsa_method.set_flags(new_flags).unwrap();
+            let actual_new_flags = rsa_method.get_flags().unwrap();
+            assert_eq!(new_flags, actual_new_flags);
+        }
+
+        {
+            let some_app_data: *mut c_void = 0x0900 as *mut c_void;
+            rsa_method.set_app_data(some_app_data).unwrap();
+            let actual_app_data = rsa_method.get_app_data().unwrap();
+            assert_eq!(some_app_data, actual_app_data);
+        }
+
+        // test all of the setters - the dummy functions for here are set down below
+
+        rsa_method.set_pub_enc(test_pub_enc).unwrap();
+        rsa_method.set_pub_dec(test_pub_dec).unwrap();
+        rsa_method.set_priv_enc(test_priv_enc);
+        rsa_method.set_priv_dec(test_priv_dec);
+        rsa_method.set_mod_exp(test_mod_exp);
+        rsa_method.set_bn_mod_exp(test_bn_mod_exp);
+        rsa_method.set_init(test_init);
+        rsa_method.set_finish(test_finish);
+        rsa_method.set_sign(test_sign);
+        rsa_method.set_verify(test_verify);
+        rsa_method.set_keygen(test_keygen);
+        rsa_method.set_multi_prime_keygen(test_multi_prime_keygen);
+    }
+
+    #[no_mangle]
+    extern fn test_pub_enc(_flen: c_int, _from: *const c_uchar, _to: *mut c_uchar, _rsa: *mut RSA, _padding: c_int) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_pub_dec(_flen: c_int, _from: *const c_uchar, _to: *mut c_uchar, _rsa: *mut RSA, _padding: c_int) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_priv_enc(_flen: c_int, _from: *const c_uchar, _to: *mut c_uchar, _rsa: *mut RSA, _padding: c_int) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_priv_dec(_flen: c_int, _from: *const c_uchar, _to: *mut c_uchar, _rsa: *mut RSA, _padding: c_int) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_mod_exp(_r0: *mut BIGNUM, _i: *const BIGNUM, _rsa: *mut RSA, _ctx: *mut BN_CTX) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_bn_mod_exp(_r: *mut BIGNUM, _a: *const BIGNUM, _p: *const BIGNUM, _m: *const BIGNUM, _ctx: *mut BN_CTX, _m_ctx: *mut BN_MONT_CTX) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_init(_rsa: *mut RSA) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_finish(_rsa: *mut RSA) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_sign(_type: c_int, _m: *const c_uchar, _m_length: c_uint, _sigret: *mut c_uchar, _siglen: *mut c_uint, _rsa: *const RSA) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_verify(_dtype: c_int, _m: *const c_uchar, _m_length: c_uint, _sigbuf: *const c_uchar, _siglen: c_uint, _rsa: *const RSA) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_keygen(_rsa: *mut RSA, _bits: c_int, _e: *mut BIGNUM, _cb: *mut BN_GENCB) -> c_int {
+        0
+    }
+
+    #[no_mangle]
+    extern fn test_multi_prime_keygen(_rsa: *mut RSA, _bits: c_int, _primes: c_int, _e: *mut BIGNUM, _cb: *mut BN_GENCB) -> c_int {
+        0
+    }
+}
+


### PR DESCRIPTION
## Changes

- Added `RSA_METHOD` bindings for `ossl110`
- Added a simple test to exercise all of the Rust->FFI code (currently does nothing but call all of the getters/setters at least once)
- I mostly followed the documentation here: https://www.openssl.org/docs/man1.1.1/man3/RSA_meth_new.html

While the previous engine pr (#2194) is more than enough for me and my own purposes, I had a really hard time getting it through CI, I had a hard time creating a PR from the `ENGINE` bindings first, and keeping the scope relatively small. Now, I'm going to try to go about it from the other direction :)

There's also the question of testing this thoroughly. I think the only way that this could be tested reasonably is if I create a fake testing only engine, and have it assert that it gets called at various points during the engine lifecycle. @sfackler to have some input on testing, now that I hopefully have a PR with a smaller scope.