### PR TITLE
make set_rsa_oaep_md visible to boringssl config

### DIFF
--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -148,7 +148,7 @@ impl<'a> Encrypter<'a> {
     /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
     ///
     /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
-    #[cfg(any(ossl102, libressl310))]
+    #[cfg(any(ossl102, libressl310, boringssl))]
     pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_oaep_md(
@@ -352,7 +352,7 @@ impl<'a> Decrypter<'a> {
     /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
     ///
     /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
-    #[cfg(any(ossl102, libressl310))]
+    #[cfg(any(ossl102, libressl310, boringssl))]
     pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_oaep_md(
@@ -478,7 +478,7 @@ mod test {
     use hex::FromHex;
 
     use crate::encrypt::{Decrypter, Encrypter};
-    #[cfg(any(ossl102, libressl310))]
+    #[cfg(any(ossl102, libressl310, boringssl))]
     use crate::hash::MessageDigest;
     use crate::pkey::PKey;
     use crate::rsa::{Padding, Rsa};
@@ -513,7 +513,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(any(ossl102, libressl310))]
+    #[cfg(any(ossl102, libressl310, boringssl))]
     fn rsa_encrypt_decrypt_with_sha256() {
         let key = include_bytes!("../test/rsa.pem");
         let private_key = Rsa::private_key_from_pem(key).unwrap();


### PR DESCRIPTION
Upstreaming https://android-review.git.corp.google.com/c/platform/external/rust/crates/openssl/+/2177444

Android's KeyMint is [using](https://android.googlesource.com/platform/system/keymint/+/refs/heads/main/boringssl/src/rsa.rs#164) this function and it uses rust-openssl with boringssl, but via a downstream patch