### PR TITLE
Fix building with latest BoringSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
               ;;
             "i686-unknown-linux-gnu")
               OS_COMPILER=linux-elf
-              OS_FLAGS=-m32 -msse2
+              OS_FLAGS="-m32 -msse2"
               ;;
             "arm-unknown-linux-gnueabihf")
               OS_COMPILER=linux-armv4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
               ;;
             "i686-unknown-linux-gnu")
               OS_COMPILER=linux-elf
-              OS_FLAGS=-m32
+              OS_FLAGS=-m32 -msse2
               ;;
             "arm-unknown-linux-gnueabihf")
               OS_COMPILER=linux-armv4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
             - false
           library:
             - name: boringssl
-              version: e6489902b7fb692875341b8ab5e57f0515f47bc1
+              version: 2db0eb3f96a5756298dcd7f9319e56a98585bd10
             - name: openssl
               version: vendored
             - name: openssl

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -944,7 +944,7 @@ fn test_verify_param_set_depth_fails_verification() {
     store_bldr.add_cert(ca).unwrap();
     let mut verify_params = X509VerifyParam::new().unwrap();
     // OpenSSL 1.1.0+ considers the root certificate to not be part of the chain, while 1.0.2 and LibreSSL do
-    let expected_depth = if cfg!(any(ossl110)) { 0 } else { 1 };
+    let expected_depth = if cfg!(any(ossl110, boringssl)) { 0 } else { 1 };
     verify_params.set_depth(expected_depth);
     store_bldr.set_param(&verify_params).unwrap();
     let store = store_bldr.build();


### PR DESCRIPTION
This required two fixes. First, test_verify_param_set_depth_fails_verification needed to be updated. The history here is that OpenSSL 1.1.0 made a backwards-incompatible change to the semantics of the depth limit. Ideally, rust-openssl would have documented the semantics of its own APIs and normalized the behavior, but it instead silently picked up the semantics change.

BoringSSL aligned with OpenSSL's new behavior in
b251d813ec615e7ef01d82073f94960eb13b1e0a, but since then rust-openssl has codified the old behavior in tests. We need to update some cfgs to reflect this.

Second, BoringSSL requires a C++ runtime (we have required a C++ compiler for a long time). This reveals a problem in Cargo's dependency management strategy for externally-built static libraries. Work around this by making some guesses about what library to link in, but see the comment for why this is unsafe. This unsafety appears to be inherent to Cargo and the choice of having Cargo drive cross-language builds, rather than providing hooks for an integrated build system.