### PR TITLE
[AIX] use /usr to find_openssl_dir

### DIFF
--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -92,8 +92,8 @@ fn find_openssl_dir(target: &str) -> OsString {
     try_pkg_config();
     try_vcpkg();
 
-    // FreeBSD and OpenBSD ship with Libre|OpenSSL but don't include a pkg-config file
-    if host == target && (target.contains("freebsd") || target.contains("openbsd")) {
+    // FreeBSD, OpenBSD, and AIX ship with Libre|OpenSSL but don't include a pkg-config file
+    if host == target && (target.contains("freebsd") || target.contains("openbsd") || target.contains("aix")) {
         return OsString::from("/usr");
     }
 

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -92,7 +92,8 @@ fn find_openssl_dir(target: &str) -> OsString {
     try_pkg_config();
     try_vcpkg();
 
-    // FreeBSD, OpenBSD, and AIX ship with Libre|OpenSSL but don't include a pkg-config file
+    // FreeBSD, OpenBSD, and AIX ship with Libre|OpenSSL
+    // TODO: see of this is still needed for OpenBSD
     if host == target && (target.contains("freebsd") || target.contains("openbsd") || target.contains("aix")) {
         return OsString::from("/usr");
     }

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -94,7 +94,9 @@ fn find_openssl_dir(target: &str) -> OsString {
 
     // FreeBSD, OpenBSD, and AIX ship with Libre|OpenSSL
     // TODO: see of this is still needed for OpenBSD
-    if host == target && (target.contains("freebsd") || target.contains("openbsd") || target.contains("aix")) {
+    if host == target
+        && (target.contains("freebsd") || target.contains("openbsd") || target.contains("aix"))
+    {
         return OsString::from("/usr");
     }
 


### PR DESCRIPTION
Similar to the FreeBSD, AIX includes OpenSSL in `/usr` but without a pkg-config setup, so follow the same path which allows us to build.