### PR TITLE
Use the newer names for STACK_OF(T) functions with BoringSSL

### DIFF
--- a/openssl/src/stack.rs
+++ b/openssl/src/stack.rs
@@ -14,7 +14,7 @@ use crate::util::ForeignTypeExt;
 use crate::{cvt, cvt_p, LenType};
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, boringssl))] {
         use ffi::{
             OPENSSL_sk_pop, OPENSSL_sk_free, OPENSSL_sk_num, OPENSSL_sk_value, OPENSSL_STACK,
             OPENSSL_sk_new_null, OPENSSL_sk_push,


### PR DESCRIPTION
This is yet another symptom of https://github.com/sfackler/rust-openssl/issues/1944.

Ideally rust-openssl would use the type-safe wrappers, which are the actual public APIs. Right now, rust-openssl's STACK_OF(T) handling is a safety regression from C. This PR doesn't address the safety issue, only works around the BoringSSL porting issue.