### PR TITLE
pkey_ctx: add ability to generate DH params & keys

### DIFF
--- a/openssl-sys/src/dh.rs
+++ b/openssl-sys/src/dh.rs
@@ -1,0 +1,32 @@
+use libc::*;
+use std::ptr;
+
+use super::super::*;
+
+cfg_if! {
+    if #[cfg(not(ossl300))] {
+        pub unsafe fn EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx: *mut EVP_PKEY_CTX, len: c_int) -> c_int {
+            EVP_PKEY_CTX_ctrl(
+                ctx,
+                EVP_PKEY_DH,
+                EVP_PKEY_OP_PARAMGEN,
+                EVP_PKEY_CTRL_DH_PARAMGEN_PRIME_LEN,
+                len,
+                ptr::null_mut(),
+            )
+        }
+        pub unsafe fn EVP_PKEY_CTX_set_dh_paramgen_generator(ctx: *mut EVP_PKEY_CTX, gen: c_int) -> c_int {
+            EVP_PKEY_CTX_ctrl(
+                ctx,
+                EVP_PKEY_DH,
+                EVP_PKEY_OP_PARAMGEN,
+                EVP_PKEY_CTRL_DH_PARAMGEN_GENERATOR,
+                gen,
+                ptr::null_mut(),
+            )
+        }
+    }
+}
+
+pub const EVP_PKEY_CTRL_DH_PARAMGEN_PRIME_LEN: c_int = EVP_PKEY_ALG_CTRL + 1;
+pub const EVP_PKEY_CTRL_DH_PARAMGEN_GENERATOR: c_int = EVP_PKEY_ALG_CTRL + 2;

--- a/openssl-sys/src/handwritten/dh.rs
+++ b/openssl-sys/src/handwritten/dh.rs
@@ -1,5 +1,11 @@
 use super::super::*;
 
+#[cfg(ossl300)]
+extern "C" {
+    pub fn EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx: *mut EVP_PKEY_CTX, len: c_int) -> c_int;
+    pub fn EVP_PKEY_CTX_set_dh_paramgen_generator(ctx: *mut EVP_PKEY_CTX, gen: c_int) -> c_int;
+}
+
 extern "C" {
     pub fn DH_new() -> *mut DH;
     pub fn DH_free(dh: *mut DH);

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -73,6 +73,7 @@ mod openssl {
     pub use self::bn::*;
     pub use self::cms::*;
     pub use self::crypto::*;
+    pub use self::dh::*;
     pub use self::dsa::*;
     pub use self::dtls1::*;
     pub use self::ec::*;
@@ -104,6 +105,7 @@ mod openssl {
     mod bn;
     mod cms;
     mod crypto;
+    mod dh;
     mod dsa;
     mod dtls1;
     mod ec;

--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -448,6 +448,40 @@ impl<T> PkeyCtxRef<T> {
         Ok(())
     }
 
+    /// Sets the DH paramgen prime length.
+    ///
+    /// This is only useful for DH keys.
+    #[corresponds(EVP_PKEY_CTX_set_dh_paramgen_prime_len)]
+    #[cfg(not(boringssl))]
+    #[inline]
+    pub fn set_dh_paramgen_prime_len(&mut self, bits: u32) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_CTX_set_dh_paramgen_prime_len(
+                self.as_ptr(),
+                bits as i32,
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    /// Sets the DH paramgen generator.
+    ///
+    /// This is only useful for DH keys.
+    #[corresponds(EVP_PKEY_CTX_set_dh_paramgen_generator)]
+    #[cfg(not(boringssl))]
+    #[inline]
+    pub fn set_dh_paramgen_generator(&mut self, bits: u32) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EVP_PKEY_CTX_set_dh_paramgen_generator(
+                self.as_ptr(),
+                bits as i32,
+            ))?;
+        }
+
+        Ok(())
+    }
+
     /// Sets the DSA paramgen bits.
     ///
     /// This is only useful for DSA keys.

--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -1013,6 +1013,18 @@ mod test {
 
     #[test]
     #[cfg(not(boringssl))]
+    fn dh_paramgen() {
+        let mut ctx = PkeyCtx::new_id(Id::DH).unwrap();
+        ctx.paramgen_init().unwrap();
+        ctx.set_dh_paramgen_prime_len(512).unwrap();
+        ctx.set_dh_paramgen_generator(2).unwrap();
+        let params = ctx.paramgen().unwrap();
+
+        assert_eq!(params.size(), 64);
+    }
+
+    #[test]
+    #[cfg(not(boringssl))]
     fn dsa_paramgen() {
         let mut ctx = PkeyCtx::new_id(Id::DSA).unwrap();
         ctx.paramgen_init().unwrap();


### PR DESCRIPTION
Progress towards #2047 by adding ability to generate DH keys using the EVP_* interfaces (rather than the deprecated DH_* interfaces).

- **sys/dh: add EVP_PKEY_CTX set dh prime_len & generator**
- **pkey_ctx: add set dh prime_len and generator**
- **pkey_ctx: dh params & key generation test**
