### PR TITLE
Add ability to create PKey from parameters

### DIFF
--- a/openssl/src/kdf.rs
+++ b/openssl/src/kdf.rs
@@ -44,6 +44,9 @@ cfg_if::cfg_if! {
         cstr_const!(OSSL_KDF_PARAM_ARGON2_LANES, b"lanes\0");
         cstr_const!(OSSL_KDF_PARAM_ARGON2_MEMCOST, b"memcost\0");
 
+        cstr_const!(KDF_ARGON2D, b"ARGON2D\0");
+        cstr_const!(KDF_ARGON2I, b"ARGON2I\0");
+        cstr_const!(KDF_ARGON2ID, b"ARGON2ID\0");
 
         #[allow(clippy::too_many_arguments)]
         pub fn argon2d(
@@ -57,7 +60,7 @@ cfg_if::cfg_if! {
             memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            argon2_helper(CStr::from_bytes_with_nul(b"ARGON2D\0").unwrap(), ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
+            argon2_helper(KDF_ARGON2D, ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -72,7 +75,7 @@ cfg_if::cfg_if! {
             memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            argon2_helper(CStr::from_bytes_with_nul(b"ARGON2I\0").unwrap(), ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
+            argon2_helper(KDF_ARGON2I, ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -87,7 +90,7 @@ cfg_if::cfg_if! {
             memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            argon2_helper(CStr::from_bytes_with_nul(b"ARGON2ID\0").unwrap(), ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
+            argon2_helper(KDF_ARGON2ID, ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
         }
 
         /// Derives a key using the argon2* algorithms.

--- a/openssl/src/kdf.rs
+++ b/openssl/src/kdf.rs
@@ -34,19 +34,16 @@ cfg_if::cfg_if! {
         use crate::error::ErrorStack;
         use crate::ossl_param::OsslParamBuilder;
 
-        // Safety: these all have null terminators.
-        // We cen remove these CStr::from_bytes_with_nul_unchecked calls
-        // when we upgrade to Rust 1.77+ with literal c"" syntax.
+        cstr_const!(OSSL_KDF_PARAM_PASSWORD, b"pass\0");
+        cstr_const!(OSSL_KDF_PARAM_SALT, b"salt\0");
+        cstr_const!(OSSL_KDF_PARAM_SECRET, b"secret\0");
+        cstr_const!(OSSL_KDF_PARAM_ITER, b"iter\0");
+        cstr_const!(OSSL_KDF_PARAM_SIZE, b"size\0");
+        cstr_const!(OSSL_KDF_PARAM_THREADS, b"threads\0");
+        cstr_const!(OSSL_KDF_PARAM_ARGON2_AD, b"ad\0");
+        cstr_const!(OSSL_KDF_PARAM_ARGON2_LANES, b"lanes\0");
+        cstr_const!(OSSL_KDF_PARAM_ARGON2_MEMCOST, b"memcost\0");
 
-        const OSSL_KDF_PARAM_PASSWORD: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"pass\0") };
-        const OSSL_KDF_PARAM_SALT: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"salt\0") };
-        const OSSL_KDF_PARAM_SECRET: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"secret\0") };
-        const OSSL_KDF_PARAM_ITER: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"iter\0") };
-        const OSSL_KDF_PARAM_SIZE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"size\0") };
-        const OSSL_KDF_PARAM_THREADS: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"threads\0") };
-        const OSSL_KDF_PARAM_ARGON2_AD: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"ad\0") };
-        const OSSL_KDF_PARAM_ARGON2_LANES: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"lanes\0") };
-        const OSSL_KDF_PARAM_ARGON2_MEMCOST: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"memcost\0") };
 
         #[allow(clippy::too_many_arguments)]
         pub fn argon2d(

--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -268,3 +268,14 @@ macro_rules! generic_foreign_type_and_impl_send_sync {
         unsafe impl<T> Sync for $borrowed<T>{}
     };
 }
+
+#[cfg_attr(not(ossl300), allow(unused_macros))]
+macro_rules! cstr_const {
+    // Safety: these all have null terminators.
+    // We cen remove these CStr::from_bytes_with_nul_unchecked calls
+    // when we upgrade to Rust 1.77+ with literal c"" syntax.
+    ($vis:vis $name:ident, $key:literal) => {
+        #[allow(dead_code)]
+        $vis const $name: &std::ffi::CStr = unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked($key) };
+    }
+}

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -86,6 +86,21 @@ impl OsslParamArray {
     }
 }
 
