### PR TITLE
Add boringssl keylog callback support

### DIFF
--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -11,7 +11,7 @@ use std::ffi::CStr;
 use std::mem;
 use std::ptr;
 use std::slice;
-#[cfg(ossl111)]
+#[cfg(any(ossl111, boringssl))]
 use std::str;
 use std::sync::Arc;
 
@@ -28,7 +28,7 @@ use crate::ssl::{
 };
 #[cfg(ossl111)]
 use crate::ssl::{ClientHelloResponse, ExtensionContext};
-#[cfg(ossl111)]
+#[cfg(any(ossl111, boringssl))]
 use crate::util::ForeignTypeRefExt;
 #[cfg(ossl111)]
 use crate::x509::X509Ref;
@@ -429,7 +429,7 @@ where
     }
 }
 
-#[cfg(ossl111)]
+#[cfg(any(ossl111, boringssl))]
 pub unsafe extern "C" fn raw_keylog<F>(ssl: *const ffi::SSL, line: *const c_char)
 where
     F: Fn(&SslRef, &str) + 'static + Sync + Send,

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1470,7 +1470,7 @@ impl SslContextBuilder {
     ///
     /// Requires OpenSSL 1.1.1 or newer.
     #[corresponds(SSL_CTX_set_keylog_callback)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, boringssl))]
     pub fn set_keylog_callback<F>(&mut self, callback: F)
     where
         F: Fn(&SslRef, &str) + 'static + Sync + Send,


### PR DESCRIPTION
Boringssl supports using the keylog callback. These changes allow it to happen.