### PR TITLE
Fix missing "__off_t" on NetBSD 10

### DIFF
--- a/openssl-sys/build/run_bindgen.rs
+++ b/openssl-sys/build/run_bindgen.rs
@@ -370,6 +370,8 @@ impl ParseCallbacks for OpensslCallbacks {
             | "SSL_set_tmp_ecdh_callback"
             | "SSL_CTX_callback_ctrl"
             | "SSL_CTX_set_alpn_select_cb" => Some(format!("{}__fixed_rust", item_info.name)),
+            // On NetBSD, "off_t" is generated as "__off_t".
+            "__off_t" => Some("off_t".to_string()),
             _ => None,
         }
     }


### PR DESCRIPTION
NetBSD uses a type redefinition guard for off_t[1] with the same name, confusing bindgen and making it generate a reference to a missing type:

```
error[E0412]: cannot find type `__off_t` in this scope
     --> .../target/debug/build/openssl-sys-f09155f99ab31e50/out/bindgen.rs:24508:17
      |
24508 |         offset: __off_t,
      |                 ^^^^^^^ help: a type alias with a similar name exists: `off_t`
```

[1]: https://github.com/NetBSD/src/blob/9ae2aa18e3f4ffeb1efda2bdd171a1f6d22fc3ce/sys/sys/types.h#L191
***
The error is reproducible when building on NetBSD 10.x with OpenSSL 3 (`off_t` is used in `SSL_sendfile` arguments) and `--features=bindgen`. Neither BoringSSL nor AWS-LC are affected due to lack of support for OpenSSL kTLS APIs.

There's an alternative way of addressing this via `OpensslCallbacks::item_name`:
```diff
diff --git a/openssl-sys/build/run_bindgen.rs b/openssl-sys/build/run_bindgen.rs
index e3ac854f..d13ab9bc 100644
--- a/openssl-sys/build/run_bindgen.rs
+++ b/openssl-sys/build/run_bindgen.rs
@@ -371,6 +371,7 @@ impl ParseCallbacks for OpensslCallbacks {
             | "SSL_set_tmp_ecdh_callback"
             | "SSL_CTX_callback_ctrl"
             | "SSL_CTX_set_alpn_select_cb" => Some(format!("{}__fixed_rust", item_info.name)),
+            "__off_t" => Some("off_t".to_string()),
             _ => None,
         }
     }
```
I'm not sure which one is preferable, LMK if you want to commit the item_name one.