### PR TITLE
strip square brackets to parse ipv6 in setup_verify_hostname

### DIFF
--- a/openssl/src/ssl/connector.rs
+++ b/openssl/src/ssl/connector.rs
@@ -395,6 +395,7 @@ cfg_if! {
 
             let param = ssl.param_mut();
             param.set_hostflags(X509CheckFlags::NO_PARTIAL_WILDCARDS);
+            let domain = domain.strip_prefix("[").and_then(|x| x.strip_suffix("]")).unwrap_or(domain);
             match domain.parse() {
                 Ok(ip) => param.set_ip(ip),
                 Err(_) => param.set_host(domain),


### PR DESCRIPTION
I have a use case where I need to use TLS (well, HTTPS), to speak to a server that doesn't have a proper hostname in CN, although it has a IPv6 address in Subject Alternative Name.

However IPv6, unlike IPv4 is often specified with square brackets, so libraries can differentiate between different segments of it and a port. Both are delimited with `:`, so IPv6 in the authority part of a url can be used like `[2a01:cc00:bbbb:aaaa:1864:842:abcd:5fd2]:443`. 

I've had some difficulties making cert verification work and in the end I found this function calling `set_host` with `[2a01:cc00:bbbb:aaaa:1864:842:abcd:5fd2]` because it couldn't parse the IP so it was assuming it must be a hostname.


[RFC3986 Uniform Resource Identifier (URI): Generic Syntax](https://www.ietf.org/rfc/rfc3986.txt) says: 

> A host identified by an Internet Protocol literal address, version 6
   [RFC3513] or later, is distinguished by enclosing the IP literal
   within square brackets ("[" and "]").  This is the only place where
   square bracket characters are allowed in the URI syntax.

It means `[` and `]` aren't even valid hostname characters so existence of this strip might exist here. 
TBH I'm not 100% convinced it shouldn't be done by all libraries using rust-openssl, but sometimes this is buried deep down in code, or straight up not possible to be done by users of such libraries because limited APIs, so why not just have it here?