### PR TITLE
Add aws-lc-fips feature to allow linking the aws-lc-fips-sys crate

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -19,11 +19,13 @@ rust-version = "1.63.0"
 vendored = ['openssl-src']
 unstable_boringssl = ['bssl-sys']
 aws-lc = ['dep:aws-lc-sys']
+aws-lc-fips = ['dep:aws-lc-fips-sys']
 
 [dependencies]
 libc = "0.2"
 bssl-sys = { version = "0.1.0", optional = true }
 aws-lc-sys = { version = "0.27", features = ["ssl"], optional = true }
+aws-lc-fips-sys = { version = "0.13", features = ["ssl", "bindgen"], optional = true }
 
 [build-dependencies]
 bindgen = { version = "0.69.0", optional = true, features = ["experimental"] }

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -35,10 +35,13 @@ extern crate aws_lc_sys;
 #[cfg(awslc)]
 #[path = "."]
 mod aws_lc {
-    #[cfg(feature = "aws-lc")]
+    #[cfg(all(feature = "aws-lc", not(feature = "aws-lc-fips")))]
     pub use aws_lc_sys::*;
 
-    #[cfg(not(feature = "aws-lc"))]
+    #[cfg(feature = "aws-lc-fips")]
+    pub use aws_lc_fips_sys::*;
+
+    #[cfg(not(any(feature = "aws-lc", feature = "aws-lc-fips")))]
     include!(concat!(env!("OUT_DIR"), "/bindgen.rs"));
 
     use libc::{c_char, c_long, c_void};

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -22,6 +22,7 @@ vendored = ['ffi/vendored']
 bindgen = ['ffi/bindgen']
 unstable_boringssl = ["ffi/unstable_boringssl"]
 aws-lc = ["ffi/aws-lc"]
+aws-lc-fips = ["ffi/aws-lc-fips"]
 default = []
 
 [dependencies]

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -12,6 +12,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(libressl)");
     println!("cargo:rustc-check-cfg=cfg(boringssl)");
     println!("cargo:rustc-check-cfg=cfg(awslc)");
+    println!("cargo:rustc-check-cfg=cfg(awslc_fips)");
 
     println!("cargo:rustc-check-cfg=cfg(libressl250)");
     println!("cargo:rustc-check-cfg=cfg(libressl251)");
@@ -57,6 +58,11 @@ fn main() {
 
     if env::var("DEP_OPENSSL_AWSLC").is_ok() {
         println!("cargo:rustc-cfg=awslc");
+    }
+
+    if env::var("DEP_OPENSSL_AWSLC_FIPS").is_ok() {
+        println!("cargo:rustc-cfg=awslc");
+        println!("cargo:rustc-cfg=awslc_fips");
     }
 
     if let Ok(v) = env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER") {

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -533,11 +533,11 @@ cfg_if! {
 mod test {
     use super::*;
     use crate::bn::BigNumContext;
-    #[cfg(not(boringssl))]
+    #[cfg(not(any(boringssl, awslc_fips)))]
     use crate::hash::MessageDigest;
-    #[cfg(not(boringssl))]
+    #[cfg(not(any(boringssl, awslc_fips)))]
     use crate::pkey::PKey;
-    #[cfg(not(boringssl))]
+    #[cfg(not(any(boringssl, awslc_fips)))]
     use crate::sign::{Signer, Verifier};
 
     #[test]
@@ -607,7 +607,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(boringssl))]
+    #[cfg(not(any(boringssl, awslc_fips)))]
     fn test_signature() {
         const TEST_DATA: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         let dsa_ref = Dsa::generate(1024).unwrap();
@@ -648,7 +648,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(boringssl))]
+    #[cfg(not(any(boringssl, awslc_fips)))]
     fn test_signature_der() {
         use std::convert::TryInto;
 

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -226,7 +226,7 @@ impl Pkcs12Builder {
     pub fn build2(&self, password: &str) -> Result<Pkcs12, ErrorStack> {
         unsafe {
             let pass = CString::new(password).unwrap();
-            #[cfg(not(boringssl))]
+            #[cfg(not(any(boringssl, awslc_fips)))]
             let pass_len = pass.as_bytes().len();
             let pass = pass.as_ptr();
             let friendly_name = self.name.as_ref().map_or(ptr::null(), |p| p.as_ptr());
@@ -259,7 +259,7 @@ impl Pkcs12Builder {
             ))
             .map(Pkcs12)?;
 
-            #[cfg(not(boringssl))]
+            #[cfg(not(any(boringssl, awslc_fips)))]
             // BoringSSL does not support overriding the MAC and will always
             // use SHA-1.
             {


### PR DESCRIPTION
Adds the ability for users to enable the `aws-lc-fips` crate feature, which when enabled will utilize the `aws-lc-fips-sys` crate for the AWS-LC bindings. This version of AWS-LC provides bindings to [AWS-LC-FIPS 3.x](https://github.com/aws/aws-lc/tree/fips-2024-09-27), which has completed FIPS validation testing by an accredited lab and has been submitted to NIST for certification.

Due to the nature of having two crate features for AWS-LC bidnings (`aws-lc`, and `aws-lc-fips`), this feature will take precedence if both features are specified due to feature unification by cargo.