### PR TITLE
Add some OpenSSL 3 QUIC raw bindings

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -71,6 +71,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
     } else {
         let openssl_version = openssl_version.unwrap();
 
+        if openssl_version >= 0x3_03_00_00_0 {
+            cfgs.push("ossl330");
+        }
         if openssl_version >= 0x3_02_00_00_0 {
             cfgs.push("ossl320");
         }

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -119,6 +119,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(ossl300)");
     println!("cargo:rustc-check-cfg=cfg(ossl310)");
     println!("cargo:rustc-check-cfg=cfg(ossl320)");
+    println!("cargo:rustc-check-cfg=cfg(ossl330)");
 
     check_ssl_kind();
 

--- a/openssl-sys/build/run_bindgen.rs
+++ b/openssl-sys/build/run_bindgen.rs
@@ -56,6 +56,10 @@ const INCLUDES: &str = "
 #include <openssl/provider.h>
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x30200000
+#include <openssl/quic.h>
+#endif
+
 #if defined(LIBRESSL_VERSION_NUMBER) || defined(OPENSSL_IS_BORINGSSL)
 #include <openssl/poly1305.h>
 #endif
@@ -70,8 +74,9 @@ pub fn run(include_dirs: &[PathBuf]) {
         .rust_target(RustTarget::Stable_1_47)
         .ctypes_prefix("::libc")
         .raw_line("use libc::*;")
+        .raw_line("#[cfg(windows)] use std::os::windows::raw::HANDLE;")
         .raw_line("type evp_pkey_st = EVP_PKEY;")
-        .allowlist_file(".*/openssl/[^/]+\\.h")
+        .allowlist_file(".*[/\\\\]openssl/[^/\\\\]+\\.h")
         .allowlist_recursively(false)
         // libc is missing pthread_once_t on macOS
         .blocklist_type("CRYPTO_ONCE")
@@ -85,6 +90,8 @@ pub fn run(include_dirs: &[PathBuf]) {
         .blocklist_type("OSSL_FUNC_core_vset_error_fn")
         .blocklist_type("OSSL_FUNC_BIO_vprintf_fn")
         .blocklist_type("OSSL_FUNC_BIO_vsnprintf_fn")
+        // struct hostent * does not exist on Windows
+        .blocklist_function("BIO_gethostbyname")
         // Maintain compatibility for existing enum definitions
         .rustified_enum("point_conversion_form_t")
         // Maintain compatibility for pre-union definitions

--- a/openssl-sys/src/bio.rs
+++ b/openssl-sys/src/bio.rs
@@ -89,7 +89,7 @@ cfg_if! {
             BIO_ctrl(bio, BIO_CTRL_DGRAM_GET_NO_TRUNC, 0, ptr::null_mut()) as c_int
         }
         pub unsafe fn BIO_dgram_set_no_trunc(bio: *mut BIO, enable: c_int) -> c_int {
-            BIO_ctrl(bio, BIO_CTRL_DGRAM_SET_NO_TRUNC, enable, ptr::null_mut()) as c_int
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_SET_NO_TRUNC, enable as c_long, ptr::null_mut()) as c_int
         }
         pub unsafe fn BIO_dgram_get_cap(bio: *mut BIO) -> u32 {
             BIO_ctrl(bio, BIO_CTRL_DGRAM_GET_CAPS, 0, ptr::null_mut()) as u32

--- a/openssl-sys/src/bio.rs
+++ b/openssl-sys/src/bio.rs
@@ -70,3 +70,47 @@ extern "C" {
         destroy: unsafe extern "C" fn(*mut BIO) -> c_int,
     ) -> c_int;
 }
+
+cfg_if! {
+    if #[cfg(ossl320)] {
+        use std::ptr;
+
+        pub const BIO_CTRL_DGRAM_GET_MTU: c_int = 41;
+        pub const BIO_CTRL_DGRAM_SET_MTU: c_int = 42;
+        pub const BIO_CTRL_DGRAM_GET_LOCAL_ADDR_CAP: c_int = 82;
+        pub const BIO_CTRL_DGRAM_GET_LOCAL_ADDR_ENABLE: c_int = 83;
+        pub const BIO_CTRL_DGRAM_SET_LOCAL_ADDR_ENABLE: c_int = 84;
+        pub const BIO_CTRL_DGRAM_GET_CAPS: c_int = 86;
+        pub const BIO_CTRL_DGRAM_SET_CAPS: c_int = 87;
+        pub const BIO_CTRL_DGRAM_GET_NO_TRUNC: c_int = 88;
+        pub const BIO_CTRL_DGRAM_SET_NO_TRUNC: c_int = 89;
+
+        pub unsafe fn BIO_dgram_get_no_trunc(bio: *mut BIO) -> c_int {
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_GET_NO_TRUNC, 0, ptr::null_mut()) as c_int
+        }
+        pub unsafe fn BIO_dgram_set_no_trunc(bio: *mut BIO, enable: c_int) -> c_int {
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_SET_NO_TRUNC, enable, ptr::null_mut()) as c_int
+        }
+        pub unsafe fn BIO_dgram_get_cap(bio: *mut BIO) -> u32 {
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_GET_CAPS, 0, ptr::null_mut()) as u32
+        }
+        pub unsafe fn BIO_dgram_set_cap(bio: *mut BIO, cap: u32) -> c_int {
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_SET_CAPS, cap as c_long, ptr::null_mut()) as c_int
+        }
+        pub unsafe fn BIO_dgram_get_local_addr_cap(bio: *mut BIO) -> c_int {
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_GET_LOCAL_ADDR_CAP, 0, ptr::null_mut()) as c_int
+        }
+        pub unsafe fn BIO_dgram_get_local_addr_enable(bio: *mut BIO, enable: *mut c_int) -> c_int {
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_GET_LOCAL_ADDR_ENABLE, 0, enable as *mut c_void) as c_int
+        }
+        pub unsafe fn BIO_dgram_set_local_addr_enable(bio: *mut BIO, enable: c_int) -> c_int {
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_SET_LOCAL_ADDR_ENABLE, enable as c_long, ptr::null_mut()) as c_int
+        }
+        pub unsafe fn BIO_dgram_get_mtu(bio: *mut BIO) -> c_uint {
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_GET_MTU, 0, ptr::null_mut()) as c_uint
+        }
+        pub unsafe fn BIO_dgram_set_mtu(bio: *mut BIO, mtu: c_uint) -> c_int {
+            BIO_ctrl(bio, BIO_CTRL_DGRAM_SET_MTU, mtu as c_long, ptr::null_mut()) as c_int
+        }
+    }
+}

