### PR TITLE
pkey_ctx: add ability to generate DSA params & keys

### DIFF
--- a/openssl-sys/src/dsa.rs
+++ b/openssl-sys/src/dsa.rs
@@ -1,0 +1,21 @@
+use libc::*;
+use std::ptr;
+
+use super::super::*;
+
+cfg_if! {
+    if #[cfg(not(ossl300))] {
+        pub unsafe fn EVP_PKEY_CTX_set_dsa_paramgen_bits(ctx: *mut EVP_PKEY_CTX, nbits: c_int) -> c_int {
+            EVP_PKEY_CTX_ctrl(
+                ctx,
+                EVP_PKEY_DSA,
+                EVP_PKEY_OP_PARAMGEN,
+                EVP_PKEY_CTRL_DSA_PARAMGEN_BITS,
+                nbits,
+                ptr::null_mut(),
+            )
+        }
+    }
+}
+
+pub const EVP_PKEY_CTRL_DSA_PARAMGEN_BITS: c_int = EVP_PKEY_ALG_CTRL + 1;

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -162,6 +162,7 @@ cfg_if! {
     }
 }
 
+pub const EVP_PKEY_OP_PARAMGEN: c_int = 1 << 1;
 pub const EVP_PKEY_OP_KEYGEN: c_int = 1 << 2;
 cfg_if! {
     if #[cfg(ossl300)] {

--- a/openssl-sys/src/handwritten/dsa.rs
+++ b/openssl-sys/src/handwritten/dsa.rs
@@ -2,6 +2,11 @@ use libc::*;
 
 use super::super::*;
 
+#[cfg(ossl300)]
+extern "C" {
+    pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(ctx: *mut EVP_PKEY_CTX, nbits: c_int) -> c_int;
+}
+
 cfg_if! {
     if #[cfg(any(ossl110, libressl280))] {
         pub enum DSA_SIG {}

--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -584,7 +584,9 @@ extern "C" {
         ...
     ) -> *mut EVP_PKEY;
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> c_int;
+    pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> c_int;
     pub fn EVP_PKEY_keygen(ctx: *mut EVP_PKEY_CTX, key: *mut *mut EVP_PKEY) -> c_int;
+    pub fn EVP_PKEY_paramgen(ctx: *mut EVP_PKEY_CTX, key: *mut *mut EVP_PKEY) -> c_int;
 
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> c_int;
     pub fn EVP_PKEY_sign(

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -73,6 +73,7 @@ mod openssl {
     pub use self::bn::*;
     pub use self::cms::*;
     pub use self::crypto::*;
+    pub use self::dsa::*;
     pub use self::dtls1::*;
     pub use self::ec::*;
     pub use self::err::*;
@@ -103,6 +104,7 @@ mod openssl {
     mod bn;
     mod cms;
     mod crypto;
+    mod dsa;
     mod dtls1;
     mod ec;
     mod err;

--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -447,6 +447,22 @@ impl<T> PkeyCtxRef<T> {
         Ok(())
     }
 
+    /// Sets the DSA paramgen bits.
+    ///
+    /// This is only useful for DSA keys.
+    #[corresponds(EVP_PKEY_CTX_set_dsa_paramgen_bits)]
+    #[inline]
+    pub fn set_dsa_paramgen_bits(&mut self, bits: u32) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_CTX_set_dsa_paramgen_bits(
+                self.as_ptr(),
+                bits as i32,
+            ))?;
+        }
+
+        Ok(())
+    }
+
     /// Returns the RSA padding mode in use.
     ///
     /// This is only useful for RSA keys.

--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -68,7 +68,7 @@ let cmac_key = ctx.keygen().unwrap();
 use crate::cipher::CipherRef;
 use crate::error::ErrorStack;
 use crate::md::MdRef;
-use crate::pkey::{HasPrivate, HasPublic, Id, PKey, PKeyRef, Private};
+use crate::pkey::{HasPrivate, HasPublic, Id, PKey, PKeyRef, Params, Private};
 use crate::rsa::Padding;
 use crate::sign::RsaPssSaltlen;
 use crate::{cvt, cvt_p};
@@ -420,6 +420,17 @@ impl<T> PkeyCtxRef<T> {
         Ok(())
     }
 
+    /// Prepares the context for key parameter generation.
+    #[corresponds(EVP_PKEY_paramgen_init)]
+    #[inline]
+    pub fn paramgen_init(&mut self) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_paramgen_init(self.as_ptr()))?;
+        }
+
+        Ok(())
+    }
+
     /// Sets which algorithm was used to compute the digest used in a
     /// signature. With RSA signatures this causes the signature to be wrapped
     /// in a `DigestInfo` structure. This is almost always what you want with
@@ -730,6 +741,17 @@ impl<T> PkeyCtxRef<T> {
         unsafe {
             let mut key = ptr::null_mut();
             cvt(ffi::EVP_PKEY_keygen(self.as_ptr(), &mut key))?;
+            Ok(PKey::from_ptr(key))
+        }
+    }
+
+    /// Generates a new set of key parameters.
+    #[corresponds(EVP_PKEY_paramgen)]
+    #[inline]
+    pub fn paramgen(&mut self) -> Result<PKey<Params>, ErrorStack> {
+        unsafe {
+            let mut key = ptr::null_mut();
+            cvt(ffi::EVP_PKEY_paramgen(self.as_ptr(), &mut key))?;
             Ok(PKey::from_ptr(key))
         }
     }


### PR DESCRIPTION
Progress towards #2047 by adding ability to generate DSA params using the EVP_* interfaces (rather than the deprecated DSA_* interfaces, excluding boring because they [removed support for DSA in PKEY_CTX](https://github.com/google/boringssl/commit/2e295b91a3c441d32f985bef0dcff5e639f1f448)).

- **sys/evp: add EVP_PKEY_paramgen & init**
- **pkey_ctx: add paramgen & init**
- **sys/dsa: add EVP_PKEY_CTX_set_dsa_paramgen_bits**
- **pkey_ctx: add set dsa paramgen bits**
- **pkey_ctx: add dsa params generation test**
