### PR TITLE
Update OpenSSL documentation URLs to new docs.openssl.org domain

### DIFF
--- a/openssl-macros/src/lib.rs
+++ b/openssl-macros/src/lib.rs
@@ -12,7 +12,7 @@ pub fn corresponds(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let function = function.to_string();
     let line = format!(
-        "This corresponds to [`{0}`](https://www.openssl.org/docs/manmaster/man3/{0}.html).",
+        "This corresponds to [`{0}`](https://docs.openssl.org/master/man3/{0}/).",
         function
     );
 

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -57,7 +57,7 @@ foreign_type_and_impl_send_sync! {
     /// further details of implementation.  Note: these docs are from the master
     /// branch as documentation on the 1.1.0 branch did not include this page.
     ///
-    /// [ASN1_GENERALIZEDTIME_set]: https://www.openssl.org/docs/manmaster/man3/ASN1_GENERALIZEDTIME_set.html
+    /// [ASN1_GENERALIZEDTIME_set]: https://docs.openssl.org/master/man3/ASN1_GENERALIZEDTIME_set/
     pub struct Asn1GeneralizedTime;
     /// Reference to a [`Asn1GeneralizedTime`]
     ///
@@ -187,7 +187,7 @@ foreign_type_and_impl_send_sync! {
     /// [ASN_TIME_set] documentation at OpenSSL explains the ASN.1 implementation
     /// used by OpenSSL.
     ///
-    /// [ASN_TIME_set]: https://www.openssl.org/docs/manmaster/crypto/ASN1_TIME_set.html
+    /// [ASN_TIME_set]: https://docs.openssl.org/master/man3/ASN1_TIME_set/
     pub struct Asn1Time;
     /// Reference to an [`Asn1Time`]
     ///
@@ -423,7 +423,7 @@ foreign_type_and_impl_send_sync! {
     /// structures.  This implementation uses [ASN1_STRING-to_UTF8] to preserve
     /// compatibility with Rust's String.
     ///
-    /// [ASN1_STRING-to_UTF8]: https://www.openssl.org/docs/manmaster/crypto/ASN1_STRING_to_UTF8.html
+    /// [ASN1_STRING-to_UTF8]: https://docs.openssl.org/master/man3/ASN1_STRING_to_UTF8/
     pub struct Asn1String;
     /// A reference to an [`Asn1String`].
     pub struct Asn1StringRef;
@@ -492,7 +492,7 @@ foreign_type_and_impl_send_sync! {
     /// OpenSSL documentation includes [`ASN1_INTEGER_set`].
     ///
     /// [`bn`]: ../bn/index.html
-    /// [`ASN1_INTEGER_set`]: https://www.openssl.org/docs/manmaster/crypto/ASN1_INTEGER_set.html
+    /// [`ASN1_INTEGER_set`]: https://docs.openssl.org/master/man3/ASN1_INTEGER_set/
     pub struct Asn1Integer;
     /// A reference to an [`Asn1Integer`].
     pub struct Asn1IntegerRef;
@@ -504,7 +504,7 @@ impl Asn1Integer {
     /// Corresponds to [`BN_to_ASN1_INTEGER`]. Also see
     /// [`BigNumRef::to_asn1_integer`].
     ///
-    /// [`BN_to_ASN1_INTEGER`]: https://www.openssl.org/docs/manmaster/crypto/BN_to_ASN1_INTEGER.html
+    /// [`BN_to_ASN1_INTEGER`]: https://docs.openssl.org/master/man3/BN_to_ASN1_INTEGER/
     /// [`BigNumRef::to_asn1_integer`]: ../bn/struct.BigNumRef.html#method.to_asn1_integer
     pub fn from_bn(bn: &BigNumRef) -> Result<Self, ErrorStack> {
         bn.to_asn1_integer()
@@ -668,7 +668,7 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [`Nid`]: ../nid/index.html
     /// [`nid::COMMONNAME`]: ../nid/constant.COMMONNAME.html
-    /// [`OBJ_nid2obj`]: https://www.openssl.org/docs/manmaster/crypto/OBJ_obj2nid.html
+    /// [`OBJ_nid2obj`]: https://docs.openssl.org/master/man3/OBJ_obj2nid/
     pub struct Asn1Object;
     /// A reference to an [`Asn1Object`].
     pub struct Asn1ObjectRef;

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -101,7 +101,7 @@ foreign_type_and_impl_send_sync! {
     /// to allocate.  BigNumContext and the OpenSSL [`BN_CTX`] structure are used
     /// internally when passing BigNum values between subroutines.
     ///
-    /// [`BN_CTX`]: https://www.openssl.org/docs/manmaster/crypto/BN_CTX_new.html
+    /// [`BN_CTX`]: https://docs.openssl.org/master/man3/BN_CTX_new/
     pub struct BigNumContext;
     /// Reference to [`BigNumContext`]
     ///
@@ -144,7 +144,7 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [`new`]: struct.BigNum.html#method.new
     /// [`Dref<Target = BigNumRef>`]: struct.BigNum.html#deref-methods
-    /// [`BN_new`]: https://www.openssl.org/docs/manmaster/crypto/BN_new.html
+    /// [`BN_new`]: https://docs.openssl.org/master/man3/BN_new/
     ///
     /// # Examples
     /// ```
@@ -1103,10 +1103,6 @@ impl BigNum {
     }
 
     /// Creates a new `BigNum` from an unsigned, big-endian encoded number of arbitrary length.
-    ///
-    /// OpenSSL documentation at [`BN_bin2bn`]
-    ///
-    /// [`BN_bin2bn`]: https://www.openssl.org/docs/manmaster/crypto/BN_bin2bn.html
     ///
     /// ```
     /// # use openssl::bn::BigNum;

--- a/openssl/src/cms.rs
+++ b/openssl/src/cms.rs
@@ -206,9 +206,6 @@ impl CmsContentInfo {
     /// Given a certificate stack `certs`, data `data`, cipher `cipher` and flags `flags`,
     /// create a CmsContentInfo struct.
     ///
-    /// OpenSSL documentation at [`CMS_encrypt`]
-    ///
-    /// [`CMS_encrypt`]: https://www.openssl.org/docs/manmaster/man3/CMS_encrypt.html
     #[corresponds(CMS_encrypt)]
     pub fn encrypt(
         certs: &StackRef<X509>,

--- a/openssl/src/derive.rs
+++ b/openssl/src/derive.rs
@@ -67,10 +67,7 @@ unsafe impl Send for Deriver<'_> {}
 #[allow(clippy::len_without_is_empty)]
 impl<'a> Deriver<'a> {
     /// Creates a new `Deriver` using the provided private key.
-    ///
-    /// This corresponds to [`EVP_PKEY_derive_init`].
-    ///
-    /// [`EVP_PKEY_derive_init`]: https://www.openssl.org/docs/manmaster/crypto/EVP_PKEY_derive_init.html
+    #[corresponds(EVP_PKEY_derive_init)]
     pub fn new<T>(key: &'a PKeyRef<T>) -> Result<Deriver<'a>, ErrorStack>
     where
         T: HasPrivate,
@@ -118,10 +115,10 @@ impl<'a> Deriver<'a> {
     ///
     /// It can be used to size the buffer passed to [`Deriver::derive`].
     ///
-    /// This corresponds to [`EVP_PKEY_derive`].
+    /// It can be used to size the buffer passed to [`Deriver::derive`].
     ///
     /// [`Deriver::derive`]: #method.derive
-    /// [`EVP_PKEY_derive`]: https://www.openssl.org/docs/manmaster/crypto/EVP_PKEY_derive_init.html
+    #[corresponds(EVP_PKEY_derive)]
     pub fn len(&mut self) -> Result<usize, ErrorStack> {
         unsafe {
             let mut len = 0;
@@ -132,10 +129,7 @@ impl<'a> Deriver<'a> {
     /// Derives a shared secret between the two keys, writing it into the buffer.
     ///
     /// Returns the number of bytes written.
-    ///
-    /// This corresponds to [`EVP_PKEY_derive`].
-    ///
-    /// [`EVP_PKEY_derive`]: https://www.openssl.org/docs/manmaster/crypto/EVP_PKEY_derive_init.html
+    #[corresponds(EVP_PKEY_derive)]
     pub fn derive(&mut self, buf: &mut [u8]) -> Result<usize, ErrorStack> {
         let mut len = buf.len();
         unsafe {

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -38,7 +38,7 @@ generic_foreign_type_and_impl_send_sync! {
     ///
     /// OpenSSL documentation at [`DSA_new`]
     ///
-    /// [`DSA_new`]: https://www.openssl.org/docs/manmaster/crypto/DSA_new.html
+    /// [`DSA_new`]: https://docs.openssl.org/master/man3/DSA_new/
     ///
     /// # Examples
     ///

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -81,7 +81,7 @@ impl Asn1Flag {
     ///
     /// OpenSSL documentation at [`EC_GROUP`]
     ///
-    /// [`EC_GROUP`]: https://www.openssl.org/docs/manmaster/crypto/EC_GROUP_get_seed_len.html
+    /// [`EC_GROUP`]: https://docs.openssl.org/master/man3/EC_GROUP_get_seed_len/
     pub const EXPLICIT_CURVE: Asn1Flag = Asn1Flag(0);
 
     /// Standard Curves
@@ -91,7 +91,7 @@ impl Asn1Flag {
     ///
     /// OpenSSL documentation at [`EC_GROUP`]
     ///
-    /// [`EC_GROUP`]: https://www.openssl.org/docs/manmaster/man3/EC_GROUP_order_bits.html
+    /// [`EC_GROUP`]: https://docs.openssl.org/master/man3/EC_GROUP_order_bits/
     pub const NAMED_CURVE: Asn1Flag = Asn1Flag(ffi::OPENSSL_EC_NAMED_CURVE);
 }
 

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -49,6 +49,7 @@ use crate::pkey::{HasPrivate, HasPublic, PKeyRef};
 use crate::rsa::Padding;
 use crate::{cvt, cvt_p};
 use foreign_types::ForeignTypeRef;
+use openssl_macros::corresponds;
 
 /// A type which encrypts data.
 pub struct Encrypter<'a> {
@@ -69,10 +70,7 @@ impl Drop for Encrypter<'_> {
 
 impl<'a> Encrypter<'a> {
     /// Creates a new `Encrypter`.
-    ///
-    /// OpenSSL documentation at [`EVP_PKEY_encrypt_init`].
-    ///
-    /// [`EVP_PKEY_encrypt_init`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt_init.html
+    #[corresponds(EVP_PKEY_encrypt_init)]
     pub fn new<T>(pkey: &'a PKeyRef<T>) -> Result<Encrypter<'a>, ErrorStack>
     where
         T: HasPublic,
@@ -110,10 +108,7 @@ impl<'a> Encrypter<'a> {
     /// Sets the RSA padding mode.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_padding`].
-    ///
-    /// [`EVP_PKEY_CTX_set_rsa_padding`]: https://www.openssl.org/docs/manmaster/crypto/EVP_PKEY_CTX_set_rsa_padding.html
+    #[corresponds(EVP_PKEY_CTX_set_rsa_padding)]
     pub fn set_rsa_padding(&mut self, padding: Padding) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_padding(
@@ -127,10 +122,7 @@ impl<'a> Encrypter<'a> {
     /// Sets the RSA MGF1 algorithm.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_mgf1_md`].
-    ///
-    /// [`EVP_PKEY_CTX_set_rsa_mgf1_md`]: https://www.openssl.org/docs/manmaster/man7/RSA-PSS.html
+    #[corresponds(EVP_PKEY_CTX_set_rsa_mgf1_md)]
     pub fn set_rsa_mgf1_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_mgf1_md(
@@ -144,10 +136,7 @@ impl<'a> Encrypter<'a> {
     /// Sets the RSA OAEP algorithm.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
-    ///
-    /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
+    #[corresponds(EVP_PKEY_CTX_set_rsa_oaep_md)]
     #[cfg(any(ossl102, libressl310, boringssl, awslc))]
     pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
@@ -162,10 +151,7 @@ impl<'a> Encrypter<'a> {
     /// Sets the RSA OAEP label.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set0_rsa_oaep_label`].
-    ///
-    /// [`EVP_PKEY_CTX_set0_rsa_oaep_label`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set0_rsa_oaep_label.html
+    #[corresponds(EVP_PKEY_CTX_set0_rsa_oaep_label)]
     #[cfg(any(ossl102, libressl310))]
     pub fn set_rsa_oaep_label(&mut self, label: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
@@ -215,9 +201,7 @@ impl<'a> Encrypter<'a> {
     /// let encoded = &encoded[..encoded_len];
     /// ```
     ///
-    /// This corresponds to [`EVP_PKEY_encrypt`].
-    ///
-    /// [`EVP_PKEY_encrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt.html
+    #[corresponds(EVP_PKEY_encrypt)]
     pub fn encrypt(&self, from: &[u8], to: &mut [u8]) -> Result<usize, ErrorStack> {
         let mut written = to.len();
         unsafe {
@@ -235,9 +219,8 @@ impl<'a> Encrypter<'a> {
 
     /// Gets the size of the buffer needed to encrypt the input data.
     ///
-    /// This corresponds to [`EVP_PKEY_encrypt`] called with a null pointer as output argument.
-    ///
-    /// [`EVP_PKEY_encrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_encrypt.html
+    /// This corresponds to `EVP_PKEY_encrypt` called with a null pointer as output argument.
+    #[corresponds(EVP_PKEY_encrypt)]
     pub fn encrypt_len(&self, from: &[u8]) -> Result<usize, ErrorStack> {
         let mut written = 0;
         unsafe {
@@ -273,10 +256,7 @@ impl Drop for Decrypter<'_> {
 
 impl<'a> Decrypter<'a> {
     /// Creates a new `Decrypter`.
-    ///
-    /// OpenSSL documentation at [`EVP_PKEY_decrypt_init`].
-    ///
-    /// [`EVP_PKEY_decrypt_init`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_decrypt_init.html
+    #[corresponds(EVP_PKEY_decrypt_init)]
     pub fn new<T>(pkey: &'a PKeyRef<T>) -> Result<Decrypter<'a>, ErrorStack>
     where
         T: HasPrivate,
@@ -314,10 +294,7 @@ impl<'a> Decrypter<'a> {
     /// Sets the RSA padding mode.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_padding`].
-    ///
-    /// [`EVP_PKEY_CTX_set_rsa_padding`]: https://www.openssl.org/docs/manmaster/crypto/EVP_PKEY_CTX_set_rsa_padding.html
+    #[corresponds(EVP_PKEY_CTX_set_rsa_padding)]
     pub fn set_rsa_padding(&mut self, padding: Padding) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_padding(
@@ -331,10 +308,7 @@ impl<'a> Decrypter<'a> {
     /// Sets the RSA MGF1 algorithm.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_mgf1_md`].
-    ///
-    /// [`EVP_PKEY_CTX_set_rsa_mgf1_md`]: https://www.openssl.org/docs/manmaster/man7/RSA-PSS.html
+    #[corresponds(EVP_PKEY_CTX_set_rsa_mgf1_md)]
     pub fn set_rsa_mgf1_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::EVP_PKEY_CTX_set_rsa_mgf1_md(
@@ -348,10 +322,7 @@ impl<'a> Decrypter<'a> {
     /// Sets the RSA OAEP algorithm.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set_rsa_oaep_md`].
-    ///
-    /// [`EVP_PKEY_CTX_set_rsa_oaep_md`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set_rsa_oaep_md.html
+    #[corresponds(EVP_PKEY_CTX_set_rsa_oaep_md)]
     #[cfg(any(ossl102, libressl310, boringssl, awslc))]
     pub fn set_rsa_oaep_md(&mut self, md: MessageDigest) -> Result<(), ErrorStack> {
         unsafe {
@@ -366,10 +337,7 @@ impl<'a> Decrypter<'a> {
     /// Sets the RSA OAEP label.
     ///
     /// This is only useful for RSA keys.
-    ///
-    /// This corresponds to [`EVP_PKEY_CTX_set0_rsa_oaep_label`].
-    ///
-    /// [`EVP_PKEY_CTX_set0_rsa_oaep_label`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_CTX_set0_rsa_oaep_label.html
+    #[corresponds(EVP_PKEY_CTX_set0_rsa_oaep_label)]
     #[cfg(any(ossl102, libressl310))]
     pub fn set_rsa_oaep_label(&mut self, label: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
@@ -434,9 +402,7 @@ impl<'a> Decrypter<'a> {
     /// let decoded = &decoded[..decoded_len];
     /// ```
     ///
-    /// This corresponds to [`EVP_PKEY_decrypt`].
-    ///
-    /// [`EVP_PKEY_decrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_decrypt.html
+    #[corresponds(EVP_PKEY_decrypt)]
     pub fn decrypt(&self, from: &[u8], to: &mut [u8]) -> Result<usize, ErrorStack> {
         let mut written = to.len();
         unsafe {
@@ -454,9 +420,8 @@ impl<'a> Decrypter<'a> {
 
     /// Gets the size of the buffer needed to decrypt the input data.
     ///
-    /// This corresponds to [`EVP_PKEY_decrypt`] called with a null pointer as output argument.
-    ///
-    /// [`EVP_PKEY_decrypt`]: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_decrypt.html
+    /// This corresponds to `EVP_PKEY_decrypt` called with a null pointer as output argument.
+    #[corresponds(EVP_PKEY_decrypt)]
     pub fn decrypt_len(&self, from: &[u8]) -> Result<usize, ErrorStack> {
         let mut written = 0;
         unsafe {

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -44,7 +44,7 @@ pub struct SignatureAlgorithms {
 /// The following documentation provides context about `Nid`s and their usage
 /// in OpenSSL.
 ///
-/// - [Obj_nid2obj](https://www.openssl.org/docs/manmaster/crypto/OBJ_create.html)
+/// - [Obj_nid2obj](https://docs.openssl.org/master/man3/OBJ_create/)
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Nid(c_int);
 

--- a/openssl/src/pkcs12.rs
+++ b/openssl/src/pkcs12.rs
@@ -242,7 +242,7 @@ impl Pkcs12Builder {
 
             // According to the OpenSSL docs, keytype is a non-standard extension for MSIE,
             // It's values are KEY_SIG or KEY_EX, see the OpenSSL docs for more information:
-            // https://www.openssl.org/docs/manmaster/crypto/PKCS12_create.html
+            // https://docs.openssl.org/master/man3/PKCS12_create/
             let keytype = 0;
 
             let pkcs12 = cvt_p(ffi::PKCS12_create(

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -376,8 +376,8 @@ impl Rsa<Public> {
     ///
     /// This corresponds to [`RSA_new`] and uses [`RSA_set0_key`].
     ///
-    /// [`RSA_new`]: https://www.openssl.org/docs/manmaster/crypto/RSA_new.html
-    /// [`RSA_set0_key`]: https://www.openssl.org/docs/manmaster/crypto/RSA_set0_key.html
+    /// [`RSA_new`]: https://docs.openssl.org/master/man3/RSA_new/
+    /// [`RSA_set0_key`]: https://docs.openssl.org/master/man3/RSA_set0_key/
     pub fn from_public_components(n: BigNum, e: BigNum) -> Result<Rsa<Public>, ErrorStack> {
         unsafe {
             let rsa = cvt_p(ffi::RSA_new())?;
@@ -436,8 +436,8 @@ impl RsaPrivateKeyBuilder {
     ///
     /// This corresponds to [`RSA_new`] and uses [`RSA_set0_key`].
     ///
-    /// [`RSA_new`]: https://www.openssl.org/docs/manmaster/crypto/RSA_new.html
-    /// [`RSA_set0_key`]: https://www.openssl.org/docs/manmaster/crypto/RSA_set0_key.html
+    /// [`RSA_new`]: https://docs.openssl.org/master/man3/RSA_new/
+    /// [`RSA_set0_key`]: https://docs.openssl.org/master/man3/RSA_set0_key/
     pub fn new(n: BigNum, e: BigNum, d: BigNum) -> Result<RsaPrivateKeyBuilder, ErrorStack> {
         unsafe {
             let rsa = cvt_p(ffi::RSA_new())?;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1097,7 +1097,7 @@ impl SslContextBuilder {
     ///
     /// See [`ciphers`] for details on the format.
     ///
-    /// [`ciphers`]: https://www.openssl.org/docs/manmaster/apps/ciphers.html
+    /// [`ciphers`]: https://docs.openssl.org/master/man1/ciphers/
     #[corresponds(SSL_CTX_set_cipher_list)]
     pub fn set_cipher_list(&mut self, cipher_list: &str) -> Result<(), ErrorStack> {
         let cipher_list = CString::new(cipher_list).unwrap();
@@ -2739,7 +2739,7 @@ impl SslRef {
     /// is not valid UTF-8, this function will return `None`. The `servername_raw` method returns
     /// the raw bytes and does not have this restriction.
     ///
-    /// [`SSL_get_servername`]: https://www.openssl.org/docs/manmaster/man3/SSL_get_servername.html
+    /// [`SSL_get_servername`]: https://docs.openssl.org/master/man3/SSL_get_servername/
     #[corresponds(SSL_get_servername)]
     // FIXME maybe rethink in 0.11?
     pub fn servername(&self, type_: NameType) -> Option<&str> {
@@ -3405,7 +3405,7 @@ impl SslRef {
     ///
     /// See [`ciphers`] for details on the format.
     ///
-    /// [`ciphers`]: https://www.openssl.org/docs/manmaster/apps/ciphers.html
+    /// [`ciphers`]: https://docs.openssl.org/master/man1/ciphers/
     #[corresponds(SSL_set_cipher_list)]
     pub fn set_cipher_list(&mut self, cipher_list: &str) -> Result<(), ErrorStack> {
         let cipher_list = CString::new(cipher_list).unwrap();

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -69,7 +69,7 @@ pub enum Mode {
 ///
 /// See OpenSSL doc at [`EVP_EncryptInit`] for more information on each algorithms.
 ///
-/// [`EVP_EncryptInit`]: https://www.openssl.org/docs/manmaster/crypto/EVP_EncryptInit.html
+/// [`EVP_EncryptInit`]: https://docs.openssl.org/master/man3/EVP_EncryptInit/
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Cipher(*const ffi::EVP_CIPHER);
 

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -121,8 +121,8 @@ impl X509StoreContextRef {
     /// This corresponds to [`X509_STORE_CTX_init`] before calling `with_context` and to
     /// [`X509_STORE_CTX_cleanup`] after calling `with_context`.
     ///
-    /// [`X509_STORE_CTX_init`]:  https://www.openssl.org/docs/manmaster/crypto/X509_STORE_CTX_init.html
-    /// [`X509_STORE_CTX_cleanup`]:  https://www.openssl.org/docs/manmaster/crypto/X509_STORE_CTX_cleanup.html
+    /// [`X509_STORE_CTX_init`]:  https://docs.openssl.org/master/man3/X509_STORE_CTX_init/
+    /// [`X509_STORE_CTX_cleanup`]:  https://docs.openssl.org/master/man3/X509_STORE_CTX_cleanup/
     pub fn init<F, T>(
         &mut self,
         trust: &store::X509StoreRef,
@@ -1206,7 +1206,7 @@ impl X509Name {
         ///
         /// This corresponds to [`d2i_X509_NAME`].
         ///
-        /// [`d2i_X509_NAME`]: https://www.openssl.org/docs/manmaster/man3/d2i_X509_NAME.html
+        /// [`d2i_X509_NAME`]: https://docs.openssl.org/master/man3/d2i_X509_NAME/
         from_der,
         X509Name,
         ffi::d2i_X509_NAME
@@ -1263,7 +1263,7 @@ impl X509NameRef {
         ///
         /// This corresponds to [`i2d_X509_NAME`].
         ///
-        /// [`i2d_X509_NAME`]: https://www.openssl.org/docs/manmaster/crypto/i2d_X509_NAME.html
+        /// [`i2d_X509_NAME`]: https://docs.openssl.org/master/man3/i2d_X509_NAME/
         to_der,
         ffi::i2d_X509_NAME
     }
@@ -1479,7 +1479,7 @@ impl X509Req {
         ///
         /// This corresponds to [`PEM_read_bio_X509_REQ`].
         ///
-        /// [`PEM_read_bio_X509_REQ`]: https://www.openssl.org/docs/manmaster/crypto/PEM_read_bio_X509_REQ.html
+        /// [`PEM_read_bio_X509_REQ`]: https://docs.openssl.org/master/man3/PEM_read_bio_X509_REQ/
         from_pem,
         X509Req,
         ffi::PEM_read_bio_X509_REQ
@@ -1490,7 +1490,7 @@ impl X509Req {
         ///
         /// This corresponds to [`d2i_X509_REQ`].
         ///
-        /// [`d2i_X509_REQ`]: https://www.openssl.org/docs/manmaster/crypto/d2i_X509_REQ.html
+        /// [`d2i_X509_REQ`]: https://docs.openssl.org/master/man3/d2i_X509_REQ/
         from_der,
         X509Req,
         ffi::d2i_X509_REQ
@@ -1505,7 +1505,7 @@ impl X509ReqRef {
         ///
         /// This corresponds to [`PEM_write_bio_X509_REQ`].
         ///
-        /// [`PEM_write_bio_X509_REQ`]: https://www.openssl.org/docs/manmaster/crypto/PEM_write_bio_X509_REQ.html
+        /// [`PEM_write_bio_X509_REQ`]: https://docs.openssl.org/master/man3/PEM_write_bio_X509_REQ/
         to_pem,
         ffi::PEM_write_bio_X509_REQ
     }
@@ -1515,7 +1515,7 @@ impl X509ReqRef {
         ///
         /// This corresponds to [`i2d_X509_REQ`].
         ///
-        /// [`i2d_X509_REQ`]: https://www.openssl.org/docs/manmaster/crypto/i2d_X509_REQ.html
+        /// [`i2d_X509_REQ`]: https://docs.openssl.org/master/man3/i2d_X509_REQ/
         to_der,
         ffi::i2d_X509_REQ
     }
@@ -1740,7 +1740,7 @@ foreign_type_and_impl_send_sync! {
 ///
 /// Corresponds to the return value from the [`X509_CRL_get0_by_*`] methods.
 ///
-/// [`X509_CRL_get0_by_*`]: https://www.openssl.org/docs/man1.1.0/man3/X509_CRL_get0_by_serial.html
+/// [`X509_CRL_get0_by_*`]: https://docs.openssl.org/master/man3/X509_CRL_get0_by_serial/
 pub enum CrlStatus<'a> {
     /// The certificate is not present in the list
     NotRevoked,

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -155,7 +155,7 @@ generic_foreign_type_and_impl_send_sync! {
 
 /// Marker type corresponding to the [`X509_LOOKUP_hash_dir`] lookup method.
 ///
-/// [`X509_LOOKUP_hash_dir`]: https://www.openssl.org/docs/manmaster/crypto/X509_LOOKUP_hash_dir.html
+/// [`X509_LOOKUP_hash_dir`]: https://docs.openssl.org/master/man3/X509_LOOKUP_hash_dir/
 // FIXME should be an enum
 pub struct HashDir;
 
@@ -190,7 +190,7 @@ impl X509LookupRef<HashDir> {
 
 /// Marker type corresponding to the [`X509_LOOKUP_file`] lookup method.
 ///
-/// [`X509_LOOKUP_file`]: https://www.openssl.org/docs/man1.1.1/man3/X509_LOOKUP_file.html
+/// [`X509_LOOKUP_file`]: https://docs.openssl.org/master/man3/X509_LOOKUP_file/
 pub struct File;
 
 impl X509Lookup<File> {


### PR DESCRIPTION
Updates all documentation links to use the new docs.openssl.org domain and replaces manual URLs with #[corresponds()] attributes where appropriate.

🤖 Generated with [Claude Code](https://claude.ai/code)