--- a/openssl-sys/src/err.rs
+++ b/openssl-sys/src/err.rs
@@ -9,8 +9,8 @@ pub const ERR_LIB_ASN1: c_int = 13;
 
 cfg_if! {
     if #[cfg(ossl300)] {
-        pub const ERR_SYSTEM_FLAG: c_ulong = c_int::max_value() as c_ulong + 1;
-        pub const ERR_SYSTEM_MASK: c_ulong = c_int::max_value() as c_ulong;
+        pub const ERR_SYSTEM_FLAG: c_ulong = c_int::MAX as c_ulong + 1;
+        pub const ERR_SYSTEM_MASK: c_ulong = c_int::MAX as c_ulong;
 
         pub const ERR_LIB_OFFSET: c_ulong = 23;
         pub const ERR_LIB_MASK: c_ulong = 0xff;

--- a/openssl-sys/src/handwritten/bio.rs
+++ b/openssl-sys/src/handwritten/bio.rs
@@ -106,3 +106,60 @@ extern "C" {
         destroy: Option<unsafe extern "C" fn(*mut BIO) -> c_int>,
     ) -> c_int;
 }
+
+#[cfg(ossl320)]
+extern "C" {
+    pub fn BIO_meth_set_sendmmsg(
+        biom: *mut BIO_METHOD,
+        f: Option<
+            unsafe extern "C" fn(
+                arg1: *mut BIO,
+                arg2: *mut BIO_MSG,
+                arg3: usize,
+                arg4: usize,
+                arg5: u64,
+                arg6: *mut usize,
+            ) -> c_int,
+        >,
+    ) -> c_int;
+    pub fn BIO_meth_set_recvmmsg(
+        biom: *mut BIO_METHOD,
+        f: Option<
+            unsafe extern "C" fn(
+                arg1: *mut BIO,
+                arg2: *mut BIO_MSG,
+                arg3: usize,
+                arg4: usize,
+                arg5: u64,
+                arg6: *mut usize,
+            ) -> c_int,
+        >,
+    ) -> c_int;
+    pub fn BIO_new_bio_dgram_pair(
+        bio1: *mut *mut BIO,
+        writebuf1: usize,
+        bio2: *mut *mut BIO,
+        writebuf2: usize,
+    ) -> c_int;
+    pub fn BIO_s_dgram_pair() -> *const BIO_METHOD;
+    pub fn BIO_s_datagram() -> *const BIO_METHOD;
+    pub fn BIO_get_rpoll_descriptor(b: *mut BIO, desc: *mut BIO_POLL_DESCRIPTOR) -> c_int;
+    pub fn BIO_get_wpoll_descriptor(b: *mut BIO, desc: *mut BIO_POLL_DESCRIPTOR) -> c_int;
+    pub fn BIO_sendmmsg(
+        b: *mut BIO,
+        msg: *mut BIO_MSG,
+        stride: usize,
+        num_msg: usize,
+        flags: u64,
+        msgs_processed: *mut usize,
+    ) -> c_int;
+    pub fn BIO_recvmmsg(
+        b: *mut BIO,
+        msg: *mut BIO_MSG,
+        stride: usize,
+        num_msg: usize,
+        flags: u64,
+        msgs_processed: *mut usize,
+    ) -> c_int;
+    pub fn BIO_err_is_non_fatal(errcode: c_uint) -> c_int;
+}

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -951,3 +951,59 @@ extern "C" {
     #[cfg(any(ossl110, libressl360))]
     pub fn SSL_get_security_level(s: *const SSL) -> c_int;
 }
