### PR TITLE
Adjustments for LibreSSL 4

### DIFF
--- a/openssl-sys/src/handwritten/conf.rs
+++ b/openssl-sys/src/handwritten/conf.rs
@@ -1,7 +1,13 @@
 use super::super::*;
 
+const_ptr_api! {
+    extern "C" {
+        pub fn NCONF_new(meth: #[const_ptr_if(libressl400)] CONF_METHOD) -> *mut CONF;
+    }
+}
+
 extern "C" {
-    pub fn NCONF_new(meth: *mut CONF_METHOD) -> *mut CONF;
+    #[cfg(not(libressl400))]
     pub fn NCONF_default() -> *mut CONF_METHOD;
     pub fn NCONF_free(conf: *mut CONF);
 }

--- a/openssl-sys/src/handwritten/types.rs
+++ b/openssl-sys/src/handwritten/types.rs
@@ -472,6 +472,7 @@ pub struct X509V3_CTX {
     subject_cert: *mut c_void,
     subject_req: *mut c_void,
     crl: *mut c_void,
+    #[cfg(not(libressl400))]
     db_meth: *mut c_void,
     db: *mut c_void,
     #[cfg(ossl300)]

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -31,6 +31,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(libressl380)");
     println!("cargo:rustc-check-cfg=cfg(libressl382)");
     println!("cargo:rustc-check-cfg=cfg(libressl390)");
+    println!("cargo:rustc-check-cfg=cfg(libressl400)");
 
     println!("cargo:rustc-check-cfg=cfg(ossl101)");
     println!("cargo:rustc-check-cfg=cfg(ossl102)");
@@ -111,6 +112,9 @@ fn main() {
         }
         if version >= 0x3_09_00_00_0 {
             println!("cargo:rustc-cfg=libressl390");
+        }
+        if version >= 0x4_00_00_00_0 {
+            println!("cargo:rustc-cfg=libressl400");
         }
     }
 

--- a/openssl/src/conf.rs
+++ b/openssl/src/conf.rs
@@ -8,7 +8,7 @@ foreign_type_and_impl_send_sync! {
     pub struct ConfRef;
 }
 
-#[cfg(not(boringssl))]
+#[cfg(not(any(boringssl, libressl400)))]
 mod methods {
     use super::Conf;
     use crate::cvt_p;
@@ -61,5 +61,5 @@ mod methods {
         }
     }
 }
-#[cfg(not(boringssl))]
+#[cfg(not(any(boringssl, libressl400)))]
 pub use methods::*;


### PR DESCRIPTION
We need to disable the conf module since `Conf::new()` doesn't really mirror the C-API, where the method is optional (and is `NULL` by all consumers I'm aware of, except rust-openssl).

This should be the last batch of changes needed in this cycle.