### PR TITLE
Switch Pkey::from_ to use set1 functions

### DIFF
--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -470,8 +470,11 @@ extern "C" {
 
     pub fn EVP_PKEY_set1_RSA(k: *mut EVP_PKEY, r: *mut RSA) -> c_int;
     pub fn EVP_PKEY_get1_RSA(k: *mut EVP_PKEY) -> *mut RSA;
+    pub fn EVP_PKEY_set1_DSA(k: *mut EVP_PKEY, k: *mut DSA) -> c_int;
     pub fn EVP_PKEY_get1_DSA(k: *mut EVP_PKEY) -> *mut DSA;
+    pub fn EVP_PKEY_set1_DH(k: *mut EVP_PKEY, k: *mut DH) -> c_int;
     pub fn EVP_PKEY_get1_DH(k: *mut EVP_PKEY) -> *mut DH;
+    pub fn EVP_PKEY_set1_EC_KEY(k: *mut EVP_PKEY, k: *mut EC_KEY) -> c_int;
     pub fn EVP_PKEY_get1_EC_KEY(k: *mut EVP_PKEY) -> *mut EC_KEY;
 
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -60,6 +60,7 @@ use openssl_macros::corresponds;
 use std::convert::{TryFrom, TryInto};
 use std::ffi::CString;
 use std::fmt;
+#[cfg(all(not(boringssl), ossl110))]
 use std::mem;
 use std::ptr;
 
@@ -407,38 +408,37 @@ impl<T> Clone for PKey<T> {
 
 impl<T> PKey<T> {
     /// Creates a new `PKey` containing an RSA key.
-    #[corresponds(EVP_PKEY_assign_RSA)]
+    #[corresponds(EVP_PKEY_set1_RSA)]
     pub fn from_rsa(rsa: Rsa<T>) -> Result<PKey<T>, ErrorStack> {
+        // TODO: Next time we make backwards incompatible changes, this could
+        // become an `&RsaRef<T>`. Same for all the other `from_*` methods.
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
             let pkey = PKey::from_ptr(evp);
-            cvt(ffi::EVP_PKEY_assign_RSA(pkey.0, rsa.as_ptr()))?;
-            mem::forget(rsa);
+            cvt(ffi::EVP_PKEY_set1_RSA(pkey.0, rsa.as_ptr()))?;
             Ok(pkey)
         }
     }
 
     /// Creates a new `PKey` containing a DSA key.
-    #[corresponds(EVP_PKEY_assign_DSA)]
+    #[corresponds(EVP_PKEY_set1_DSA)]
     pub fn from_dsa(dsa: Dsa<T>) -> Result<PKey<T>, ErrorStack> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
             let pkey = PKey::from_ptr(evp);
-            cvt(ffi::EVP_PKEY_assign_DSA(pkey.0, dsa.as_ptr()))?;
-            mem::forget(dsa);
+            cvt(ffi::EVP_PKEY_set1_DSA(pkey.0, dsa.as_ptr()))?;
             Ok(pkey)
         }
     }
 
     /// Creates a new `PKey` containing a Diffie-Hellman key.
-    #[corresponds(EVP_PKEY_assign_DH)]
+    #[corresponds(EVP_PKEY_set1_DH)]
     #[cfg(not(boringssl))]
     pub fn from_dh(dh: Dh<T>) -> Result<PKey<T>, ErrorStack> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
             let pkey = PKey::from_ptr(evp);
-            cvt(ffi::EVP_PKEY_assign_DH(pkey.0, dh.as_ptr()))?;
-            mem::forget(dh);
+            cvt(ffi::EVP_PKEY_set1_DH(pkey.0, dh.as_ptr()))?;
             Ok(pkey)
         }
     }
@@ -460,13 +460,12 @@ impl<T> PKey<T> {
     }
 
     /// Creates a new `PKey` containing an elliptic curve key.
-    #[corresponds(EVP_PKEY_assign_EC_KEY)]
+    #[corresponds(EVP_PKEY_set1_EC_KEY)]
     pub fn from_ec_key(ec_key: EcKey<T>) -> Result<PKey<T>, ErrorStack> {
         unsafe {
             let evp = cvt_p(ffi::EVP_PKEY_new())?;
             let pkey = PKey::from_ptr(evp);
-            cvt(ffi::EVP_PKEY_assign_EC_KEY(pkey.0, ec_key.as_ptr()))?;
-            mem::forget(ec_key);
+            cvt(ffi::EVP_PKEY_set1_EC_KEY(pkey.0, ec_key.as_ptr()))?;
             Ok(pkey)
         }
     }


### PR DESCRIPTION
They're more type safe, because they aren't macros, and they slightly simplify reference counting.