### PR TITLE
macros: fully qualify imports

### DIFF
--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -9,7 +9,7 @@ macro_rules! private_key_from_pem {
                 let bio = crate::bio::MemBioSlice::new(pem)?;
                 let passphrase = ::std::ffi::CString::new(passphrase).unwrap();
                 cvt_p($f(bio.as_ptr(),
-                         ptr::null_mut(),
+                         ::std::ptr::null_mut(),
                          None,
                          passphrase.as_ptr() as *const _ as *mut _))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
@@ -25,7 +25,7 @@ macro_rules! private_key_from_pem {
                 let mut cb = crate::util::CallbackState::new(callback);
                 let bio = crate::bio::MemBioSlice::new(pem)?;
                 cvt_p($f(bio.as_ptr(),
-                         ptr::null_mut(),
+                         ::std::ptr::null_mut(),
                          Some(crate::util::invoke_passwd_cb::<F>),
                          &mut cb as *mut _ as *mut _))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
@@ -42,11 +42,11 @@ macro_rules! private_key_to_pem {
                 let bio = crate::bio::MemBio::new()?;
                 cvt($f(bio.as_ptr(),
                         self.as_ptr(),
-                        ptr::null(),
-                        ptr::null_mut(),
+                        ::std::ptr::null(),
+                        ::std::ptr::null_mut(),
                         -1,
                         None,
-                        ptr::null_mut()))?;
+                        ::std::ptr::null_mut()))?;
                 Ok(bio.get_buf().to_owned())
             }
         }
@@ -66,7 +66,7 @@ macro_rules! private_key_to_pem {
                         passphrase.as_ptr() as *const _ as *mut _,
                         passphrase.len() as ::libc::c_int,
                         None,
-                        ptr::null_mut()))?;
+                        ::std::ptr::null_mut()))?;
                 Ok(bio.get_buf().to_owned())
             }
         }
@@ -92,7 +92,7 @@ macro_rules! to_der {
         pub fn $n(&self) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
                 let len = crate::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
-                                        ptr::null_mut()))?;
+                                        ::std::ptr::null_mut()))?;
                 let mut buf = vec![0; len as usize];
                 crate::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
                               &mut buf.as_mut_ptr()))?;

--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -8,7 +8,7 @@ macro_rules! private_key_from_pem {
                 ffi::init();
                 let bio = crate::bio::MemBioSlice::new(pem)?;
                 let passphrase = ::std::ffi::CString::new(passphrase).unwrap();
-                cvt_p($f(bio.as_ptr(),
+                crate::cvt_p($f(bio.as_ptr(),
                          ::std::ptr::null_mut(),
                          None,
                          passphrase.as_ptr() as *const _ as *mut _))
@@ -24,7 +24,7 @@ macro_rules! private_key_from_pem {
                 ffi::init();
                 let mut cb = crate::util::CallbackState::new(callback);
                 let bio = crate::bio::MemBioSlice::new(pem)?;
-                cvt_p($f(bio.as_ptr(),
+                crate::cvt_p($f(bio.as_ptr(),
                          ::std::ptr::null_mut(),
                          Some(crate::util::invoke_passwd_cb::<F>),
                          &mut cb as *mut _ as *mut _))
@@ -40,7 +40,7 @@ macro_rules! private_key_to_pem {
         pub fn $n(&self) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
                 let bio = crate::bio::MemBio::new()?;
-                cvt($f(bio.as_ptr(),
+                crate::cvt($f(bio.as_ptr(),
                         self.as_ptr(),
                         ::std::ptr::null(),
                         ::std::ptr::null_mut(),
@@ -60,7 +60,7 @@ macro_rules! private_key_to_pem {
             unsafe {
                 let bio = crate::bio::MemBio::new()?;
                 assert!(passphrase.len() <= ::libc::c_int::MAX as usize);
-                cvt($f(bio.as_ptr(),
+                crate::cvt($f(bio.as_ptr(),
                         self.as_ptr(),
                         cipher.as_ptr(),
                         passphrase.as_ptr() as *const _ as *mut _,
@@ -79,7 +79,7 @@ macro_rules! to_pem {
         pub fn $n(&self) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
                 let bio = crate::bio::MemBio::new()?;
-                cvt($f(bio.as_ptr(), self.as_ptr()))?;
+                crate::cvt($f(bio.as_ptr(), self.as_ptr()))?;
                 Ok(bio.get_buf().to_owned())
             }
         }
@@ -124,7 +124,7 @@ macro_rules! from_pem {
             unsafe {
                 crate::init();
                 let bio = crate::bio::MemBioSlice::new(pem)?;
-                cvt_p($f(bio.as_ptr(), ::std::ptr::null_mut(), None, ::std::ptr::null_mut()))
+                crate::cvt_p($f(bio.as_ptr(), ::std::ptr::null_mut(), None, ::std::ptr::null_mut()))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
             }
         }


### PR DESCRIPTION
Let's be consistent here so that when we use the macros it's not a requirement to ensure we have the right imports in the callee code.