+impl OsslParamArrayRef {
+    /// Merges two `ParamsRef` objects into a new `Params` object.
+    #[corresponds(OSSL_PARAM_merge)]
+    #[allow(dead_code)]
+    pub fn merge(&self, other: &OsslParamArrayRef) -> Result<OsslParamArray, ErrorStack> {
+        // merge combines the two lists by borrowing the params from the input lists
+        let merge_ptr = cvt_p(unsafe { ffi::OSSL_PARAM_merge(self.as_ptr(), other.as_ptr()) })?;
+        // because the merge doesn't copy data, we need to dupe the result so we own everything
+        let result = unsafe { ffi::OSSL_PARAM_dup(merge_ptr) };
+        // then free the merge result to drop borrowed the references to the original lists
+        unsafe { ffi::OSSL_PARAM_free(merge_ptr) };
+        cvt_p(result).map(|p| unsafe { OsslParamArray::from_ptr(p) })
+    }
+}
+
 foreign_type_and_impl_send_sync! {
     type CType = ffi::OSSL_PARAM_BLD;
     fn drop = ffi::OSSL_PARAM_BLD_free;
@@ -292,5 +307,55 @@ mod tests {
 
         assert_param(&params, OSSL_PKEY_PARAM_PUB_KEY, false);
         assert_param(&params, OSSL_PKEY_PARAM_GROUP_NAME, true);
+    }
+
+    #[test]
+    fn test_merge() {
+        let (n, e, d) = (0xbc747fc5, 0x10001, 0x7b133399);
+        let mut merged_params: OsslParamArray;
+
+        // Create a param array with just n in a scoped block so that bn_n, and the builder are dropped
+        {
+            let bn_n = BigNum::from_u32(n).unwrap();
+            let mut builder = OsslParamBuilder::new().unwrap();
+            builder.add_bn(OSSL_PKEY_PARAM_RSA_N, &bn_n).unwrap();
+            merged_params = builder.to_param().unwrap();
+        }
+
+        // We should still be able to pull back n and get the correct value, but not e or d (yet)
+        let bn_n = BigNum::from_u32(n).unwrap();
+        assert_bn_equal(&merged_params, OSSL_PKEY_PARAM_RSA_N, &bn_n);
+        assert_param(&merged_params, OSSL_PKEY_PARAM_RSA_E, true);
+        assert_param(&merged_params, OSSL_PKEY_PARAM_RSA_D, true);
+
+        // Create a new param array with just e and merge it in
+        {
+            let bn_e = BigNum::from_u32(e).unwrap();
+            let mut builder = OsslParamBuilder::new().unwrap();
+            builder.add_bn(OSSL_PKEY_PARAM_RSA_E, &bn_e).unwrap();
+            let params = builder.to_param().unwrap();
+            merged_params = merged_params.merge(&params).unwrap();
+        }
+
+        // We should still be able to pull back n & e and get the correct value, but not d (yet)
+        let bn_e = BigNum::from_u32(e).unwrap();
+        assert_bn_equal(&merged_params, OSSL_PKEY_PARAM_RSA_N, &bn_n);
+        assert_bn_equal(&merged_params, OSSL_PKEY_PARAM_RSA_E, &bn_e);
+        assert_param(&merged_params, OSSL_PKEY_PARAM_RSA_D, true);
+
+        // Again, create a new param array with just d and merge it in
+        {
+            let bn_d = BigNum::from_u32(d).unwrap();
+            let mut builder = OsslParamBuilder::new().unwrap();
+            builder.add_bn(OSSL_PKEY_PARAM_RSA_D, &bn_d).unwrap();
+            let params = builder.to_param().unwrap();
+            merged_params = merged_params.merge(&params).unwrap();
+        }
+
+        // We should be able to pull all of n, e & d out and get the correct values
+        let bn_d = BigNum::from_u32(d).unwrap();
+        assert_bn_equal(&merged_params, OSSL_PKEY_PARAM_RSA_N, &bn_n);
+        assert_bn_equal(&merged_params, OSSL_PKEY_PARAM_RSA_E, &bn_e);
+        assert_bn_equal(&merged_params, OSSL_PKEY_PARAM_RSA_D, &bn_d);
     }
 }

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -914,6 +914,25 @@ impl<T> TryFrom<PKey<T>> for Dh<T> {
     }
 }
 
