### PR TITLE
Disable AES-CFB128 ciphers for BoringSSL

### DIFF
--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -238,6 +238,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb1() as *mut _) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_192_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_192_cfb128() as *mut _) }
     }
@@ -295,6 +296,7 @@ impl Cipher {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb1() as *mut _) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_256_cfb128() -> &'static CipherRef {
         unsafe { CipherRef::from_ptr(ffi::EVP_aes_256_cfb128() as *mut _) }
     }

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -114,6 +114,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_cfb1()) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_128_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_128_cfb128()) }
     }
@@ -159,6 +160,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_cfb1()) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_192_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_192_cfb128()) }
     }
@@ -209,6 +211,7 @@ impl Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_cfb1()) }
     }
 
+    #[cfg(not(boringssl))]
     pub fn aes_256_cfb128() -> Cipher {
         unsafe { Cipher(ffi::EVP_aes_256_cfb128()) }
     }


### PR DESCRIPTION
The ciphers above are only available from libdecrepit, thus any attempt to use these from Rust code will fail to link.

Furthermore, this introduced a dependency on libdecrepit when linking Rust staticlib to a non-Rust application.