### PR TITLE
Ensure beginning and end of the error output is readable

### DIFF
--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -187,7 +187,8 @@ https://github.com/sfackler/rust-openssl#windows
         );
     }
 
-    panic!("{}", msg);
+    eprintln!("{}", msg);
+    std::process::exit(101); // same as panic previously
 }
 
 /// Attempt to find OpenSSL through pkg-config.

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -213,7 +213,7 @@ fn try_pkg_config() {
     {
         Ok(lib) => lib,
         Err(e) => {
-            println!("run pkg_config fail: {:?}", e);
+            println!("\n\nCould not find openssl via pkg-config:\n{}\n", e);
             return;
         }
     };

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -102,13 +102,21 @@ fn find_openssl_dir(target: &str) -> OsString {
         return OsString::from("/usr/local");
     }
 
+    let msg_header =
+        "Could not find directory of OpenSSL installation, and this `-sys` crate cannot
+proceed without this knowledge. If OpenSSL is installed and this crate had
+trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
+compilation process.";
+
+    println!(
+        "cargo:warning={} See stderr section below for further information.",
+        msg_header.replace('\n', " ")
+    );
+
     let mut msg = format!(
         "
 
-Could not find directory of OpenSSL installation, and this `-sys` crate cannot
-proceed without this knowledge. If OpenSSL is installed and this crate had
-trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
-compilation process.
+{}
 
 Make sure you also have the development packages of openssl installed.
 For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.
@@ -122,6 +130,7 @@ $TARGET = {}
 openssl-sys = {}
 
 ",
+        msg_header,
         host,
         target,
         env!("CARGO_PKG_VERSION")


### PR DESCRIPTION
When the build fails, [the Cargo output is messy](https://github.com/rust-lang/cargo/issues/10159), and there's unhelpful noise added at both ends of openssl's message. The beginning of output gets a vague error and long meaningless stdout dump, and the end gets a backtrace of an unimportant code location.

This improves the output in two ways:

1. Emits `cargo:warning=` with the first paragraph of the error, so the cause of the failure is printed and highlighted by Cargo first,
2. Changes a `panic` to direct stderr print to avoid Rust adding unnecessary panic-related help.