+
+#[cfg(ossl320)]
+extern "C" {
+    pub fn OSSL_QUIC_client_method() -> *const SSL_METHOD;
+    pub fn OSSL_QUIC_client_thread_method() -> *const SSL_METHOD;
+    pub fn SSL_get_event_timeout(s: *mut SSL, tv: *mut timeval, is_infinite: *mut c_int) -> c_int;
+    pub fn SSL_handle_events(s: *mut SSL) -> c_int;
+    pub fn SSL_get_blocking_mode(s: *mut SSL) -> c_int;
+    pub fn SSL_set_blocking_mode(s: *mut SSL, blocking: c_int) -> c_int;
+    pub fn SSL_get_rpoll_descriptor(s: *mut SSL, desc: *mut BIO_POLL_DESCRIPTOR) -> c_int;
+    pub fn SSL_get_wpoll_descriptor(s: *mut SSL, desc: *mut BIO_POLL_DESCRIPTOR) -> c_int;
+    pub fn SSL_net_read_desired(s: *mut SSL) -> c_int;
+    pub fn SSL_net_write_desired(s: *mut SSL) -> c_int;
+    pub fn SSL_set1_initial_peer_addr(s: *mut SSL, peer_addr: *const BIO_ADDR) -> c_int;
+    pub fn SSL_shutdown_ex(
+        ssl: *mut SSL,
+        flags: u64,
+        args: *const SSL_SHUTDOWN_EX_ARGS,
+        args_len: usize,
+    ) -> c_int;
+    pub fn SSL_stream_conclude(ssl: *mut SSL, flags: u64) -> c_int;
+    pub fn SSL_stream_reset(
+        ssl: *mut SSL,
+        args: *const SSL_STREAM_RESET_ARGS,
+        args_len: usize,
+    ) -> c_int;
+    pub fn SSL_get_stream_read_state(ssl: *mut SSL) -> c_int;
+    pub fn SSL_get_stream_write_state(ssl: *mut SSL) -> c_int;
+    pub fn SSL_get_conn_close_info(
+        ssl: *mut SSL,
+        info: *mut SSL_CONN_CLOSE_INFO,
+        info_len: usize,
+    ) -> c_int;
+    pub fn SSL_get0_connection(s: *mut SSL) -> *mut SSL;
+    pub fn SSL_is_connection(s: *mut SSL) -> c_int;
+    pub fn SSL_get_stream_type(s: *mut SSL) -> c_int;
+    pub fn SSL_get_stream_id(s: *mut SSL) -> u64;
+    pub fn SSL_new_stream(s: *mut SSL, flags: u64) -> *mut SSL;
+    pub fn SSL_accept_stream(s: *mut SSL, flags: u64) -> *mut SSL;
+    pub fn SSL_set_incoming_stream_policy(s: *mut SSL, policy: c_int, aec: u64) -> c_int;
+    pub fn SSL_get_accept_stream_queue_len(s: *mut SSL) -> usize;
+    pub fn SSL_set_default_stream_mode(s: *mut SSL, mode: u32) -> c_int;
+}
+
+#[cfg(ossl330)]
+extern "C" {
+    pub fn SSL_write_ex2(
+        s: *mut SSL,
+        buf: *const c_void,
+        num: usize,
+        flags: u64,
+        written: *mut usize,
+    ) -> c_int;
+    pub fn SSL_get_value_uint(s: *mut SSL, class_: u32, id: u32, v: *mut u64) -> c_int;
+    pub fn SSL_set_value_uint(s: *mut SSL, class_: u32, id: u32, v: u64) -> c_int;
+}

