### PR TITLE
fix unable to find library -latomic for ohos

### DIFF
--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -214,6 +214,7 @@ fn main() {
         && (env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux"
             || env::var("CARGO_CFG_TARGET_OS").unwrap() == "android")
         && env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap() == "32"
+        && !env::var("TARGET").unwrap().ends_with("-linux-ohos")
     {
         println!("cargo:rustc-link-lib=atomic");
     }


### PR DESCRIPTION

build has failed for target `armv7-unknown-linux-ohos`

This has build logs for ohos
```
  = note: ld.lld: error: unable to find library -latomic
          clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
```

I found this issue, it seems to be to solve the issue with the Android link
https://github.com/openssl/openssl/issues/14083 (Android x86: undefined reference to __atomic_* (Alpha11))

After I removed `-latomic`, rust-openssl compilation passed and ran well for ohos.

Maybe ohos doesn't need this library

```
    Finished `release` profile [optimized] target(s)
```

