### PR TITLE
Unify the two BoringSSL codepaths a bit and simplify init

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -6,7 +6,6 @@
     non_upper_case_globals,
     unused_imports
 )]
-#![cfg_attr(feature = "unstable_boringssl", allow(ambiguous_glob_reexports))]
 #![doc(html_root_url = "https://docs.rs/openssl-sys/0.9")]
 #![recursion_limit = "128"] // configure fixed limit across all rust versions
 
@@ -15,21 +14,19 @@ pub use libc::c_int;
 
 #[cfg(feature = "unstable_boringssl")]
 extern crate bssl_sys;
-#[cfg(feature = "unstable_boringssl")]
-pub use bssl_sys::*;
 
-#[cfg(all(boringssl, not(feature = "unstable_boringssl")))]
+#[cfg(boringssl)]
 #[path = "."]
 mod boringssl {
+    #[cfg(feature = "unstable_boringssl")]
+    pub use bssl_sys::*;
+    #[cfg(not(feature = "unstable_boringssl"))]
     include!(concat!(env!("OUT_DIR"), "/bindgen.rs"));
 
-    pub fn init() {
-        unsafe {
-            CRYPTO_library_init();
-        }
-    }
+    // BoringSSL does not require initialization.
+    pub fn init() {}
 }
-#[cfg(all(boringssl, not(feature = "unstable_boringssl")))]
+#[cfg(boringssl)]
 pub use boringssl::*;
 
 #[cfg(openssl)]


### PR DESCRIPTION
Although bssl-sys (currently) provides init, it only does so for rust-openssl, and it's more natural for rust-openssl to consistently be responsible for it. Also BoringSSL has not required initialization at all since June 2024.

I've also removed the ambiguous_glob_reexports allowance. I couldn't reproduce whatever triggered it, and it seems unlikely that the two codepaths would have different needs here.

This leaves the remaining non-build unstable_boringssl trigger so minor that perhaps we should just remove it here? It dates to some problematic Android Rust integration. At this point, it's just an external mechanism to get the same output as the build.rs logic around bindgen, mostly because bindgen has perpetual deficiencies w.r.t.  correctly binding C, so we need to work around it. Ideally there wouldn't be two sources of those workarounds, but Google's build environments care about build reproducibility and hermeticity, while Rust and Cargo have... very much not achieved this yet. But there's no reason for rust-openssl's build to care about this.