### PR TITLE
Use --experimental with bindgen-cli with aws-lc build

### DIFF
--- a/openssl-sys/build/run_bindgen.rs
+++ b/openssl-sys/build/run_bindgen.rs
@@ -322,6 +322,7 @@ pub fn run_awslc(include_dirs: &[PathBuf], symbol_prefix: Option<String>) {
         .arg("--default-macro-constant-type=signed")
         .arg("--rustified-enum=point_conversion_form_t")
         .arg(r"--allowlist-file=.*(/|\\)openssl((/|\\)[^/\\]+)+\.h")
+        .arg("--experimental")
         .arg("--wrap-static-fns")
         .arg("--wrap-static-fns-path")
         .arg(out_dir.join("awslc_static_wrapper").display().to_string())


### PR DESCRIPTION
Enables the `--experimental` as done with the BoringSSL build in order to support the older bingen-cli version on Ubuntu 24.04.