+cfg_if! {
+    if #[cfg(ossl300)] {
+        cstr_const!(pub(crate) OSSL_PKEY_PARAM_GROUP_NAME, b"group\0");
+
+        cstr_const!(pub(crate) OSSL_PKEY_PARAM_PUB_KEY, b"pub\0");
+        cstr_const!(pub(crate) OSSL_PKEY_PARAM_PRIV_KEY, b"priv\0");
+
+        cstr_const!(pub(crate) OSSL_PKEY_PARAM_FFC_P, b"p\0");
+        cstr_const!(pub(crate) OSSL_PKEY_PARAM_FFC_G, b"g\0");
+        cstr_const!(pub(crate) OSSL_PKEY_PARAM_FFC_Q, b"q\0");
+
+        cstr_const!(pub(crate) OSSL_PKEY_PARAM_RSA_N, b"n\0");
+        cstr_const!(pub(crate) OSSL_PKEY_PARAM_RSA_E, b"e\0");
+        cstr_const!(pub(crate) OSSL_PKEY_PARAM_RSA_D, b"d\0");
+
+        cstr_const!(pub(crate) OSSL_SIGNATURE_PARAM_NONCE_TYPE, b"nonce-type\0");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::convert::TryInto;

--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -70,6 +70,12 @@ use crate::cipher::CipherRef;
 use crate::error::ErrorStack;
 use crate::md::MdRef;
 use crate::nid::Nid;
+#[cfg(ossl300)]
+use crate::ossl_param::OsslParamArrayRef;
+#[cfg(ossl320)]
+use crate::ossl_param::OsslParamBuilder;
+#[cfg(ossl320)]
+use crate::pkey::OSSL_SIGNATURE_PARAM_NONCE_TYPE;
 use crate::pkey::{HasPrivate, HasPublic, Id, PKey, PKeyRef, Params, Private};
 use crate::rsa::Padding;
 use crate::sign::RsaPssSaltlen;
@@ -82,8 +88,6 @@ use libc::c_int;
 use libc::c_uint;
 use openssl_macros::corresponds;
 use std::convert::TryFrom;
-#[cfg(ossl320)]
-use std::ffi::CStr;
 use std::ptr;
 
 /// HKDF modes of operation.
@@ -865,6 +869,14 @@ impl<T> PkeyCtxRef<T> {
         }
     }
 
+    /// Sets parameters on the given context
+    #[corresponds(EVP_PKEY_CTX_set_params)]
+    #[cfg(ossl300)]
+    #[cfg_attr(not(ossl320), allow(dead_code))]
+    fn set_params(&mut self, params: &OsslParamArrayRef) -> Result<(), ErrorStack> {
+        cvt(unsafe { ffi::EVP_PKEY_CTX_set_params(self.as_ptr(), params.as_ptr()) }).map(|_| ())
+    }
+
     /// Sets the nonce type for a private key context.
     ///
     /// The nonce for DSA and ECDSA can be either random (the default) or deterministic (as defined by RFC 6979).
