### PR TITLE
Explicit rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+# this project uses the default rustfmt settings


### PR DESCRIPTION
I have my custom rustfmt configuration, which automatically "breaks" formatting in projects that assume the default formatting. This change explicitly selects the formatting that is required.
