### PR TITLE
Update bindgen; Update MSRV to 1.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,31 @@ members = [
     "openssl-sys",
     "systest",
 ]
+
+[workspace.dependencies]
+aws-lc-fips-sys = { version = "0.13", features = ["ssl", "bindgen"] }
+aws-lc-sys = { version = "0.30.0", features = ["ssl"] }
+bitflags = "2.2.1"
+bssl-sys = { version = "0.1.0" }
+cfg-if = "1.0"
+foreign-types = "0.3.1"
+hex = "0.4"
+libc = "0.2"
+once_cell = "1.5.2"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+
+# Build dependencies
+bindgen = { version = "0.69.0", features = ["experimental"] }
+cc = "1.0.61"
+openssl-src = { version = "300.2.0",  features = ["legacy"] }
+pkg-config = "0.3.9"
+vcpkg = "0.2.8"
+ctest = "0.4.11"
+
+# Workspace dependencies
+openssl-macros = { path = "./openssl-macros" }
+openssl-sys = { path = "./openssl-sys" }
+openssl = { path = "./openssl" }
+ffi = { package = "openssl-sys",  path = "./openssl-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ quote = "1"
 syn = { version = "2", features = ["full"] }
 
 # Build dependencies
-bindgen = { version = "0.69.0", features = ["experimental"] }
+bindgen = { version = "0.72.0", features = ["experimental"] }
 cc = "1.0.61"
 openssl-src = { version = "300.2.0",  features = ["legacy"] }
 pkg-config = "0.3.9"

--- a/openssl-errors/Cargo.toml
+++ b/openssl-errors/Cargo.toml
@@ -8,13 +8,13 @@ description = "Custom error library support for the openssl crate."
 repository = "https://github.com/sfackler/rust-openssl"
 readme = "README.md"
 categories = ["api-bindings"]
-rust-version = "1.63.0"
+rust-version = "1.70.0"
 
 [dependencies]
-cfg-if = "1.0"
-libc = "0.2"
+cfg-if.workspace = true
+libc.workspace = true
 
-openssl-sys = { version = "0.9.64", path = "../openssl-sys" }
+openssl-sys.workspace = true
 
 [dev-dependencies]
-openssl = { version = "0.10.19", path = "../openssl" }
+openssl.workspace = true

--- a/openssl-macros/Cargo.toml
+++ b/openssl-macros/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Internal macros used by the openssl crate."
 repository = "https://github.com/sfackler/rust-openssl"
-rust-version = "1.63.0"
+rust-version = "1.70.0"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "2", features = ["full"] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -20,6 +20,7 @@ vendored = ['openssl-src']
 unstable_boringssl = ['bssl-sys']
 aws-lc = ['dep:aws-lc-sys']
 aws-lc-fips = ['dep:aws-lc-fips-sys']
+bindgen = ['dep:bindgen']
 
 [dependencies]
 libc.workspace = true

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "external-ffi-bindings"]
 links = "openssl"
 build = "build/main.rs"
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.70.0"
 
 [features]
 vendored = ['openssl-src']
@@ -22,17 +22,17 @@ aws-lc = ['dep:aws-lc-sys']
 aws-lc-fips = ['dep:aws-lc-fips-sys']
 
 [dependencies]
-libc = "0.2"
-bssl-sys = { version = "0.1.0", optional = true }
-aws-lc-sys = { version = "0.27", features = ["ssl"], optional = true }
-aws-lc-fips-sys = { version = "0.13", features = ["ssl", "bindgen"], optional = true }
+libc.workspace = true
+bssl-sys = { workspace = true, optional = true}
+aws-lc-sys = { workspace = true, optional = true}
+aws-lc-fips-sys = { workspace = true, optional = true}
 
 [build-dependencies]
-bindgen = { version = "0.69.0", optional = true, features = ["experimental"] }
-cc = "1.0.61"
-openssl-src = { version = "300.2.0", optional = true, features = ["legacy"] }
-pkg-config = "0.3.9"
-vcpkg = "0.2.8"
+bindgen = { workspace = true, optional = true }
+cc.workspace = true
+openssl-src = { workspace = true, optional = true }
+pkg-config.workspace = true
+vcpkg.workspace = true
 
 # We don't actually use metadeps for annoying reasons but this is still here for tooling
 [package.metadata.pkg-config]

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -38,7 +38,7 @@ fn resolve_with_wellknown_homebrew_location(dir: &str) -> Option<PathBuf> {
     // for quick resolution if possible.
     //  `pkg-config` on brew doesn't necessarily contain settings for openssl apparently.
     for version in &versions {
-        let homebrew = Path::new(dir).join(format!("opt/{}", version));
+        let homebrew = Path::new(dir).join(format!("opt/{version}"));
         if homebrew.exists() {
             return Some(homebrew);
         }
@@ -199,7 +199,7 @@ https://github.com/sfackler/rust-openssl#windows
         );
     }
 
