### PR TITLE
chore: add perl-File-Compare depency mention for Fedora

### DIFF
--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -45,7 +45,7 @@
 //! $ sudo apt-get install pkg-config libssl-dev
 //!
 //! # Fedora
-//! $ sudo dnf install pkgconf perl-FindBin perl-IPC-Cmd openssl-devel
+//! $ sudo dnf install pkgconf perl-FindBin perl-IPC-Cmd perl-File-Compare openssl-devel
 //!
 //! # Alpine Linux
 //! $ apk add pkgconf openssl-dev


### PR DESCRIPTION
Adds a small comment to mention the perl-File-Compare dependency on Fedora.

Related to #2381 .