### PR TITLE
build(deps): Update `openssl-macro` to version `0.1.1`

### DIFF
--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -30,7 +30,7 @@ foreign-types = "0.3.1"
 libc = "0.2"
 once_cell = "1.5.2"
 
-openssl-macros = { version = "0.1.0", path = "../openssl-macros" }
+openssl-macros = { version = "0.1.1", path = "../openssl-macros" }
 ffi = { package = "openssl-sys", version = "0.9.104", path = "../openssl-sys" }
 
 [dev-dependencies]


### PR DESCRIPTION
The minimal version of `openssl-macros` needs to be the latest version. If `0.1.0` is used, then all kinds of compiler errors in the macro usage of `openssl` occur.

I found this by running `cargo minimal-versions check` on crate `native-tls`. I don't know of any simple CI check to add to this project to detect this problem in the future.