### PR TITLE
Enable additional capabilities for AWS-LC

### DIFF
--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -33,6 +33,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(libressl382)");
     println!("cargo:rustc-check-cfg=cfg(libressl390)");
     println!("cargo:rustc-check-cfg=cfg(libressl400)");
+    println!("cargo:rustc-check-cfg=cfg(libressl410)");
 
     println!("cargo:rustc-check-cfg=cfg(ossl101)");
     println!("cargo:rustc-check-cfg=cfg(ossl102)");
@@ -120,6 +121,9 @@ fn main() {
         }
         if version >= 0x4_00_00_00_0 {
             println!("cargo:rustc-cfg=libressl400");
+        }
+        if version >= 0x4_01_00_00_0 {
+            println!("cargo:rustc-cfg=libressl410");
         }
     }
 

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -37,18 +37,15 @@ use crate::{cvt, cvt_n, cvt_p, LenType};
 use openssl_macros::corresponds;
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl350))] {
+    if #[cfg(any(ossl110, libressl350, awslc))] {
         use ffi::{
-            BN_get_rfc2409_prime_1024, BN_get_rfc2409_prime_768, BN_get_rfc3526_prime_1536,
-            BN_get_rfc3526_prime_2048, BN_get_rfc3526_prime_3072, BN_get_rfc3526_prime_4096,
+            BN_get_rfc3526_prime_1536, BN_get_rfc3526_prime_2048, BN_get_rfc3526_prime_3072, BN_get_rfc3526_prime_4096,
             BN_get_rfc3526_prime_6144, BN_get_rfc3526_prime_8192, BN_is_negative,
         };
-    } else if #[cfg(any(boringssl, awslc))] {
+    } else if #[cfg(boringssl)] {
         use ffi::BN_is_negative;
     } else {
         use ffi::{
-            get_rfc2409_prime_1024 as BN_get_rfc2409_prime_1024,
-            get_rfc2409_prime_768 as BN_get_rfc2409_prime_768,
             get_rfc3526_prime_1536 as BN_get_rfc3526_prime_1536,
             get_rfc3526_prime_2048 as BN_get_rfc3526_prime_2048,
             get_rfc3526_prime_3072 as BN_get_rfc3526_prime_3072,
@@ -61,6 +58,19 @@ cfg_if! {
         unsafe fn BN_is_negative(bn: *const ffi::BIGNUM) -> c_int {
             (*bn).neg
         }
+    }
+}
+
+cfg_if! {
+    if #[cfg(any(ossl110, libressl350))] {
+        use ffi::{
+            BN_get_rfc2409_prime_1024, BN_get_rfc2409_prime_768
+        };
+    } else if #[cfg(not(any(boringssl, awslc)))] {
+        use ffi::{
+            get_rfc2409_prime_1024 as BN_get_rfc2409_prime_1024,
+            get_rfc2409_prime_768 as BN_get_rfc2409_prime_768,
+        };
     }
 }
 
@@ -1014,7 +1024,7 @@ impl BigNum {
     ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-3
     #[corresponds(BN_get_rfc3526_prime_1536)]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn get_rfc3526_prime_1536() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1028,7 +1038,7 @@ impl BigNum {
     ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-3
     #[corresponds(BN_get_rfc3526_prime_2048)]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn get_rfc3526_prime_2048() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1042,7 +1052,7 @@ impl BigNum {
     ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-4
     #[corresponds(BN_get_rfc3526_prime_3072)]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn get_rfc3526_prime_3072() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1056,7 +1066,7 @@ impl BigNum {
     ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-4
     #[corresponds(BN_get_rfc3526_prime_4096)]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn get_rfc3526_prime_4096() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1070,7 +1080,7 @@ impl BigNum {
     ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-6
     #[corresponds(BN_get_rfc3526_prime_6114)]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn get_rfc3526_prime_6144() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();
@@ -1084,7 +1094,7 @@ impl BigNum {
     ///
     /// [`RFC 3526`]: https://tools.ietf.org/html/rfc3526#page-6
     #[corresponds(BN_get_rfc3526_prime_8192)]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn get_rfc3526_prime_8192() -> Result<BigNum, ErrorStack> {
         unsafe {
             ffi::init();

--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -166,7 +166,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_xts() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_256_xts() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_xts() as *mut _) }
     }
@@ -175,17 +175,17 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_ctr() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_128_cfb1() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_cfb1() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_128_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_cfb128() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_128_cfb8() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_cfb8() as *mut _) }
     }
