### PR TITLE
Adding support for CADES → CMS_CADES flag

### DIFF
--- a/openssl-sys/src/cms.rs
+++ b/openssl-sys/src/cms.rs
@@ -44,3 +44,5 @@ pub const CMS_DEBUG_DECRYPT: c_uint = 0x20000;
 pub const CMS_KEY_PARAM: c_uint = 0x40000;
 #[cfg(ossl110)]
 pub const CMS_ASCIICRLF: c_uint = 0x80000;
+#[cfg(ossl300)]
+pub const CMS_CADES: c_uint = 0x100000;

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -47,6 +47,8 @@ bitflags! {
         const KEY_PARAM = ffi::CMS_KEY_PARAM;
         #[cfg(all(not(libressl), not(ossl101), not(ossl102)))]
         const ASCIICRLF = ffi::CMS_ASCIICRLF;
+        #[cfg(all(not(libressl), not(ossl101), not(ossl102), not(ossl110), not(ossl110g), not(ossl110h), not(ossl111), not(ossl111d)))]
+        const CADES = ffi::CMS_CADES;
     }
 }
 


### PR DESCRIPTION
Hello!

So, the title seems pretty explicative.

I was trying to write an app, capable to sign and verify CAdES-BES compliant opaque signatures.
Instead of rewriting the famous wheel, I have choosen to use OpenSSL libs and API, an write it down in rust.
However, at some point, I have noticed that at the moment, rust bindings are missing CMS_CADES, that is instead present in OpenSSL since 3.0.0 https://mta.openssl.org/pipermail/openssl-commits/2019-January/021722.html (correct me if I picked up the wrong entry version).

So, as it is a simple change, I have added CMS_CADES support to the rust bindings, if you do not mind :) , as I gess others can take advantage of this!

A note, at line 50 of `openssl/src/cms.rs` , I have added `#[cfg(all(not(libressl), not(ossl101), not(ossl102), not(ossl110), not(ossl110g), not(ossl110h), not(ossl111), not(ossl111d)))]` , however, on my system fails, as probably I have wrong choosen what to avoid or my understading or #[cfg] is wrong? Please give feedback about, thanks. Maybe my system sees OpenSSL as known version? Bah. My version is the standard Ubuntu 24.10 packaged one, at the moment of writing→ `OpenSSL 3.3.1 4 Jun 2024 (Library: OpenSSL 3.3.1 4 Jun 2024)`

I have added this #[cfg] and [cfg(ossl300)] on line 47 of `openssl-sys/src/cms.rs `as to avoid both LibreSSL (that seems to not have CAdES-BES support, as far as I have searched for, correct me if I am wrong) and OpenSSL versions lower than 3.0.0 (simply cms support does not have CAdES and related ESS stuffs neede for CAdES-BES signatures in lower versions).

Commenting the "annoying" cfg in `openssl/src/cms.rs` (the one I have added I mean), my tiny application works, and give a signed CAdES-BES compliant file, that I am adding as attachment to you to verify. Using external tools for verification, the p7m obtained seems to have a valid and without missing attributes CAdES-BES signature :) . However, as I have not already implemented pkcs#11 to obtain certs/private keys from my smartcard, and other stuffs (I wanted to first try to see if CAdES via the rust bindings was possible at all in first palce), I have used a self-singed generated certificate to sign the `test.txt` file, with content `CIAOCIAOCIAO` (yes, a really original test content :D )

I am leaving as attachment a zip, with both original and signed p7m as github does support p7m as attachment.
[test.zip](https://github.com/user-attachments/files/18469121/test.zip)

