### PR TITLE
Increment `openssl-macros` version to add repository field in crates.io

### DIFF
--- a/openssl-macros/Cargo.toml
+++ b/openssl-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Internal macros used by the openssl crate."

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -31,7 +31,7 @@ foreign-types = "0.3.1"
 libc = "0.2"
 once_cell = "1.5.2"
 
-openssl-macros = { version = "0.1.1", path = "../openssl-macros" }
+openssl-macros = { version = "0.1.2", path = "../openssl-macros" }
 ffi = { package = "openssl-sys", version = "0.9.107", path = "../openssl-sys" }
 
 [dev-dependencies]


### PR DESCRIPTION
While a repository has been added to `openssl-macros`'s `Cargo.toml` in #2211, the crate's version has not been incremented to reflect the change. This means that [crates.io does not have the repository field](https://crates.io/api/v1/crates/openssl-macros) actually updated, unfortunately. 

Version updates:

* [`openssl-macros/Cargo.toml`](diffhunk://#diff-303456c454473de84125bbd115afbc2a841b113fdc829a308bdf70d4e13a243cL3-R3): Updated the version of the `openssl-macros` crate from "0.1.1" to "0.1.2".
* [`openssl/Cargo.toml`](diffhunk://#diff-e779406c7d4a5b26183259187485a0d78e0f8d84d83ab41865dc0208babcd02fL34-R34): Updated the dependency version of `openssl-macros` from "0.1.1" to "0.1.2".