-    eprintln!("{}", msg);
+    eprintln!("{msg}");
     std::process::exit(101); // same as panic previously
 }
 
@@ -225,7 +225,7 @@ fn try_pkg_config() {
     {
         Ok(lib) => lib,
         Err(e) => {
-            println!("\n\nCould not find openssl via pkg-config:\n{}\n", e);
+            println!("\n\nCould not find openssl via pkg-config:\n{e}\n");
             return;
         }
     };
@@ -258,7 +258,7 @@ fn try_vcpkg() {
     {
         Ok(lib) => lib,
         Err(e) => {
-            println!("note: vcpkg did not find openssl: {}", e);
+            println!("note: vcpkg did not find openssl: {e}");
             return;
         }
     };

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -1,8 +1,3 @@
-#![allow(
-    // This can be removed once our MSRV is raised to 1.66.
-    clippy::uninlined_format_args,
-)]
-
 #[cfg(feature = "bindgen")]
 extern crate bindgen;
 extern crate cc;
@@ -34,11 +29,11 @@ enum Version {
 
 fn env_inner(name: &str) -> Option<OsString> {
     let var = env::var_os(name);
-    println!("cargo:rerun-if-env-changed={}", name);
+    println!("cargo:rerun-if-env-changed={name}");
 
     match var {
         Some(ref v) => println!("{} = {}", name, v.to_string_lossy()),
-        None => println!("{} unset", name),
+        None => println!("{name} unset"),
     }
 
     var
@@ -46,7 +41,7 @@ fn env_inner(name: &str) -> Option<OsString> {
 
 fn env(name: &str) -> Option<OsString> {
     let prefix = env::var("TARGET").unwrap().to_uppercase().replace('-', "_");
-    let prefixed = format!("{}_{}", prefix, name);
+    let prefixed = format!("{prefix}_{name}");
     env_inner(&prefixed).or_else(|| env_inner(name))
 }
 
@@ -69,9 +64,9 @@ fn check_ssl_kind() {
 
         if let Ok(vars) = env::var("DEP_BSSL_CONF") {
             for var in vars.split(',') {
-                println!("cargo:rustc-cfg=osslconf=\"{}\"", var);
+                println!("cargo:rustc-cfg=osslconf=\"{var}\"");
             }
-            println!("cargo:conf={}", vars);
+            println!("cargo:conf={vars}");
         }
 
         // BoringSSL does not have any build logic, exit early
@@ -196,12 +191,12 @@ fn main() {
     let potential_path = include_dir.join("openssl");
     if potential_path.exists() && !cfg!(feature = "vendored") {
         if let Some(printable_include) = potential_path.to_str() {
-            println!("cargo:rerun-if-changed={}", printable_include);
+            println!("cargo:rerun-if-changed={printable_include}");
         }
     }
 
     if !lib_dirs.iter().all(|p| p.exists()) {
-        panic!("OpenSSL library directory does not exist: {:?}", lib_dirs);
+        panic!("OpenSSL library directory does not exist: {lib_dirs:?}");
     }
     if !include_dir.exists() {
         panic!(
@@ -240,7 +235,7 @@ fn main() {
 
     let kind = determine_mode(&lib_dirs, &libs);
     for lib in libs.into_iter() {
-        println!("cargo:rustc-link-lib={}={}", kind, lib);
+        println!("cargo:rustc-link-lib={kind}={lib}");
     }
 
     // libssl in BoringSSL requires the C++ runtime, and static libraries do
@@ -271,7 +266,7 @@ fn main() {
             "macos" => "c++",
             _ => "stdc++",
         };
-        println!("cargo:rustc-link-lib={}", cpp_lib);
+        println!("cargo:rustc-link-lib={cpp_lib}");
     }
 
     // https://github.com/openssl/openssl/pull/15086
@@ -330,7 +325,7 @@ fn validate_headers(include_dirs: &[PathBuf]) -> Version {
             panic!(
                 "
 Header expansion error:
-{:?}
+{e:?}
 
 Failed to find OpenSSL development headers.
 
@@ -350,8 +345,7 @@ specific to your distribution:
 See rust-openssl documentation for more information:
 
     https://docs.rs/openssl
-",
-                e
+"
             );
         }
     };
@@ -392,7 +386,7 @@ See rust-openssl documentation for more information:
     }
 
     for enabled in &enabled {
-        println!("cargo:rustc-cfg=osslconf=\"{}\"", enabled);
+        println!("cargo:rustc-cfg=osslconf=\"{enabled}\"");
     }
     println!("cargo:conf={}", enabled.join(","));
 
@@ -414,11 +408,11 @@ See rust-openssl documentation for more information:
     println!("cargo:rustc-cfg=openssl");
 
     for cfg in cfgs::get(openssl_version, libressl_version) {
-        println!("cargo:rustc-cfg={}", cfg);
+        println!("cargo:rustc-cfg={cfg}");
     }
 
     if let Some(libressl_version) = libressl_version {
-        println!("cargo:libressl_version_number={:x}", libressl_version);
+        println!("cargo:libressl_version_number={libressl_version:x}");
 
         let major = (libressl_version >> 28) as u8;
         let minor = (libressl_version >> 20) as u8;
@@ -470,12 +464,12 @@ See rust-openssl documentation for more information:
         };
 
         println!("cargo:libressl=true");
-        println!("cargo:libressl_version={}{}{}", major, minor, fix);
+        println!("cargo:libressl_version={major}{minor}{fix}");
         println!("cargo:version=101");
         Version::Libressl
     } else {
         let openssl_version = openssl_version.unwrap();
-        println!("cargo:version_number={:x}", openssl_version);
+        println!("cargo:version_number={openssl_version:x}");
 
         if openssl_version >= 0x4_00_00_00_0 {
             version_error()
@@ -529,7 +523,7 @@ fn parse_version(version: &str) -> u64 {
 
 // parses a string that looks like 3_0_0
 fn parse_new_version(version: &str) -> u64 {
-    println!("version: {}", version);
+    println!("version: {version}");
     let mut it = version.split('_');
     let major = it.next().unwrap().parse::<u64>().unwrap();
     let minor = it.next().unwrap().parse::<u64>().unwrap();
@@ -566,20 +560,19 @@ fn determine_mode(libdirs: &[PathBuf], libs: &[&str]) -> &'static str {
     }
     let can_static = libs
         .iter()
-        .all(|l| files.contains(&format!("lib{}.a", l)) || files.contains(&format!("{}.lib", l)));
+        .all(|l| files.contains(&format!("lib{l}.a")) || files.contains(&format!("{l}.lib")));
     let can_dylib = libs.iter().all(|l| {
-        files.contains(&format!("lib{}.so", l))
-            || files.contains(&format!("{}.dll", l))
-            || files.contains(&format!("lib{}.dylib", l))
+        files.contains(&format!("lib{l}.so"))
+            || files.contains(&format!("{l}.dll"))
+            || files.contains(&format!("lib{l}.dylib"))
     });
     match (can_static, can_dylib) {
         (true, false) => return "static",
         (false, true) => return "dylib",
         (false, false) => {
             panic!(
-                "OpenSSL libdir at `{:?}` does not contain the required files \
-                 to either statically or dynamically link OpenSSL",
-                libdirs
+                "OpenSSL libdir at `{libdirs:?}` does not contain the required files \
+                 to either statically or dynamically link OpenSSL"
             );
         }
         (true, true) => {}

--- a/openssl-sys/build/run_bindgen.rs
+++ b/openssl-sys/build/run_bindgen.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "bindgen")]
-use bindgen::callbacks::{MacroParsingBehavior, ParseCallbacks};
+use bindgen::callbacks::{ItemInfo, MacroParsingBehavior, ParseCallbacks};
 #[cfg(feature = "bindgen")]
 use bindgen::{MacroTypeVariation, RustTarget};
 use std::io::Write;
@@ -80,7 +80,7 @@ pub fn run(include_dirs: &[PathBuf]) {
 
     let mut builder = bindgen::builder()
         .parse_callbacks(Box::new(OpensslCallbacks))
-        .rust_target(RustTarget::Stable_1_47)
+        .rust_target(RustTarget::stable(70, 0).unwrap())
         .ctypes_prefix("::libc")
         .raw_line("use libc::*;")
         .raw_line("#[cfg(windows)] use std::os::windows::raw::HANDLE;")
@@ -134,7 +134,7 @@ pub fn run_boringssl(include_dirs: &[PathBuf]) {
         .expect("Failed to write contents to boring_static_wrapper.h");
 
     let mut builder = bindgen::builder()
-        .rust_target(RustTarget::Stable_1_47)
+        .rust_target(RustTarget::stable(70, 0).unwrap())
         .ctypes_prefix("::libc")
         .raw_line("use libc::*;")
         .derive_default(false)
@@ -188,7 +188,7 @@ pub fn run_boringssl(include_dirs: &[PathBuf]) {
         .arg(out_dir.join("bindgen.rs"))
         // Must be a valid version from
         // https://docs.rs/bindgen/latest/bindgen/enum.RustTarget.html
-        .arg("--rust-target=1.47")
+        .arg("--rust-target=1.70")
         .arg("--ctypes-prefix=::libc")
         .arg("--raw-line=use libc::*;")
         .arg("--no-derive-default")
@@ -257,7 +257,7 @@ pub fn run_awslc(include_dirs: &[PathBuf], symbol_prefix: Option<String>) {
         .expect("Failed to write contents to awslc_static_wrapper.h");
 
     let mut builder = bindgen::builder()
-        .rust_target(RustTarget::Stable_1_47)
+        .rust_target(RustTarget::stable(70, 0).unwrap())
         .ctypes_prefix("::libc")
         .raw_line("use libc::*;")
         .derive_default(false)
@@ -314,7 +314,7 @@ pub fn run_awslc(include_dirs: &[PathBuf], symbol_prefix: Option<String>) {
         .arg(out_dir.join("bindgen.rs"))
         // Must be a valid version from
         // https://docs.rs/bindgen/latest/bindgen/enum.RustTarget.html
-        .arg("--rust-target=1.47")
+        .arg("--rust-target=1.70")
         .arg("--ctypes-prefix=::libc")
         .arg("--raw-line=use libc::*;")
         .arg("--no-derive-default")
@@ -354,8 +354,8 @@ impl ParseCallbacks for OpensslCallbacks {
         MacroParsingBehavior::Ignore
     }
 
-    fn item_name(&self, original_item_name: &str) -> Option<String> {
-        match original_item_name {
+    fn item_name(&self, item_info: ItemInfo) -> Option<String> {
+        match item_info.name {
             // Our original definitions of these are wrong, so rename to avoid breakage
             "CRYPTO_EX_new"
             | "CRYPTO_EX_dup"
@@ -373,7 +373,7 @@ impl ParseCallbacks for OpensslCallbacks {
             | "SSL_CTX_set_tmp_ecdh_callback"
             | "SSL_set_tmp_ecdh_callback"
             | "SSL_CTX_callback_ctrl"
-            | "SSL_CTX_set_alpn_select_cb" => Some(format!("{}__fixed_rust", original_item_name)),
+            | "SSL_CTX_set_alpn_select_cb" => Some(format!("{}__fixed_rust", item_info.name)),
             _ => None,
         }
     }

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["crypto", "tls", "ssl", "dtls"]
 categories = ["cryptography", "api-bindings"]
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.70.0"
 
 # these are deprecated and don't do anything anymore
 [features]
@@ -26,14 +26,14 @@ aws-lc-fips = ["ffi/aws-lc-fips"]
 default = []
 
 [dependencies]
-bitflags = "2.2.1"
-cfg-if = "1.0"
-foreign-types = "0.3.1"
-libc = "0.2"
-once_cell = "1.5.2"
+bitflags.workspace = true
+cfg-if.workspace = true
+foreign-types.workspace = true
+libc.workspace = true
+once_cell.workspace = true
 
-openssl-macros = { version = "0.1.1", path = "../openssl-macros" }
-ffi = { package = "openssl-sys", version = "0.9.109", path = "../openssl-sys" }
+openssl-macros.workspace = true
+ffi.workspace = true # 0.9.109 => -
 
 [dev-dependencies]
-hex = "0.4"
+hex.workspace = true

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -2,14 +2,14 @@
 name = "systest"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-libc = "0.2"
-openssl-sys = { path = "../openssl-sys" }
+libc.workspace = true
+openssl-sys.workspace = true
 
 [build-dependencies]
-ctest = "0.4.11"
+ctest.workspace = true
 
 [features]
 vendored = ['openssl-sys/vendored']


### PR DESCRIPTION
### Context
* Bindgen versions 0.70, 0.71 and 0.72 fix a variety of issues around bindings generation. See change-log: https://github.com/rust-lang/rust-bindgen/blob/main/CHANGELOG.md
* These versions of bindgen require an MSRV of 1.70.0.

### Description
This PR bumps the MSRV to 1.70 and updates the bindgen dependency to 0.72.0 (the latest current release).

Details:
* Updated bindgen-related logic to be compatible the 0.72.0 API changes.
* Changed dependencies to be configured at the workspace level.
* Applied a "cargo clippy --fix", and removed a clippy-allow that's no longer needed.
* Bumped the aws-lc-sys dependecy to the latest v0.30.0.