--- a/openssl-sys/src/handwritten/types.rs
+++ b/openssl-sys/src/handwritten/types.rs
@@ -53,6 +53,20 @@ cfg_if! {
     }
 }
 cfg_if! {
+    if #[cfg(ossl320)] {
+        pub enum BIO_ADDR {}
+        pub enum BIO_POLL_DESCRIPTOR {}
+        #[repr(C)]
+        pub struct BIO_MSG {
+            pub data: *mut c_void,
+            pub data_len: usize,
+            pub peer: *mut BIO_ADDR,
+            pub local: *mut BIO_ADDR,
+            pub flags: u64,
+        }
+    }
+}
+cfg_if! {
     if #[cfg(any(ossl110, libressl350))] {
         pub enum BIGNUM {}
     } else {
@@ -1029,6 +1043,27 @@ cfg_if! {
             info: *mut c_void,
             stringth: c_int,
             srp_Mask: c_ulong,
+        }
+    }
+}
+cfg_if! {
+    if #[cfg(ossl320)] {
+        #[repr(C)]
+        pub struct SSL_CONN_CLOSE_INFO {
+            pub error_code: u64,
+            pub frame_type: u64,
+            pub reason: *const ::libc::c_char,
+            pub reason_len: usize,
+            pub flags: u32,
+        }
+        #[repr(C)]
+        pub struct SSL_SHUTDOWN_EX_ARGS {
+            pub quic_error_code: u64,
+            pub quic_reason: *const c_char,
+        }
+        #[repr(C)]
+        pub struct SSL_STREAM_RESET_ARGS {
+            pub quic_error_code: u64,
         }
     }
 }

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -644,3 +644,73 @@ pub unsafe fn SSL_session_reused(ssl: *mut SSL) -> c_int {
 pub const OPENSSL_INIT_LOAD_SSL_STRINGS: u64 = 0x00200000;
 #[cfg(ossl111b)]
 pub const OPENSSL_INIT_NO_ATEXIT: u64 = 0x00080000;
+
+cfg_if! {
+    if #[cfg(ossl330)] {
+        pub const SSL_VALUE_CLASS_GENERIC: c_uint = 0;
+        pub const SSL_VALUE_CLASS_FEATURE_REQUEST: c_uint = 1;
+        pub const SSL_VALUE_CLASS_FEATURE_PEER_REQUEST: c_uint = 2;
+        pub const SSL_VALUE_CLASS_FEATURE_NEGOTIATED: c_uint = 3;
+
+        pub const SSL_VALUE_NONE: c_uint = 0;
+        pub const SSL_VALUE_QUIC_STREAM_BIDI_LOCAL_AVAIL: c_uint = 1;
+        pub const SSL_VALUE_QUIC_STREAM_BIDI_REMOTE_AVAIL: c_uint = 2;
+        pub const SSL_VALUE_QUIC_STREAM_UNI_LOCAL_AVAIL: c_uint = 3;
+        pub const SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL: c_uint = 4;
+        pub const SSL_VALUE_QUIC_IDLE_TIMEOUT: c_uint = 5;
+        pub const SSL_VALUE_EVENT_HANDLING_MODE: c_uint = 6;
+        pub const SSL_VALUE_STREAM_WRITE_BUF_SIZE: c_uint = 7;
+        pub const SSL_VALUE_STREAM_WRITE_BUF_USED: c_uint = 8;
+        pub const SSL_VALUE_STREAM_WRITE_BUF_AVAIL: c_uint = 9;
+
+        pub const SSL_VALUE_EVENT_HANDLING_MODE_INHERIT: c_uint = 0;
+        pub const SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT: c_uint = 1;
+        pub const SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT: c_uint = 2;
+
+        pub unsafe fn SSL_get_generic_value_uint(ssl: *mut SSL, id: u32, value: *mut u64) -> c_int {
+            SSL_get_value_uint(ssl, SSL_VALUE_CLASS_GENERIC, id, value)
+        }
+        pub unsafe fn SSL_set_generic_value_uint(ssl: *mut SSL, id: u32, value: u64) -> c_int {
+            SSL_set_value_uint(ssl, SSL_VALUE_CLASS_GENERIC, id, value)
+        }
+        pub unsafe fn SSL_get_feature_request_uint(ssl: *mut SSL, id: u32, value: *mut u64) -> c_int {
+            SSL_get_value_uint(ssl, SSL_VALUE_CLASS_FEATURE_REQUEST, id, value)
+        }
+        pub unsafe fn SSL_set_feature_request_uint(ssl: *mut SSL, id: u32, value: u64) -> c_int {
+            SSL_set_value_uint(ssl, SSL_VALUE_CLASS_FEATURE_REQUEST, id, value)
+        }
+        pub unsafe fn SSL_get_feature_peer_request_uint(ssl: *mut SSL, id: u32, value: *mut u64) -> c_int {
+            SSL_get_value_uint(ssl, SSL_VALUE_CLASS_FEATURE_PEER_REQUEST, id, value)
+        }
+        pub unsafe fn SSL_get_feature_negotiated_uint(ssl: *mut SSL, id: u32, value: *mut u64) -> c_int {
+            SSL_get_value_uint(ssl, SSL_VALUE_CLASS_FEATURE_NEGOTIATED, id, value)
+        }
+        pub unsafe fn SSL_get_quic_stream_bidi_local_avail(ssl: *mut SSL, value: *mut u64) -> c_int {
+            SSL_get_generic_value_uint(ssl, SSL_VALUE_QUIC_STREAM_BIDI_LOCAL_AVAIL, value)
+        }
+        pub unsafe fn SSL_get_quic_stream_bidi_remote_avail(ssl: *mut SSL, value: *mut u64) -> c_int {
+            SSL_get_generic_value_uint(ssl, SSL_VALUE_QUIC_STREAM_BIDI_REMOTE_AVAIL, value)
+        }
+        pub unsafe fn SSL_get_quic_stream_uni_local_avail(ssl: *mut SSL, value: *mut u64) -> c_int {
+            SSL_get_generic_value_uint(ssl, SSL_VALUE_QUIC_STREAM_UNI_LOCAL_AVAIL, value)
+        }
+        pub unsafe fn SSL_get_quic_stream_uni_remote_avail(ssl: *mut SSL, value: *mut u64) -> c_int {
+            SSL_get_generic_value_uint(ssl, SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL, value)
+        }
+        pub unsafe fn SSL_get_event_handling_mode(ssl: *mut SSL, value: *mut u64) -> c_int {
+            SSL_get_generic_value_uint(ssl, SSL_VALUE_EVENT_HANDLING_MODE, value)
+        }
+        pub unsafe fn SSL_set_event_handling_mode(ssl: *mut SSL, value: u64) -> c_int {
+            SSL_set_generic_value_uint(ssl, SSL_VALUE_EVENT_HANDLING_MODE, value)
+        }
+        pub unsafe fn SSL_get_stream_write_buf_size(ssl: *mut SSL, value: *mut u64) -> c_int {
+            SSL_get_generic_value_uint(ssl, SSL_VALUE_STREAM_WRITE_BUF_SIZE, value)
+        }
+        pub unsafe fn SSL_get_stream_write_buf_avail(ssl: *mut SSL, value: *mut u64) -> c_int {
+            SSL_get_generic_value_uint(ssl, SSL_VALUE_STREAM_WRITE_BUF_AVAIL, value)
+        }
+        pub unsafe fn SSL_get_stream_write_buf_used(ssl: *mut SSL, value: *mut u64) -> c_int {
+            SSL_get_generic_value_uint(ssl, SSL_VALUE_STREAM_WRITE_BUF_USED, value)
+        }
+    }
+}

