### PR TITLE
Add helper to return &mut SslRef from stream

### DIFF
--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -3991,6 +3991,11 @@ impl<S> SslStream<S> {
     pub fn ssl(&self) -> &SslRef {
         &self.ssl
     }
+
+    /// Returns a mutable reference to the `Ssl` object associated with this stream.
+    pub fn ssl_mut(&mut self) -> &mut SslRef {
+        &mut self.ssl
+    }
 }
 
 impl<S: Read + Write> Read for SslStream<S> {


### PR DESCRIPTION
Currently there is no way to retrieve a mutable reference to the underlying `SslRef` given some `SslStream`. This PR adds an `ssl_mut` method to do that.