### PR TITLE
allow conversion from MessageDigest to Md

### DIFF
--- a/openssl/src/md.rs
+++ b/openssl/src/md.rs
@@ -76,6 +76,12 @@ pub struct Md(Inner);
 unsafe impl Sync for Md {}
 unsafe impl Send for Md {}
 
+impl From<crate::hash::MessageDigest> for Md {
+    fn from(value: crate::hash::MessageDigest) -> Self {
+        unsafe { Md::from_ptr(value.as_ptr() as *mut _) }
+    }
+}
+
 impl Md {
     /// Returns the `Md` corresponding to an [`Nid`].
     #[corresponds(EVP_get_digestbynid)]


### PR DESCRIPTION
This eases porting from legacy const EVP_MD to dynamic EVP_MD, especially in codebases that need to support boringssl/libressl in addition to OpenSSL 3.