@@ -194,7 +194,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_gcm() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_128_ccm() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_128_ccm() as *mut _) }
     }
@@ -233,7 +233,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_ctr() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_192_cfb1() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb1() as *mut _) }
     }
@@ -242,7 +242,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb128() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_192_cfb8() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb8() as *mut _) }
     }
@@ -251,7 +251,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_gcm() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_192_ccm() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_ccm() as *mut _) }
     }
@@ -290,7 +290,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_ctr() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_256_cfb1() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb1() as *mut _) }
     }
@@ -299,7 +299,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb128() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_256_cfb8() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb8() as *mut _) }
     }
@@ -308,7 +308,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_gcm() as *mut _) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_256_ccm() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_ccm() as *mut _) }
     }
@@ -500,7 +500,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_chacha20() as *mut _) }
     }
 
-    #[cfg(all(any(ossl110, libressl360), not(osslconf = "OPENSSL_NO_CHACHA")))]
+    #[cfg(all(any(ossl110, libressl360, awslc), not(osslconf = "OPENSSL_NO_CHACHA")))]
     pub fn chacha20_poly1305() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_chacha20_poly1305() as *mut _) }
     }

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -809,8 +809,173 @@ mod test {
         aes_128_cbc(cipher);
     }
 
+    #[cfg(not(boringssl))]
+    #[test]
+    fn default_aes_128_ccm() {
+        // from https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/ccmtestvectors.zip
+        let cipher = Cipher::aes_128_ccm();
+        aes_ccm(
+            cipher,
+            "26511fb51fcfa75cb4b44da75a6e5a0e",
+            "ea98ec44f5a86715014783172e",
+            "4da40b80579c1d9a5309f7efecb7c059a2f914511ca5fc10",
+            "e4692b9f06b666c7451b146c8aeb07a6e30c629d28065c3dde5940325b14b810",
+            "1bf0ba0ebb20d8edba59f29a9371750c9c714078f73c335d",
+            "2f1322ac69b848b001476323aed84c47",
+        );
+    }
+
+    #[cfg(not(boringssl))]
+    #[test]
+    fn default_aes_192_ccm() {
+        // from https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/ccmtestvectors.zip
+        let cipher = Cipher::aes_192_ccm();
+        aes_ccm(
+            cipher,
+            "26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886",
+            "ea98ec44f5a86715014783172e",
+            "4da40b80579c1d9a5309f7efecb7c059a2f914511ca5fc10",
+            "e4692b9f06b666c7451b146c8aeb07a6e30c629d28065c3dde5940325b14b810",
+            "30c154c616946eccc2e241d336ad33720953e449a0e6b0f0",
+            "dbf8e9464909bdf337e48093c082a10b",
+        );
+    }
+
+    #[cfg(not(boringssl))]
+    #[test]
+    fn default_aes_256_ccm() {
+        // from https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/ccmtestvectors.zip
+        let cipher = Cipher::aes_256_ccm();
+        aes_ccm(
+            cipher,
+            "314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e",
+            "3542fbe0f59a6d5f3abf619b7d",
+            "c5b3d71312ea14f2f8fae5bd1a453192b6604a45db75c5ed",
+            "dd4531f158a2fa3bc8a339f770595048f4a42bc1b03f2e824efc6ba4985119d8",
+            "39c2e8f6edfe663b90963b98eb79e2d4f7f28a5053ae8881",
+            "567a6b4426f1667136bed4a5e32a2bc1",
+        );
+    }
+
+    #[cfg(not(boringssl))]
+    fn aes_ccm(
+        cipher: &CipherRef,
+        key: &'static str,
+        iv: &'static str,
+        pt: &'static str,
+        aad: &'static str,
+        ct: &'static str,
+        tag: &'static str,
+    ) {
+        let key = hex::decode(key).unwrap();
+        let iv = hex::decode(iv).unwrap();
+        let pt = hex::decode(pt).unwrap();
+        let ct = hex::decode(ct).unwrap();
+        let aad = hex::decode(aad).unwrap();
+        let tag = hex::decode(tag).unwrap();
+
+        let mut ctx = CipherCtx::new().unwrap();
+
+        ctx.encrypt_init(Some(cipher), None, None).unwrap();
+        ctx.set_iv_length(iv.len()).unwrap();
+        ctx.set_tag_length(tag.len()).unwrap();
+        ctx.encrypt_init(None, Some(&key), Some(&iv)).unwrap();
+        ctx.set_data_len(pt.len()).unwrap();
+
+        let mut buf = vec![];
+        ctx.cipher_update(&aad, None).unwrap();
+        ctx.cipher_update_vec(&pt, &mut buf).unwrap();
+        ctx.cipher_final_vec(&mut buf).unwrap();
+        assert_eq!(buf, ct);
+
+        let mut out_tag = vec![0u8; tag.len()];
+        ctx.tag(&mut out_tag).unwrap();
+        assert_eq!(tag, out_tag);
+
+        ctx.decrypt_init(Some(cipher), None, None).unwrap();
+        ctx.set_iv_length(iv.len()).unwrap();
+        ctx.set_tag(&tag).unwrap();
+        ctx.decrypt_init(None, Some(&key), Some(&iv)).unwrap();
+        ctx.set_data_len(pt.len()).unwrap();
+
+        let mut buf = vec![];
+        ctx.cipher_update(&aad, None).unwrap();
+        ctx.cipher_update_vec(&ct, &mut buf).unwrap();
+        // Some older libraries don't support calling EVP_CipherFinal/EVP_DecryptFinal for CCM
+        // https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption#Authenticated_Decryption_using_CCM_mode
+        #[cfg(any(libressl410, ossl111, awslc, boringssl))]
+        ctx.cipher_final_vec(&mut buf).unwrap();
+
+        assert_eq!(buf, pt);
+    }
+
+    #[cfg(not(any(boringssl, awslc)))]
+    #[test]
+    fn default_aes_128_xts() {
+        // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes/XTSTestVectors.zip
+        let cipher = Cipher::aes_128_xts();
+        aes_xts(
+            cipher,
+            "a1b90cba3f06ac353b2c343876081762090923026e91771815f29dab01932f2f",
+            "4faef7117cda59c66e4b92013e768ad5",
+            "ebabce95b14d3c8d6fb350390790311c",
+            "778ae8b43cb98d5a825081d5be471c63",
+        );
+    }
+
+    #[cfg(not(boringssl))]
+    #[test]
+    fn default_aes_256_xts() {
+        // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/aes/XTSTestVectors.zip
+        let cipher = Cipher::aes_256_xts();
+        aes_xts(cipher, "1ea661c58d943a0e4801e42f4b0947149e7f9f8e3e68d0c7505210bd311a0e7cd6e13ffdf2418d8d1911c004cda58da3d619b7e2b9141e58318eea392cf41b08", "adf8d92627464ad2f0428e84a9f87564", "2eedea52cd8215e1acc647e810bbc3642e87287f8d2e57e36c0a24fbc12a202e", "cbaad0e2f6cea3f50b37f934d46a9b130b9d54f07e34f36af793e86f73c6d7db");
+    }
+
+    #[cfg(not(boringssl))]
+    fn aes_xts(
+        cipher: &CipherRef,
+        key: &'static str,
+        i: &'static str,
+        pt: &'static str,
+        ct: &'static str,
+    ) {
+        let key = hex::decode(key).unwrap();
+        let i = hex::decode(i).unwrap();
+        let pt = hex::decode(pt).unwrap();
+        let ct = hex::decode(ct).unwrap();
+
+        let mut ctx = CipherCtx::new().unwrap();
+        ctx.encrypt_init(Some(cipher), Some(&key), Some(&i))
+            .unwrap();
+        let mut buf = vec![];
+        ctx.cipher_update_vec(&pt, &mut buf).unwrap();
+        ctx.cipher_final_vec(&mut buf).unwrap();
+
+        assert_eq!(ct, buf);
+
+        ctx.decrypt_init(Some(cipher), Some(&key), Some(&i))
+            .unwrap();
+        let mut buf = vec![];
+        ctx.cipher_update_vec(&ct, &mut buf).unwrap();
+        ctx.cipher_final_vec(&mut buf).unwrap();
+
+        assert_eq!(pt, buf);
+    }
+
     #[test]
     fn test_stream_ciphers() {
+        #[cfg(not(boringssl))]
+        {
+            test_stream_cipher(Cipher::aes_128_cfb1());
+            test_stream_cipher(Cipher::aes_128_cfb8());
+            test_stream_cipher(Cipher::aes_128_cfb128());
+            test_stream_cipher(Cipher::aes_192_cfb1());
+            test_stream_cipher(Cipher::aes_192_cfb8());
+            test_stream_cipher(Cipher::aes_192_cfb128());
+            test_stream_cipher(Cipher::aes_256_cfb1());
+            test_stream_cipher(Cipher::aes_256_cfb8());
+            test_stream_cipher(Cipher::aes_256_cfb128());
+        }
         test_stream_cipher(Cipher::aes_192_ctr());
         test_stream_cipher(Cipher::aes_256_ctr());
     }

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -903,7 +903,7 @@ mod test {
         ctx.cipher_update_vec(&ct, &mut buf).unwrap();
         // Some older libraries don't support calling EVP_CipherFinal/EVP_DecryptFinal for CCM
         // https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption#Authenticated_Decryption_using_CCM_mode
-        #[cfg(any(libressl410, ossl111, awslc, boringssl))]
+        #[cfg(any(ossl111, awslc, boringssl))]
         ctx.cipher_final_vec(&mut buf).unwrap();
 
         assert_eq!(buf, pt);

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -533,11 +533,11 @@ cfg_if! {
 mod test {
     use super::*;
     use crate::bn::BigNumContext;
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     use crate::hash::MessageDigest;
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     use crate::pkey::PKey;
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     use crate::sign::{Signer, Verifier};
 
     #[test]
@@ -607,7 +607,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     fn test_signature() {
         const TEST_DATA: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         let dsa_ref = Dsa::generate(1024).unwrap();
@@ -648,7 +648,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     fn test_signature_der() {
         use std::convert::TryInto;
 

--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -238,7 +238,7 @@ impl Error {
 
     /// Returns the raw OpenSSL error constant for the library reporting the
     /// error.
-    // On BoringSSL ERR_GET_{LIB,FUNC,REASON} are `unsafe`, but on
+    // On AWS-LC and BoringSSL ERR_GET_{LIB,FUNC,REASON} are `unsafe`, but on
     // OpenSSL/LibreSSL they're safe.
     #[allow(unused_unsafe)]
     pub fn library_code(&self) -> libc::c_int {
@@ -263,7 +263,7 @@ impl Error {
     }
 
     /// Returns the raw OpenSSL error constant for the reason for the error.
-    // On BoringSSL ERR_GET_{LIB,FUNC,REASON} are `unsafe`, but on
+    // On AWS-LC and BoringSSL ERR_GET_{LIB,FUNC,REASON} are `unsafe`, but on
     // OpenSSL/LibreSSL they're safe.
     #[allow(unused_unsafe)]
     pub fn reason_code(&self) -> libc::c_int {
@@ -310,7 +310,7 @@ impl fmt::Debug for Error {
 }
 
 impl fmt::Display for Error {
-    // On BoringSSL ERR_GET_{LIB,FUNC,REASON} are `unsafe`, but on
+    // On AWS-LC and BoringSSL ERR_GET_{LIB,FUNC,REASON} are `unsafe`, but on
     // OpenSSL/LibreSSL they're safe.
     #[allow(unused_unsafe)]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -824,7 +824,7 @@ mod tests {
         #[cfg(ossl111)]
         assert_eq!(MessageDigest::shake_256().size(), 32);
         #[cfg(awslc)]
-        assert_eq!(MessageDigest::shake_128().size(), 0);
+        assert_eq!(MessageDigest::shake_256().size(), 0);
         assert_eq!(
             MessageDigest::shake_256().type_().as_raw(),
             Nid::SHAKE256.as_raw()

--- a/openssl/src/hash.rs
+++ b/openssl/src/hash.rs
@@ -94,7 +94,7 @@ impl MessageDigest {
         }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn null() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_md_null()) }
     }
@@ -123,32 +123,32 @@ impl MessageDigest {
         unsafe { MessageDigest(ffi::EVP_sha512()) }
     }
 
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     pub fn sha3_224() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_sha3_224()) }
     }
 
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     pub fn sha3_256() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_sha3_256()) }
     }
 
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     pub fn sha3_384() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_sha3_384()) }
     }
 
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     pub fn sha3_512() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_sha3_512()) }
     }
 
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, awslc))]
     pub fn shake_128() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_shake128()) }
     }
 
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, awslc))]
     pub fn shake_256() -> MessageDigest {
         unsafe { MessageDigest(ffi::EVP_shake256()) }
     }
