### PR TITLE
Add ec::EcKey::private_key_from_der_for_group

### DIFF
--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -1009,6 +1009,29 @@ impl EcKey<Private> {
         EcKey<Private>,
         ffi::d2i_ECPrivateKey
     }
+
+    /// Decodes a DER-encoded elliptic curve private key structure for the specified curve.
+    #[corresponds(EC_KEY_parse_private_key)]
+    #[cfg(boringssl)]
+    pub fn private_key_from_der_for_group(
+        der: &[u8],
+        group: &EcGroupRef,
+    ) -> Result<EcKey<Private>, ErrorStack> {
+        unsafe {
+            let mut cbs = ffi::CBS {
+                data: der.as_ptr(),
+                len: der.len(),
+            };
+            let p = cvt_p(ffi::EC_KEY_parse_private_key(
+                &mut cbs as *mut ffi::CBS,
+                group.as_ptr(),
+            ))?;
+            if ffi::CBS_len(p) != 0 {
+                todo!()
+            }
+            Ok(EcKey::from_ptr(p))
+        }
+    }
 }
 
 impl<T> Clone for EcKey<T> {


### PR DESCRIPTION
Upstreaming https://android-review.googlesource.com/c/platform/external/rust/crates/openssl/+/2191953

In the `ECPrivateKey` schema (RFC 5915 s3) the parameters field which holds the NamedCurve is optional.

If an EC key was originally enclosed in a PKCS#8 (RFC 5208 s5) wrapper, the curve may be identified in the wrapper (in the `AlgorithmIdentifier.parameters` field) rather than in the `ECPrivateKey`.

In this case, the existing `ec::EcKey::private_key_from_der()` method (which corresponds to `d2i_ECPrivateKey()`) cannot determine the curve and so cannot import such a key.

Add a new method that includes explicit specification of the curve to cope with this situation, passing through to the (BoringSSL-specific) `EC_KEY_parse_private_key` function.