--- a/openssl-sys/src/tls1.rs
+++ b/openssl-sys/src/tls1.rs
@@ -74,7 +74,16 @@ pub unsafe fn SSL_CTX_set_tlsext_servername_callback__fixed_rust(
     ctx: *mut SSL_CTX,
     cb: Option<unsafe extern "C" fn(*mut SSL, *mut c_int, *mut c_void) -> c_int>,
 ) -> c_long {
-    SSL_CTX_callback_ctrl__fixed_rust(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, mem::transmute(cb))
+    SSL_CTX_callback_ctrl__fixed_rust(
+        ctx,
+        SSL_CTRL_SET_TLSEXT_SERVERNAME_CB,
+        mem::transmute::<
+            std::option::Option<
+                unsafe extern "C" fn(*mut SSL, *mut c_int, *mut libc::c_void) -> i32,
+            >,
+            std::option::Option<unsafe extern "C" fn()>,
+        >(cb),
+    )
 }
 
 pub const SSL_TLSEXT_ERR_OK: c_int = 0;
@@ -90,7 +99,14 @@ pub unsafe fn SSL_CTX_set_tlsext_status_cb(
     ctx: *mut SSL_CTX,
     cb: Option<unsafe extern "C" fn(*mut SSL, *mut c_void) -> c_int>,
 ) -> c_long {
-    SSL_CTX_callback_ctrl__fixed_rust(ctx, SSL_CTRL_SET_TLSEXT_STATUS_REQ_CB, mem::transmute(cb))
+    SSL_CTX_callback_ctrl__fixed_rust(
+        ctx,
+        SSL_CTRL_SET_TLSEXT_STATUS_REQ_CB,
+        mem::transmute::<
+            std::option::Option<unsafe extern "C" fn(*mut SSL, *mut c_void) -> i32>,
+            std::option::Option<unsafe extern "C" fn()>,
+        >(cb),
+    )
 }
 
 pub unsafe fn SSL_CTX_set_tlsext_status_arg(ctx: *mut SSL_CTX, arg: *mut c_void) -> c_long {

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -42,6 +42,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(ossl300)");
     println!("cargo:rustc-check-cfg=cfg(ossl310)");
     println!("cargo:rustc-check-cfg=cfg(ossl320)");
+    println!("cargo:rustc-check-cfg=cfg(ossl330)");
 
     if env::var("DEP_OPENSSL_LIBRESSL").is_ok() {
         println!("cargo:rustc-cfg=libressl");
@@ -151,6 +152,9 @@ fn main() {
         }
         if version >= 0x3_02_00_00_0 {
             println!("cargo:rustc-cfg=ossl320");
+        }
+        if version >= 0x3_03_00_00_0 {
+            println!("cargo:rustc-cfg=ossl330");
         }
     }
 }

