### PR TITLE
Add support for argon2d and argon2i variants

### DIFF
--- a/openssl/src/kdf.rs
+++ b/openssl/src/kdf.rs
@@ -47,7 +47,7 @@ cfg_if::cfg_if! {
             memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            return argon2_helper(c"ARGON2D", ctx, pass, salt, ad, secret, iter, lanes, memcost, out);
+            return argon2_helper(CStr::from_bytes_with_nul(b"ARGON2D\0").unwrap(), ctx, pass, salt, ad, secret, iter, lanes, memcost, out);
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -62,7 +62,7 @@ cfg_if::cfg_if! {
             memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            return argon2_helper(c"ARGON2I", ctx, pass, salt, ad, secret, iter, lanes, memcost, out);
+            return argon2_helper(CStr::from_bytes_with_nul(b"ARGON2I\0").unwrap(), ctx, pass, salt, ad, secret, iter, lanes, memcost, out);
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -77,7 +77,7 @@ cfg_if::cfg_if! {
             memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            return argon2_helper(c"ARGON2ID", ctx, pass, salt, ad, secret, iter, lanes, memcost, out);
+            return argon2_helper(CStr::from_bytes_with_nul(b"ARGON2ID\0").unwrap(), ctx, pass, salt, ad, secret, iter, lanes, memcost, out);
         }
 
         /// Derives a key using the argon2* algorithms.


### PR DESCRIPTION
Expose functionality of supplementary variants, Argon2d and Argon2i, as described in RFC 9106