### PR TITLE
LibreSSL 4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,17 +184,17 @@ jobs:
               bindgen: true
               library:
                 name: libressl
-                version: 3.7.3
+                version: 3.8.4
             - target: x86_64-unknown-linux-gnu
               bindgen: true
               library:
                 name: libressl
-                version: 3.8.3
+                version: 3.9.2
             - target: x86_64-unknown-linux-gnu
               bindgen: true
               library:
                 name: libressl
-                version: 3.9.1
+                version: 4.0.0
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:
@@ -204,17 +204,17 @@ jobs:
               bindgen: false
               library:
                 name: libressl
-                version: 3.7.3
+                version: 3.8.4
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:
                 name: libressl
-                version: 3.8.3
+                version: 3.9.2
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:
                 name: libressl
-                version: 3.9.1
+                version: 4.0.0
       name: ${{ matrix.target }}-${{ matrix.library.name }}-${{ matrix.library.version }}-${{ matrix.bindgen }}
       runs-on: ubuntu-latest
       env:

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -380,6 +380,8 @@ See rust-openssl documentation for more information:
             (3, 8, _) => ('3', '8', 'x'),
             (3, 9, 0) => ('3', '9', '0'),
             (3, 9, _) => ('3', '9', 'x'),
+            (4, 0, 0) => ('4', '0', '0'),
+            (4, 0, _) => ('4', '0', 'x'),
             _ => version_error(),
         };
 
@@ -422,7 +424,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3), or LibreSSL 2.5
-through 3.9.x, but a different version of OpenSSL was found. The build is now aborting
+through 4.0.x, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "


### PR DESCRIPTION
LibreSSL 4.0.0 was released. It's stable.

Alternate PR to #2314