--- a/openssl/src/aes.rs
+++ b/openssl/src/aes.rs
@@ -95,7 +95,7 @@ impl AesKey {
     #[corresponds(AES_set_encrypt_key)]
     pub fn new_encrypt(key: &[u8]) -> Result<AesKey, KeyError> {
         unsafe {
-            assert!(key.len() <= c_int::max_value() as usize / 8);
+            assert!(key.len() <= c_int::MAX as usize / 8);
 
             let mut aes_key = MaybeUninit::uninit();
             let r = ffi::AES_set_encrypt_key(
@@ -119,7 +119,7 @@ impl AesKey {
     #[corresponds(AES_set_decrypt_key)]
     pub fn new_decrypt(key: &[u8]) -> Result<AesKey, KeyError> {
         unsafe {
-            assert!(key.len() <= c_int::max_value() as usize / 8);
+            assert!(key.len() <= c_int::MAX as usize / 8);
 
             let mut aes_key = MaybeUninit::uninit();
             let r = ffi::AES_set_decrypt_key(

--- a/openssl/src/base64.rs
+++ b/openssl/src/base64.rs
@@ -11,7 +11,7 @@ use openssl_macros::corresponds;
 /// Panics if the input length or computed output length overflow a signed C integer.
 #[corresponds(EVP_EncodeBlock)]
 pub fn encode_block(src: &[u8]) -> String {
-    assert!(src.len() <= c_int::max_value() as usize);
+    assert!(src.len() <= c_int::MAX as usize);
     let src_len = src.len() as LenType;
 
     let len = encoded_len(src_len).unwrap();
@@ -42,7 +42,7 @@ pub fn decode_block(src: &str) -> Result<Vec<u8>, ErrorStack> {
         return Ok(vec![]);
     }
 
-    assert!(src.len() <= c_int::max_value() as usize);
+    assert!(src.len() <= c_int::MAX as usize);
     let src_len = src.len() as LenType;
 
     let len = decoded_len(src_len).unwrap();

--- a/openssl/src/bio.rs
+++ b/openssl/src/bio.rs
@@ -21,7 +21,7 @@ impl<'a> MemBioSlice<'a> {
     pub fn new(buf: &'a [u8]) -> Result<MemBioSlice<'a>, ErrorStack> {
         ffi::init();
 
-        assert!(buf.len() <= c_int::max_value() as usize);
+        assert!(buf.len() <= c_int::MAX as usize);
         let bio = unsafe {
             cvt_p(BIO_new_mem_buf(
                 buf.as_ptr() as *const _,

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -187,7 +187,7 @@ impl BigNumRef {
     pub fn div_word(&mut self, w: u32) -> Result<u64, ErrorStack> {
         unsafe {
             let r = ffi::BN_div_word(self.as_ptr(), w.into());
-            if r == ffi::BN_ULONG::max_value() {
+            if r == ffi::BN_ULONG::MAX {
                 Err(ErrorStack::get())
             } else {
                 Ok(r.into())
@@ -201,7 +201,7 @@ impl BigNumRef {
     pub fn mod_word(&self, w: u32) -> Result<u64, ErrorStack> {
         unsafe {
             let r = ffi::BN_mod_word(self.as_ptr(), w.into());
-            if r == ffi::BN_ULONG::max_value() {
+            if r == ffi::BN_ULONG::MAX {
                 Err(ErrorStack::get())
             } else {
                 Ok(r.into())
@@ -1108,7 +1108,7 @@ impl BigNum {
     pub fn from_slice(n: &[u8]) -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
-            assert!(n.len() <= LenType::max_value() as usize);
+            assert!(n.len() <= LenType::MAX as usize);
 
             cvt_p(ffi::BN_bin2bn(
                 n.as_ptr(),
@@ -1136,7 +1136,7 @@ impl BigNum {
     #[corresponds(BN_bin2bn)]
     pub fn copy_from_slice(&mut self, n: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(n.len() <= LenType::max_value() as usize);
+            assert!(n.len() <= LenType::MAX as usize);
 
             cvt_p(ffi::BN_bin2bn(n.as_ptr(), n.len() as LenType, self.0))?;
             Ok(())

--- a/openssl/src/ecdsa.rs
+++ b/openssl/src/ecdsa.rs
@@ -32,7 +32,7 @@ impl EcdsaSig {
         T: HasPrivate,
     {
         unsafe {
-            assert!(data.len() <= c_int::max_value() as usize);
+            assert!(data.len() <= c_int::MAX as usize);
             let sig = cvt_p(ffi::ECDSA_do_sign(
                 data.as_ptr(),
                 data.len() as LenType,
@@ -77,7 +77,7 @@ impl EcdsaSigRef {
         T: HasPublic,
     {
         unsafe {
-            assert!(data.len() <= c_int::max_value() as usize);
+            assert!(data.len() <= c_int::MAX as usize);
             cvt_n(ffi::ECDSA_do_verify(
                 data.as_ptr(),
                 data.len() as LenType,

--- a/openssl/src/envelope.rs
+++ b/openssl/src/envelope.rs
@@ -75,7 +75,7 @@ impl Seal {
     ///
     /// Panics if `output.len() < input.len() + block_size` where `block_size` is
     /// the block size of the cipher (see `Cipher::block_size`), or if
-    /// `output.len() > c_int::max_value()`.
+    /// `output.len() > c_int::MAX`.
     pub fn update(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize, ErrorStack> {
         self.ctx.cipher_update(input, Some(output))
     }
@@ -130,7 +130,7 @@ impl Open {
     ///
     /// Panics if `output.len() < input.len() + block_size` where
     /// `block_size` is the block size of the cipher (see `Cipher::block_size`),
-    /// or if `output.len() > c_int::max_value()`.
+    /// or if `output.len() > c_int::MAX`.
     pub fn update(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize, ErrorStack> {
         self.ctx.cipher_update(input, Some(output))
     }

--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! private_key_to_pem {
         ) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
                 let bio = crate::bio::MemBio::new()?;
-                assert!(passphrase.len() <= ::libc::c_int::max_value() as usize);
+                assert!(passphrase.len() <= ::libc::c_int::MAX as usize);
                 cvt($f(bio.as_ptr(),
                         self.as_ptr(),
                         cipher.as_ptr(),
@@ -109,7 +109,7 @@ macro_rules! from_der {
             use std::convert::TryInto;
             unsafe {
                 ffi::init();
-                let len = ::std::cmp::min(der.len(), ::libc::c_long::max_value() as usize) as ::libc::c_long;
+                let len = ::std::cmp::min(der.len(), ::libc::c_long::MAX as usize) as ::libc::c_long;
                 crate::cvt_p($f(::std::ptr::null_mut(), &mut der.as_ptr(), len.try_into().unwrap()))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
             }

--- a/openssl/src/pkcs5.rs
+++ b/openssl/src/pkcs5.rs
@@ -38,7 +38,7 @@ pub fn bytes_to_key(
     count: i32,
 ) -> Result<KeyIvPair, ErrorStack> {
     unsafe {
-        assert!(data.len() <= c_int::max_value() as usize);
+        assert!(data.len() <= c_int::MAX as usize);
         let salt_ptr = match salt {
             Some(salt) => {
                 assert_eq!(salt.len(), ffi::PKCS5_SALT_LEN as usize);

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -482,7 +482,7 @@ impl PKey<Private> {
     #[cfg(not(boringssl))]
     pub fn hmac(key: &[u8]) -> Result<PKey<Private>, ErrorStack> {
         unsafe {
-            assert!(key.len() <= c_int::max_value() as usize);
+            assert!(key.len() <= c_int::MAX as usize);
             let key = cvt_p(ffi::EVP_PKEY_new_mac_key(
                 ffi::EVP_PKEY_HMAC,
                 ptr::null_mut(),
@@ -676,7 +676,7 @@ impl PKey<Private> {
     pub fn private_key_from_pkcs8(der: &[u8]) -> Result<PKey<Private>, ErrorStack> {
         unsafe {
             ffi::init();
-            let len = der.len().min(c_long::max_value() as usize) as c_long;
+            let len = der.len().min(c_long::MAX as usize) as c_long;
             let p8inf = cvt_p(ffi::d2i_PKCS8_PRIV_KEY_INFO(
                 ptr::null_mut(),
                 &mut der.as_ptr(),

--- a/openssl/src/rand.rs
+++ b/openssl/src/rand.rs
@@ -32,7 +32,7 @@ use openssl_macros::corresponds;
 pub fn rand_bytes(buf: &mut [u8]) -> Result<(), ErrorStack> {
     unsafe {
         ffi::init();
-        assert!(buf.len() <= c_int::max_value() as usize);
+        assert!(buf.len() <= c_int::MAX as usize);
         cvt(ffi::RAND_bytes(buf.as_mut_ptr(), buf.len() as LenType)).map(|_| ())
     }
 }
@@ -57,7 +57,7 @@ pub fn rand_bytes(buf: &mut [u8]) -> Result<(), ErrorStack> {
 pub fn rand_priv_bytes(buf: &mut [u8]) -> Result<(), ErrorStack> {
     unsafe {
         ffi::init();
-        assert!(buf.len() <= c_int::max_value() as usize);
+        assert!(buf.len() <= c_int::MAX as usize);
         cvt(ffi::RAND_priv_bytes(buf.as_mut_ptr(), buf.len() as LenType)).map(|_| ())
     }
 }

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -129,7 +129,7 @@ where
         to: &mut [u8],
         padding: Padding,
     ) -> Result<usize, ErrorStack> {
-        assert!(from.len() <= i32::max_value() as usize);
+        assert!(from.len() <= i32::MAX as usize);
         assert!(to.len() >= self.size() as usize);
 
         unsafe {
@@ -157,7 +157,7 @@ where
         to: &mut [u8],
         padding: Padding,
     ) -> Result<usize, ErrorStack> {
-        assert!(from.len() <= i32::max_value() as usize);
+        assert!(from.len() <= i32::MAX as usize);
         assert!(to.len() >= self.size() as usize);
 
         unsafe {
@@ -301,7 +301,7 @@ where
         to: &mut [u8],
         padding: Padding,
     ) -> Result<usize, ErrorStack> {
-        assert!(from.len() <= i32::max_value() as usize);
+        assert!(from.len() <= i32::MAX as usize);
         assert!(to.len() >= self.size() as usize);
 
         unsafe {
@@ -328,7 +328,7 @@ where
         to: &mut [u8],
         padding: Padding,
     ) -> Result<usize, ErrorStack> {
-        assert!(from.len() <= i32::max_value() as usize);
+        assert!(from.len() <= i32::MAX as usize);
         assert!(to.len() >= self.size() as usize);
 
         unsafe {

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -72,7 +72,7 @@ pub unsafe fn get_mut<'a, S: 'a>(bio: *mut BIO) -> &'a mut S {
 }
 
 pub unsafe fn set_dtls_mtu_size<S>(bio: *mut BIO, mtu_size: usize) {
-    if mtu_size as u64 > c_long::max_value() as u64 {
+    if mtu_size as u64 > c_long::MAX as u64 {
         panic!(
             "Given MTU size {} can't be represented in a positive `c_long` range",
             mtu_size

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -965,7 +965,7 @@ impl SslContextBuilder {
     #[corresponds(SSL_CTX_set_session_id_context)]
     pub fn set_session_id_context(&mut self, sid_ctx: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(sid_ctx.len() <= c_uint::max_value() as usize);
+            assert!(sid_ctx.len() <= c_uint::MAX as usize);
             cvt(ffi::SSL_CTX_set_session_id_context(
                 self.as_ptr(),
                 sid_ctx.as_ptr(),
@@ -1228,7 +1228,7 @@ impl SslContextBuilder {
     #[cfg(any(ossl102, libressl261, boringssl))]
     pub fn set_alpn_protos(&mut self, protocols: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(protocols.len() <= c_uint::max_value() as usize);
+            assert!(protocols.len() <= c_uint::MAX as usize);
             let r = ffi::SSL_CTX_set_alpn_protos(
                 self.as_ptr(),
                 protocols.as_ptr(),
@@ -2487,7 +2487,7 @@ impl SslRef {
     #[cfg(any(ossl102, libressl261, boringssl))]
     pub fn set_alpn_protos(&mut self, protocols: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(protocols.len() <= c_uint::max_value() as usize);
+            assert!(protocols.len() <= c_uint::MAX as usize);
             let r =
                 ffi::SSL_set_alpn_protos(self.as_ptr(), protocols.as_ptr(), protocols.len() as _);
             // fun fact, SSL_set_alpn_protos has a reversed return code D:
@@ -2938,7 +2938,7 @@ impl SslRef {
     #[cfg(not(boringssl))]
     pub fn set_ocsp_status(&mut self, response: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(response.len() <= c_int::max_value() as usize);
+            assert!(response.len() <= c_int::MAX as usize);
             let p = cvt_p(ffi::OPENSSL_malloc(response.len() as _))?;
             ptr::copy_nonoverlapping(response.as_ptr(), p as *mut u8, response.len());
             cvt(ffi::SSL_set_tlsext_status_ocsp_resp(
@@ -3801,7 +3801,7 @@ impl<S: Read + Write> SslStream<S> {
                     return Ok(0);
                 }
 
-                let len = usize::min(c_int::max_value() as usize, buf.len()) as c_int;
+                let len = usize::min(c_int::MAX as usize, buf.len()) as c_int;
                 let ret = unsafe {
                     ffi::SSL_read(self.ssl().as_ptr(), buf.as_mut_ptr().cast(), len)
                 };
@@ -3842,7 +3842,7 @@ impl<S: Read + Write> SslStream<S> {
                     return Ok(0);
                 }
 
-                let len = usize::min(c_int::max_value() as usize, buf.len()) as c_int;
+                let len = usize::min(c_int::MAX as usize, buf.len()) as c_int;
                 let ret = unsafe {
                     ffi::SSL_write(self.ssl().as_ptr(), buf.as_ptr().cast(), len)
                 };
@@ -3880,7 +3880,7 @@ impl<S: Read + Write> SslStream<S> {
                     return Ok(0);
                 }
 
-                let len = usize::min(c_int::max_value() as usize, buf.len()) as c_int;
+                let len = usize::min(c_int::MAX as usize, buf.len()) as c_int;
                 let ret = unsafe {
                     ffi::SSL_peek(self.ssl().as_ptr(), buf.as_mut_ptr().cast(), len)
                 };

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -691,7 +691,7 @@ impl Crypter {
     /// Panics for block ciphers if `output.len() < input.len() + block_size`,
     /// where `block_size` is the block size of the cipher (see `Cipher::block_size`).
     ///
-    /// Panics if `output.len() > c_int::max_value()`.
+    /// Panics if `output.len() > c_int::MAX`.
     pub fn update(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize, ErrorStack> {
         self.ctx.cipher_update(input, Some(output))
     }

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1093,7 +1093,7 @@ impl X509NameBuilder {
     pub fn append_entry_by_text(&mut self, field: &str, value: &str) -> Result<(), ErrorStack> {
         unsafe {
             let field = CString::new(field).unwrap();
-            assert!(value.len() <= crate::SLenType::max_value() as usize);
+            assert!(value.len() <= crate::SLenType::MAX as usize);
             cvt(ffi::X509_NAME_add_entry_by_txt(
                 self.0.as_ptr(),
                 field.as_ptr() as *mut _,
@@ -1120,7 +1120,7 @@ impl X509NameBuilder {
     ) -> Result<(), ErrorStack> {
         unsafe {
             let field = CString::new(field).unwrap();
-            assert!(value.len() <= crate::SLenType::max_value() as usize);
+            assert!(value.len() <= crate::SLenType::MAX as usize);
             cvt(ffi::X509_NAME_add_entry_by_txt(
                 self.0.as_ptr(),
                 field.as_ptr() as *mut _,
@@ -1141,7 +1141,7 @@ impl X509NameBuilder {
     /// [`X509_NAME_add_entry_by_NID`]: https://www.openssl.org/docs/manmaster/crypto/X509_NAME_add_entry_by_NID.html
     pub fn append_entry_by_nid(&mut self, field: Nid, value: &str) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(value.len() <= crate::SLenType::max_value() as usize);
+            assert!(value.len() <= crate::SLenType::MAX as usize);
             cvt(ffi::X509_NAME_add_entry_by_NID(
                 self.0.as_ptr(),
                 field.as_raw(),
@@ -1167,7 +1167,7 @@ impl X509NameBuilder {
         ty: Asn1Type,
     ) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(value.len() <= crate::SLenType::max_value() as usize);
+            assert!(value.len() <= crate::SLenType::MAX as usize);
             cvt(ffi::X509_NAME_add_entry_by_NID(
                 self.0.as_ptr(),
                 field.as_raw(),

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -103,7 +103,7 @@ fn main() {
             && s.chars().next().unwrap().is_lowercase()
         {
             format!("struct {}", s)
-        } else if s.starts_with("stack_st_") {
+        } else if s.starts_with("stack_st_") || s == "timeval" {
             format!("struct {}", s)
         } else {
             s.to_string()


### PR DESCRIPTION
This PR mainly focuses on `openssl-sys` and raw bindings to OpenSSL 3 QUIC features that I think might be useful for implementing high-level, ergonomic QUIC bindings in `openssl` crate. Also fixed some minor issues when using `bindgen` feature with Windows MSVC.

Related: #2242 