@@ -874,17 +886,10 @@ impl<T> PkeyCtxRef<T> {
     #[cfg(ossl320)]
     #[corresponds(EVP_PKEY_CTX_set_params)]
     pub fn set_nonce_type(&mut self, nonce_type: NonceType) -> Result<(), ErrorStack> {
-        let nonce_field_name = CStr::from_bytes_with_nul(b"nonce-type\0").unwrap();
-        let mut nonce_type = nonce_type.0;
-        unsafe {
-            let param_nonce =
-                ffi::OSSL_PARAM_construct_uint(nonce_field_name.as_ptr(), &mut nonce_type);
-            let param_end = ffi::OSSL_PARAM_construct_end();
-
-            let params = [param_nonce, param_end];
-            cvt(ffi::EVP_PKEY_CTX_set_params(self.as_ptr(), params.as_ptr()))?;
-        }
-        Ok(())
+        let mut builder = OsslParamBuilder::new()?;
+        builder.add_uint(OSSL_SIGNATURE_PARAM_NONCE_TYPE, nonce_type.0)?;
+        let params = builder.to_param()?;
+        self.set_params(&params)
     }
 
     /// Gets the nonce type for a private key context.
@@ -896,11 +901,12 @@ impl<T> PkeyCtxRef<T> {
     #[cfg(ossl320)]
     #[corresponds(EVP_PKEY_CTX_get_params)]
     pub fn nonce_type(&mut self) -> Result<NonceType, ErrorStack> {
-        let nonce_field_name = CStr::from_bytes_with_nul(b"nonce-type\0").unwrap();
         let mut nonce_type: c_uint = 0;
         unsafe {
-            let param_nonce =
-                ffi::OSSL_PARAM_construct_uint(nonce_field_name.as_ptr(), &mut nonce_type);
+            let param_nonce = ffi::OSSL_PARAM_construct_uint(
+                OSSL_SIGNATURE_PARAM_NONCE_TYPE.as_ptr(),
+                &mut nonce_type,
+            );
             let param_end = ffi::OSSL_PARAM_construct_end();
 
             let mut params = [param_nonce, param_end];

--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -70,7 +70,7 @@ use crate::cipher::CipherRef;
 use crate::error::ErrorStack;
 use crate::md::MdRef;
 use crate::nid::Nid;
-#[cfg(ossl320)]
+#[cfg(ossl300)]
 use crate::ossl_param::OsslParamArrayRef;
 #[cfg(ossl320)]
 use crate::ossl_param::OsslParamBuilder;
@@ -479,6 +479,35 @@ impl<T> PkeyCtxRef<T> {
         }
 
         Ok(())
+    }
+
+    /// Prepares the context for creating a key from user data.
+    #[corresponds(EVP_PKEY_fromdata_init)]
+    #[inline]
+    #[cfg(ossl300)]
+    pub(crate) fn fromdata_init(&mut self) -> Result<(), ErrorStack> {
+        cvt(unsafe { ffi::EVP_PKEY_fromdata_init(self.as_ptr()) }).map(|_| ())
+    }
+
+    /// Convert a stack of Params into a PKey.
+    #[corresponds(EVP_PKEY_fromdata)]
+    #[inline]
+    #[cfg(ossl300)]
+    pub(crate) fn fromdata<K>(
+        &mut self,
+        params: &OsslParamArrayRef,
+        selection: Selection,
+    ) -> Result<PKey<K>, ErrorStack> {
+        let mut key_ptr = ptr::null_mut();
+        cvt(unsafe {
+            ffi::EVP_PKEY_fromdata(
+                self.as_ptr(),
+                &mut key_ptr,
+                selection.into(),
+                params.as_ptr(),
+            )
+        })?;
+        Ok(unsafe { PKey::from_ptr(key_ptr) })
     }
 
     /// Sets which algorithm was used to compute the digest used in a
@@ -962,6 +991,18 @@ impl<T> PkeyCtxRef<T> {
     }
 }
 
+/// Creates a new `PKey` from the given ID and parameters.
+#[cfg(ossl300)]
+#[allow(dead_code)] // TODO: remove when used by pkey creation
+pub(crate) fn pkey_from_params<K: SelectionT>(
+    id: Id,
+    params: &OsslParamArrayRef,
+) -> Result<PKey<K>, ErrorStack> {
+    let mut ctx = PkeyCtx::new_id(id)?;
+    ctx.fromdata_init()?;
+    ctx.fromdata(params, K::SELECTION)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -972,7 +1013,11 @@ mod test {
     use crate::hash::{hash, MessageDigest};
     use crate::md::Md;
     use crate::nid::Nid;
+    #[cfg(ossl300)]
+    use crate::ossl_param::OsslParamBuilder;
     use crate::pkey::PKey;
+    #[cfg(ossl300)]
+    use crate::pkey::{OSSL_PKEY_PARAM_RSA_D, OSSL_PKEY_PARAM_RSA_E, OSSL_PKEY_PARAM_RSA_N};
     use crate::rsa::Rsa;
     use crate::sign::Verifier;
     #[cfg(not(boringssl))]
@@ -1345,5 +1390,27 @@ mxJ7imIrEg9nIQ==
         ctx.sign_to_vec(&hashed_input, &mut output).unwrap();
         assert_eq!(output, expected_output);
         assert!(ErrorStack::get().errors().is_empty());
+    }
+
+    #[test]
+    #[cfg(ossl300)]
+    fn test_pkey_from_params() {
+        let n = BigNum::from_u32(0xbc747fc5).unwrap();
+        let e = BigNum::from_u32(0x10001).unwrap();
+        let d = BigNum::from_u32(0x7b133399).unwrap();
+
+        let mut builder = OsslParamBuilder::new().unwrap();
+        builder.add_bn(OSSL_PKEY_PARAM_RSA_N, &n).unwrap();
+        builder.add_bn(OSSL_PKEY_PARAM_RSA_E, &e).unwrap();
+        builder.add_bn(OSSL_PKEY_PARAM_RSA_D, &d).unwrap();
+        let params = builder.to_param().unwrap();
+
+        let pkey: PKey<Private> = pkey_from_params(Id::RSA, &params).unwrap();
+
+        let rsa = pkey.rsa().unwrap();
+
+        assert_eq!(rsa.n(), &n);
+        assert_eq!(rsa.e(), &e);
+        assert_eq!(rsa.d(), &d);
     }
 }


### PR DESCRIPTION
Work towards #2047 by adding ability to create PKeys from OSSL params.

Also:
* tidy up creation of `OSSL_PARAM_*` on the way.
* write some tests for the internal OsslParam* API.
