### PR TITLE
tag functions not relevant for BoringSSL

### DIFF
--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -238,6 +238,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb1() as *mut _) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_192_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb128() as *mut _) }
     }
@@ -295,6 +296,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb1() as *mut _) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_256_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb128() as *mut _) }
     }
@@ -345,12 +347,12 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_bf_ecb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_BF", boringssl)))]
     pub fn bf_cfb64() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_bf_cfb64() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_BF", boringssl)))]
     pub fn bf_ofb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_bf_ofb() as *mut _) }
     }
@@ -395,102 +397,102 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_rc4() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia128_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_128_cfb128() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia128_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_128_ecb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia128_cbc() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_128_cbc() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia128_ofb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_128_ofb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia192_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_192_cfb128() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia192_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_192_ecb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia192_cbc() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_192_cbc() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia192_ofb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_192_ofb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia256_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_256_cfb128() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia256_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_256_ecb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia256_cbc() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_256_cbc() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia256_ofb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_camellia_256_ofb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAST", boringssl)))]
     pub fn cast5_cfb64() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_cast5_cfb64() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAST", boringssl)))]
     pub fn cast5_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_cast5_ecb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAST", boringssl)))]
     pub fn cast5_cbc() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_cast5_cbc() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAST", boringssl)))]
     pub fn cast5_ofb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_cast5_ofb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_IDEA", boringssl)))]
     pub fn idea_cfb64() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_idea_cfb64() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_IDEA", boringssl)))]
     pub fn idea_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_idea_ecb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_IDEA", boringssl)))]
     pub fn idea_cbc() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_idea_cbc() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_IDEA", boringssl)))]
     pub fn idea_ofb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_idea_ofb() as *mut _) }
     }
@@ -505,22 +507,22 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_chacha20_poly1305() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", boringssl)))]
     pub fn seed_cbc() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_seed_cbc() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", boringssl)))]
     pub fn seed_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_seed_cfb128() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", boringssl)))]
     pub fn seed_ecb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_seed_ecb() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", boringssl)))]
     pub fn seed_ofb() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_seed_ofb() as *mut _) }
     }

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -148,7 +148,7 @@ impl<'a> Encrypter<'a> {
     /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
     ///
     /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
-    #[cfg(any(ossl102, libressl310))]
+    #[cfg(any(ossl102, libressl310, boringssl))]
     pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_oaep_md(
@@ -352,7 +352,7 @@ impl<'a> Decrypter<'a> {
     /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
     ///
     /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
-    #[cfg(any(ossl102, libressl310))]
+    #[cfg(any(ossl102, libressl310, boringssl))]
     pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_oaep_md(

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -153,7 +153,7 @@ impl MessageDigest {
         unsafe { MessageDigest(ffi::EVP_shake256()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_RMD160"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_RMD160", boringssl)))]
     pub fn ripemd160() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_ripemd160()) }
     }

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -152,7 +152,7 @@ pub mod base64;
 pub mod bn;
 pub mod cipher;
 pub mod cipher_ctx;
-#[cfg(all(not(libressl), not(osslconf = "OPENSSL_NO_CMS")))]
+#[cfg(all(not(libressl), not(osslconf = "OPENSSL_NO_CMS"), not(boringssl)))]
 pub mod cms;
 pub mod conf;
 pub mod derive;
@@ -175,7 +175,7 @@ pub mod md;
 pub mod md_ctx;
 pub mod memcmp;
 pub mod nid;
-#[cfg(not(osslconf = "OPENSSL_NO_OCSP"))]
+#[cfg(all(not(osslconf = "OPENSSL_NO_OCSP"), not(boringssl)))]
 pub mod ocsp;
 pub mod pkcs12;
 pub mod pkcs5;

--- a/openssl/src/md.rs
+++ b/openssl/src/md.rs
@@ -188,7 +188,7 @@ impl Md {
         unsafe { MdRef::from_ptr(ffi::EVP_shake256() as *mut _) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_RMD160"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_RMD160", boringssl)))]
     #[inline]
     pub fn ripemd160() -> &'static MdRef {
         unsafe { MdRef::from_ptr(ffi::EVP_ripemd160() as *mut _) }

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -114,6 +114,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_cfb1()) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_128_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_cfb128()) }
     }
@@ -159,6 +160,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_cfb1()) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_192_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_cfb128()) }
     }
@@ -209,6 +211,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_cfb1()) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_256_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_cfb128()) }
     }
@@ -247,12 +250,12 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_bf_ecb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_BF", boringssl)))]
     pub fn bf_cfb64() -> Cipher {
         unsafe { Cipher(ffi::EVP_bf_cfb64()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_BF"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_BF", boringssl)))]
     pub fn bf_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_bf_ofb()) }
     }
@@ -297,82 +300,82 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_rc4()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_128_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_128_cbc()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_128_ecb() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_128_ecb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_128_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_128_ofb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_128_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_128_cfb128()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_192_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_192_cbc()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_192_ecb() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_192_ecb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_192_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_192_ofb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_192_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_192_cfb128()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_256_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_256_cbc()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_256_ecb() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_256_ecb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_256_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_256_ofb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAMELLIA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAMELLIA", boringssl)))]
     pub fn camellia_256_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_camellia_256_cfb128()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAST", boringssl)))]
     pub fn cast5_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_cast5_cbc()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAST", boringssl)))]
     pub fn cast5_ecb() -> Cipher {
         unsafe { Cipher(ffi::EVP_cast5_ecb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAST", boringssl)))]
     pub fn cast5_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_cast5_ofb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_CAST"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_CAST", boringssl)))]
     pub fn cast5_cfb64() -> Cipher {
         unsafe { Cipher(ffi::EVP_cast5_cfb64()) }
     }
@@ -389,42 +392,42 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_chacha20_poly1305()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_IDEA", boringssl)))]
     pub fn idea_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_idea_cbc()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_IDEA", boringssl)))]
     pub fn idea_ecb() -> Cipher {
         unsafe { Cipher(ffi::EVP_idea_ecb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_IDEA", boringssl)))]
     pub fn idea_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_idea_ofb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_IDEA"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_IDEA", boringssl)))]
     pub fn idea_cfb64() -> Cipher {
         unsafe { Cipher(ffi::EVP_idea_cfb64()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", boringssl)))]
     pub fn seed_cbc() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_cbc()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", boringssl)))]
     pub fn seed_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_cfb128()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", boringssl)))]
     pub fn seed_ecb() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_ecb()) }
     }
 
-    #[cfg(not(osslconf = "OPENSSL_NO_SEED"))]
+    #[cfg(not(any(osslconf = "OPENSSL_NO_SEED", boringssl)))]
     pub fn seed_ofb() -> Cipher {
         unsafe { Cipher(ffi::EVP_seed_ofb()) }
     }


### PR DESCRIPTION
it would simplify some of the downstream patches in Android and other places, e.g., https://android.googlesource.com/platform/external/rust/crates/openssl/+/refs/heads/main/patches/