@@ -481,7 +481,7 @@ pub fn hash(t: MessageDigest, data: &[u8]) -> Result<DigestBytes, ErrorStack> {
 /// assert_eq!(buf, spec);
 /// ```
 ///
-#[cfg(ossl111)]
+#[cfg(any(ossl111, awslc))]
 pub fn hash_xof(t: MessageDigest, data: &[u8], buf: &mut [u8]) -> Result<(), ErrorStack> {
     let mut h = Hasher::new(t)?;
     h.update(data)?;
@@ -500,7 +500,7 @@ mod tests {
         assert_eq!(hex::encode(res), hashtest.1);
     }
 
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, awslc))]
     fn hash_xof_test(hashtype: MessageDigest, hashtest: &(&str, &str)) {
         let expected = Vec::from_hex(hashtest.1).unwrap();
         let mut buf = vec![0; expected.len()];
@@ -701,7 +701,7 @@ mod tests {
         );
     }
 
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     #[test]
     fn test_sha3_224() {
         let tests = [(
@@ -721,7 +721,7 @@ mod tests {
         );
     }
 
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     #[test]
     fn test_sha3_256() {
         let tests = [(
@@ -741,7 +741,7 @@ mod tests {
         );
     }
 
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     #[test]
     fn test_sha3_384() {
         let tests = [("416c6c20796f75722062617365206172652062656c6f6e6720746f207573",
@@ -761,7 +761,7 @@ mod tests {
         );
     }
 
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     #[test]
     fn test_sha3_512() {
         let tests = [("416c6c20796f75722062617365206172652062656c6f6e6720746f207573",
@@ -781,7 +781,7 @@ mod tests {
         );
     }
 
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, awslc))]
     #[test]
     fn test_shake_128() {
         let tests = [(
@@ -796,14 +796,17 @@ mod tests {
         }
 
         assert_eq!(MessageDigest::shake_128().block_size(), 168);
+        #[cfg(ossl111)]
         assert_eq!(MessageDigest::shake_128().size(), 16);
+        #[cfg(awslc)]
+        assert_eq!(MessageDigest::shake_128().size(), 0);
         assert_eq!(
             MessageDigest::shake_128().type_().as_raw(),
             Nid::SHAKE128.as_raw()
         );
     }
 
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, awslc))]
     #[test]
     fn test_shake_256() {
         let tests = [(
@@ -818,7 +821,10 @@ mod tests {
         }
 
         assert_eq!(MessageDigest::shake_256().block_size(), 136);
+        #[cfg(ossl111)]
         assert_eq!(MessageDigest::shake_256().size(), 32);
+        #[cfg(awslc)]
+        assert_eq!(MessageDigest::shake_128().size(), 0);
         assert_eq!(
             MessageDigest::shake_256().type_().as_raw(),
             Nid::SHAKE256.as_raw()

--- a/openssl/src/md.rs
+++ b/openssl/src/md.rs
@@ -117,7 +117,7 @@ impl Md {
     }
 
     #[inline]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn null() -> &'static MdRef {
         unsafe { MdRef::from_ptr(ffi::EVP_md_null() as *mut _) }
     }

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -1078,19 +1078,19 @@ impl Nid {
     pub const SM2: Nid = Nid(ffi::NID_sm2);
     #[cfg(any(ossl111, libressl291))]
     pub const SM3: Nid = Nid(ffi::NID_sm3);
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     pub const SHA3_224: Nid = Nid(ffi::NID_sha3_224);
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     pub const SHA3_256: Nid = Nid(ffi::NID_sha3_256);
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     pub const SHA3_384: Nid = Nid(ffi::NID_sha3_384);
-    #[cfg(any(ossl111, libressl380))]
+    #[cfg(any(ossl111, libressl380, awslc))]
     pub const SHA3_512: Nid = Nid(ffi::NID_sha3_512);
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, awslc))]
     pub const SHAKE128: Nid = Nid(ffi::NID_shake128);
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, awslc))]
     pub const SHAKE256: Nid = Nid(ffi::NID_shake256);
-    #[cfg(any(ossl110, libressl271))]
+    #[cfg(any(ossl110, libressl271, awslc))]
     pub const CHACHA20_POLY1305: Nid = Nid(ffi::NID_chacha20_poly1305);
 }
 

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -271,9 +271,6 @@ impl Pkcs12Builder {
                 cvt(ffi::PKCS12_set_mac(
                     pkcs12.as_ptr(),
                     pass,
-                    // -1 could be passed in for the password length in OpenSSL,
-                    // but AWS-LC does not support that at this time.
-                    // We know the length so explicitly provide it.
                     pass_len.try_into().unwrap(),
                     ptr::null_mut(),
                     0,

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -6,7 +6,7 @@ use std::ffi::CString;
 use std::ptr;
 
 use crate::error::ErrorStack;
-#[cfg(not(any(boringssl, awslc)))]
+#[cfg(not(boringssl))]
 use crate::hash::MessageDigest;
 use crate::nid::Nid;
 use crate::pkey::{HasPrivate, PKey, PKeyRef, Private};
@@ -102,7 +102,7 @@ impl Pkcs12 {
             nid_cert: Nid::UNDEF,
             iter: ffi::PKCS12_DEFAULT_ITER,
             mac_iter: ffi::PKCS12_DEFAULT_ITER,
-            #[cfg(not(any(boringssl, awslc)))]
+            #[cfg(not(boringssl))]
             mac_md: None,
         }
     }
@@ -132,7 +132,7 @@ pub struct Pkcs12Builder {
     iter: c_int,
     mac_iter: c_int,
     // FIXME remove
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     mac_md: Option<MessageDigest>,
 }
 
@@ -194,7 +194,7 @@ impl Pkcs12Builder {
     }
 
     /// MAC message digest type
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn mac_md(&mut self, md: MessageDigest) -> &mut Self {
         self.mac_md = Some(md);
         self
@@ -226,6 +226,8 @@ impl Pkcs12Builder {
     pub fn build2(&self, password: &str) -> Result<Pkcs12, ErrorStack> {
         unsafe {
             let pass = CString::new(password).unwrap();
+            #[cfg(not(boringssl))]
+            let pass_len = pass.as_bytes().len();
             let pass = pass.as_ptr();
             let friendly_name = self.name.as_ref().map_or(ptr::null(), |p| p.as_ptr());
             let pkey = self.pkey.as_ref().map_or(ptr::null(), |p| p.as_ptr());
@@ -257,9 +259,9 @@ impl Pkcs12Builder {
             ))
             .map(Pkcs12)?;
 
-            #[cfg(not(any(boringssl, awslc)))]
+            #[cfg(not(boringssl))]
             // BoringSSL does not support overriding the MAC and will always
-            // use SHA-1
+            // use SHA-1.
             {
                 let md_type = self
                     .mac_md
@@ -269,7 +271,10 @@ impl Pkcs12Builder {
                 cvt(ffi::PKCS12_set_mac(
                     pkcs12.as_ptr(),
                     pass,
-                    -1,
+                    // -1 could be passed in for the password length in OpenSSL,
+                    // but AWS-LC does not support that at this time.
+                    // We know the length so explicitly provide it.
+                    pass_len.try_into().unwrap(),
                     ptr::null_mut(),
                     0,
                     self.mac_iter,

--- a/openssl/src/sign.rs
+++ b/openssl/src/sign.rs
@@ -593,7 +593,7 @@ unsafe fn EVP_DigestVerifyFinal(
 #[cfg(test)]
 mod test {
     use hex::{self, FromHex};
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     use std::iter;
 
     use crate::ec::{EcGroup, EcKey};
@@ -601,7 +601,7 @@ mod test {
     use crate::nid::Nid;
     use crate::pkey::PKey;
     use crate::rsa::{Padding, Rsa};
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, awslc))]
     use crate::sign::RsaPssSaltlen;
     use crate::sign::{Signer, Verifier};
 
@@ -657,7 +657,7 @@ mod test {
         assert!(!verifier.verify(&Vec::from_hex(SIGNATURE).unwrap()).unwrap());
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     fn test_hmac(ty: MessageDigest, tests: &[(Vec<u8>, Vec<u8>, Vec<u8>)]) {
         for (key, data, res) in tests.iter() {
             let pkey = PKey::hmac(key).unwrap();
@@ -668,7 +668,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     fn hmac_md5() {
         // test vectors from RFC 2202
         let tests: [(Vec<u8>, Vec<u8>, Vec<u8>); 7] = [
@@ -715,7 +715,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     fn hmac_sha1() {
         // test vectors from RFC 2202
         let tests: [(Vec<u8>, Vec<u8>, Vec<u8>); 7] = [
@@ -806,7 +806,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, awslc))]
     fn rsa_sign_verify() {
         let key = include_bytes!("../test/rsa.pem");
         let private_key = Rsa::private_key_from_pem(key).unwrap();

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -616,7 +616,7 @@ impl SslAlert {
 
 /// An error returned from an ALPN selection callback.
 ///
-/// Requires BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
+/// Requires AWS-LC or BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
 #[cfg(any(ossl102, libressl261, boringssl, awslc))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct AlpnError(c_int);
@@ -625,7 +625,7 @@ pub struct AlpnError(c_int);
 impl AlpnError {
     /// Terminate the handshake with a fatal alert.
     ///
-    /// Requires BoringSSL or OpenSSL 1.1.0 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.1.0 or newer.
     #[cfg(any(ossl110, boringssl, awslc))]
     pub const ALERT_FATAL: AlpnError = AlpnError(ffi::SSL_TLSEXT_ERR_ALERT_FATAL);
 
@@ -668,7 +668,7 @@ impl SslVersion {
 
     /// TLSv1.3
     ///
-    /// Requires BoringSSL or OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.1.1 or LibreSSL 3.4.0 or newer.
     #[cfg(any(ossl111, libressl340, boringssl, awslc))]
     pub const TLS1_3: SslVersion = SslVersion(ffi::TLS1_3_VERSION);
 
@@ -1172,7 +1172,7 @@ impl SslContextBuilder {
     /// A value of `None` will enable protocol versions down to the lowest version supported by
     /// OpenSSL.
     ///
-    /// Requires BoringSSL or OpenSSL 1.1.0 or LibreSSL 2.6.1 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.1.0 or LibreSSL 2.6.1 or newer.
     #[corresponds(SSL_CTX_set_min_proto_version)]
     #[cfg(any(ossl110, libressl261, boringssl, awslc))]
     pub fn set_min_proto_version(&mut self, version: Option<SslVersion>) -> Result<(), ErrorStack> {
@@ -1190,7 +1190,7 @@ impl SslContextBuilder {
     /// A value of `None` will enable protocol versions up to the highest version supported by
     /// OpenSSL.
     ///
-    /// Requires BoringSSL or OpenSSL 1.1.0 or or LibreSSL 2.6.1 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.1.0 or or LibreSSL 2.6.1 or newer.
     #[corresponds(SSL_CTX_set_max_proto_version)]
     #[cfg(any(ossl110, libressl261, boringssl, awslc))]
     pub fn set_max_proto_version(&mut self, version: Option<SslVersion>) -> Result<(), ErrorStack> {
@@ -1248,7 +1248,7 @@ impl SslContextBuilder {
     /// and `http/1.1` is encoded as `b"\x06spdy/1\x08http/1.1"`. The protocols are ordered by
     /// preference.
     ///
-    /// Requires BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
     #[corresponds(SSL_CTX_set_alpn_protos)]
     #[cfg(any(ossl102, libressl261, boringssl, awslc))]
     pub fn set_alpn_protos(&mut self, protocols: &[u8]) -> Result<(), ErrorStack> {
@@ -1292,7 +1292,7 @@ impl SslContextBuilder {
     /// of those protocols on success. The [`select_next_proto`] function implements the standard
     /// protocol selection algorithm.
     ///
-    /// Requires BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
     ///
     /// [`SslContextBuilder::set_alpn_protos`]: struct.SslContextBuilder.html#method.set_alpn_protos
     /// [`select_next_proto`]: fn.select_next_proto.html
@@ -1339,7 +1339,7 @@ impl SslContextBuilder {
 
     /// Returns a reference to the X509 verification configuration.
     ///
-    /// Requires BoringSSL or OpenSSL 1.0.2 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.0.2 or newer.
     #[corresponds(SSL_CTX_get0_param)]
     #[cfg(any(ossl102, boringssl, libressl261, awslc))]
     pub fn verify_param(&self) -> &X509VerifyParamRef {
@@ -1348,7 +1348,7 @@ impl SslContextBuilder {
 
     /// Returns a mutable reference to the X509 verification configuration.
     ///
-    /// Requires BoringSSL or OpenSSL 1.0.2 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.0.2 or newer.
     #[corresponds(SSL_CTX_get0_param)]
     #[cfg(any(ossl102, boringssl, libressl261, awslc))]
     pub fn verify_param_mut(&mut self) -> &mut X509VerifyParamRef {
@@ -1751,7 +1751,7 @@ impl SslContextBuilder {
 
     /// Sets the context's supported elliptic curve groups.
     ///
-    /// Requires BoringSSL or OpenSSL 1.1.1 or LibreSSL 2.5.1 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.1.1 or LibreSSL 2.5.1 or newer.
     #[corresponds(SSL_CTX_set1_groups_list)]
     #[cfg(any(ossl111, boringssl, libressl251, awslc))]
     pub fn set_groups_list(&mut self, groups: &str) -> Result<(), ErrorStack> {
@@ -2499,7 +2499,7 @@ impl SslRef {
 
     /// Like [`SslContextBuilder::set_alpn_protos`].
     ///
-    /// Requires BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
     ///
     /// [`SslContextBuilder::set_alpn_protos`]: struct.SslContextBuilder.html#method.set_alpn_protos
     #[corresponds(SSL_set_alpn_protos)]
@@ -2655,7 +2655,7 @@ impl SslRef {
     /// The protocol's name is returned is an opaque sequence of bytes. It is up to the client
     /// to interpret it.
     ///
-    /// Requires BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.0.2 or LibreSSL 2.6.1 or newer.
     #[corresponds(SSL_get0_alpn_selected)]
     #[cfg(any(ossl102, libressl261, boringssl, awslc))]
     pub fn selected_alpn_protocol(&self) -> Option<&[u8]> {
@@ -2780,7 +2780,7 @@ impl SslRef {
 
     /// Returns a mutable reference to the X509 verification configuration.
     ///
-    /// Requires BoringSSL or OpenSSL 1.0.2 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.0.2 or newer.
     #[corresponds(SSL_get0_param)]
     #[cfg(any(ossl102, boringssl, libressl261, awslc))]
     pub fn param_mut(&mut self) -> &mut X509VerifyParamRef {
@@ -3342,7 +3342,7 @@ impl SslRef {
     /// A value of `None` will enable protocol versions down to the lowest version supported by
     /// OpenSSL.
     ///
-    /// Requires BoringSSL or OpenSSL 1.1.0 or LibreSSL 2.6.1 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.1.0 or LibreSSL 2.6.1 or newer.
     #[corresponds(SSL_set_min_proto_version)]
     #[cfg(any(ossl110, libressl261, boringssl, awslc))]
     pub fn set_min_proto_version(&mut self, version: Option<SslVersion>) -> Result<(), ErrorStack> {
@@ -3360,7 +3360,7 @@ impl SslRef {
     /// A value of `None` will enable protocol versions up to the highest version supported by
     /// OpenSSL.
     ///
-    /// Requires BoringSSL or OpenSSL 1.1.0 or or LibreSSL 2.6.1 or newer.
+    /// Requires AWS-LC or BoringSSL or OpenSSL 1.1.0 or or LibreSSL 2.6.1 or newer.
     #[corresponds(SSL_set_max_proto_version)]
     #[cfg(any(ossl110, libressl261, boringssl, awslc))]
     pub fn set_max_proto_version(&mut self, version: Option<SslVersion>) -> Result<(), ErrorStack> {

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -109,7 +109,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_ctr()) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_128_cfb1() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_cfb1()) }
     }
@@ -118,7 +118,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_cfb128()) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_128_cfb8() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_cfb8()) }
     }
@@ -127,7 +127,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_gcm()) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_128_ccm() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_ccm()) }
     }
@@ -154,7 +154,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_ctr()) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_192_cfb1() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_cfb1()) }
     }
@@ -163,7 +163,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_cfb128()) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_192_cfb8() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_cfb8()) }
     }
@@ -195,7 +195,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_cbc()) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_256_xts() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_xts()) }
     }
@@ -204,7 +204,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_ctr()) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_256_cfb1() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_cfb1()) }
     }
@@ -213,7 +213,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_cfb128()) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_256_cfb8() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_cfb8()) }
     }
@@ -222,7 +222,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_gcm()) }
     }
 
-    #[cfg(not(any(boringssl, awslc)))]
+    #[cfg(not(boringssl))]
     pub fn aes_256_ccm() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_ccm()) }
     }
@@ -384,7 +384,7 @@ impl Cipher {
     }
 
     /// Requires OpenSSL 1.1.0 or newer.
-    #[cfg(all(any(ossl110, libressl360), not(osslconf = "OPENSSL_NO_CHACHA")))]
+    #[cfg(all(any(ossl110, libressl360, awslc), not(osslconf = "OPENSSL_NO_CHACHA")))]
     pub fn chacha20_poly1305() -> Cipher {
         unsafe { Cipher(ffi::EVP_chacha20_poly1305()) }
     }
@@ -1633,7 +1633,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(ossl110, libressl360))]
+    #[cfg(any(ossl110, libressl360, awslc))]
     fn test_chacha20_poly1305() {
         let key = "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f";
         let iv = "070000004041424344454647";


### PR DESCRIPTION
This was the follow-up work to the recently merged support for AWS-LC in https://github.com/sfackler/rust-openssl/pull/1805.

This enables some additional API support in various parts of the openssl crate. This includes some specific AES cipher support likes CFB, CCM, and XTS. Also includes support for SHA3 digests and SHAKE128 and SHAKE256.