### PR TITLE
ML-KEM/ML-DSA part 2: param builder

### DIFF
--- a/openssl/src/kdf.rs
+++ b/openssl/src/kdf.rs
@@ -34,15 +34,15 @@ cfg_if::cfg_if! {
         use crate::error::ErrorStack;
         use crate::ossl_param::OsslParamBuilder;
 
-        const OSSL_KDF_PARAM_PASSWORD: &[u8; 5] = b"pass\0";
-        const OSSL_KDF_PARAM_SALT: &[u8; 5] = b"salt\0";
-        const OSSL_KDF_PARAM_SECRET: &[u8; 7] = b"secret\0";
-        const OSSL_KDF_PARAM_ITER: &[u8; 5] = b"iter\0";
-        const OSSL_KDF_PARAM_SIZE: &[u8; 5] = b"size\0";
-        const OSSL_KDF_PARAM_THREADS: &[u8; 8] = b"threads\0";
-        const OSSL_KDF_PARAM_ARGON2_AD: &[u8; 3] = b"ad\0";
-        const OSSL_KDF_PARAM_ARGON2_LANES: &[u8; 6] = b"lanes\0";
-        const OSSL_KDF_PARAM_ARGON2_MEMCOST: &[u8; 8] = b"memcost\0";
+        const OSSL_KDF_PARAM_PASSWORD: &CStr = c"pass";
+        const OSSL_KDF_PARAM_SALT: &CStr = c"salt";
+        const OSSL_KDF_PARAM_SECRET: &CStr = c"secret";
+        const OSSL_KDF_PARAM_ITER: &CStr = c"iter";
+        const OSSL_KDF_PARAM_SIZE: &CStr = c"size";
+        const OSSL_KDF_PARAM_THREADS: &CStr = c"threads";
+        const OSSL_KDF_PARAM_ARGON2_AD: &CStr = c"ad";
+        const OSSL_KDF_PARAM_ARGON2_LANES: &CStr = c"lanes";
+        const OSSL_KDF_PARAM_ARGON2_MEMCOST: &CStr = c"memcost";
 
         #[allow(clippy::too_many_arguments)]
         pub fn argon2d(
@@ -120,7 +120,7 @@ cfg_if::cfg_if! {
             if max_threads > 0 {
                 threads = cmp::min(lanes, cmp::min(max_threads, u32::MAX as u64) as u32);
             }
-            let bld = OsslParamBuilder::new()?;
+            let mut bld = OsslParamBuilder::new()?;
             bld.add_octet_string(OSSL_KDF_PARAM_PASSWORD, pass)?;
             bld.add_octet_string(OSSL_KDF_PARAM_SALT, salt)?;
             bld.add_uint(OSSL_KDF_PARAM_THREADS, threads)?;

--- a/openssl/src/kdf.rs
+++ b/openssl/src/kdf.rs
@@ -25,15 +25,24 @@ impl Drop for EvpKdfCtx {
 cfg_if::cfg_if! {
     if #[cfg(all(ossl320, not(osslconf = "OPENSSL_NO_ARGON2")))] {
         use std::cmp;
-        use std::ffi::c_void;
         use std::ffi::CStr;
-        use std::mem::MaybeUninit;
         use std::ptr;
         use foreign_types::ForeignTypeRef;
         use libc::c_char;
         use crate::{cvt, cvt_p};
         use crate::lib_ctx::LibCtxRef;
         use crate::error::ErrorStack;
+        use crate::ossl_param::OsslParamBuilder;
+
+        const OSSL_KDF_PARAM_PASSWORD: &[u8; 5] = b"pass\0";
+        const OSSL_KDF_PARAM_SALT: &[u8; 5] = b"salt\0";
+        const OSSL_KDF_PARAM_SECRET: &[u8; 7] = b"secret\0";
+        const OSSL_KDF_PARAM_ITER: &[u8; 5] = b"iter\0";
+        const OSSL_KDF_PARAM_SIZE: &[u8; 5] = b"size\0";
+        const OSSL_KDF_PARAM_THREADS: &[u8; 8] = b"threads\0";
+        const OSSL_KDF_PARAM_ARGON2_AD: &[u8; 3] = b"ad\0";
+        const OSSL_KDF_PARAM_ARGON2_LANES: &[u8; 6] = b"lanes\0";
+        const OSSL_KDF_PARAM_ARGON2_MEMCOST: &[u8; 8] = b"memcost\0";
 
         #[allow(clippy::too_many_arguments)]
         pub fn argon2d(
@@ -94,72 +103,40 @@ cfg_if::cfg_if! {
             salt: &[u8],
             ad: Option<&[u8]>,
             secret: Option<&[u8]>,
-            mut iter: u32,
-            mut lanes: u32,
-            mut memcost: u32,
+            iter: u32,
+            lanes: u32,
+            memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            unsafe {
+            let libctx = ctx.map_or(ptr::null_mut(), ForeignTypeRef::as_ptr);
+            let max_threads = unsafe {
                 ffi::init();
-                let libctx = ctx.map_or(ptr::null_mut(), ForeignTypeRef::as_ptr);
-
-                let max_threads = ffi::OSSL_get_max_threads(libctx);
-                let mut threads = 1;
-                // If max_threads is 0, then this isn't a threaded build.
-                // If max_threads is > u32::MAX we need to clamp since
-                // argon2's threads parameter is a u32.
-                if max_threads > 0 {
-                    threads = cmp::min(lanes, cmp::min(max_threads, u32::MAX as u64) as u32);
-                }
-                let mut params: [ffi::OSSL_PARAM; 10] =
-                    core::array::from_fn(|_| MaybeUninit::<ffi::OSSL_PARAM>::zeroed().assume_init());
-                let mut idx = 0;
-                params[idx] = ffi::OSSL_PARAM_construct_octet_string(
-                    b"pass\0".as_ptr() as *const c_char,
-                    pass.as_ptr() as *mut c_void,
-                    pass.len(),
-                );
-                idx += 1;
-                params[idx] = ffi::OSSL_PARAM_construct_octet_string(
-                    b"salt\0".as_ptr() as *const c_char,
-                    salt.as_ptr() as *mut c_void,
-                    salt.len(),
-                );
-                idx += 1;
-                params[idx] =
-                    ffi::OSSL_PARAM_construct_uint(b"threads\0".as_ptr() as *const c_char, &mut threads);
-                idx += 1;
-                params[idx] =
-                    ffi::OSSL_PARAM_construct_uint(b"lanes\0".as_ptr() as *const c_char, &mut lanes);
-                idx += 1;
-                params[idx] =
-                    ffi::OSSL_PARAM_construct_uint(b"memcost\0".as_ptr() as *const c_char, &mut memcost);
-                idx += 1;
-                params[idx] =
-                    ffi::OSSL_PARAM_construct_uint(b"iter\0".as_ptr() as *const c_char, &mut iter);
-                idx += 1;
-                let mut size = out.len() as u32;
-                params[idx] =
-                    ffi::OSSL_PARAM_construct_uint(b"size\0".as_ptr() as *const c_char, &mut size);
-                idx += 1;
-                if let Some(ad) = ad {
-                    params[idx] = ffi::OSSL_PARAM_construct_octet_string(
-                        b"ad\0".as_ptr() as *const c_char,
-                        ad.as_ptr() as *mut c_void,
-                        ad.len(),
-                    );
-                    idx += 1;
-                }
-                if let Some(secret) = secret {
-                    params[idx] = ffi::OSSL_PARAM_construct_octet_string(
-                        b"secret\0".as_ptr() as *const c_char,
-                        secret.as_ptr() as *mut c_void,
-                        secret.len(),
-                    );
-                    idx += 1;
-                }
-                params[idx] = ffi::OSSL_PARAM_construct_end();
-
+                ffi::OSSL_get_max_threads(libctx)
+            };
+            let mut threads = 1;
+            // If max_threads is 0, then this isn't a threaded build.
+            // If max_threads is > u32::MAX we need to clamp since
+            // argon2id's threads parameter is a u32.
+            if max_threads > 0 {
+                threads = cmp::min(lanes, cmp::min(max_threads, u32::MAX as u64) as u32);
+            }
+            let bld = OsslParamBuilder::new()?;
+            bld.add_octet_string(OSSL_KDF_PARAM_PASSWORD, pass)?;
+            bld.add_octet_string(OSSL_KDF_PARAM_SALT, salt)?;
+            bld.add_uint(OSSL_KDF_PARAM_THREADS, threads)?;
+            bld.add_uint(OSSL_KDF_PARAM_ARGON2_LANES, lanes)?;
+            bld.add_uint(OSSL_KDF_PARAM_ARGON2_MEMCOST, memcost)?;
+            bld.add_uint(OSSL_KDF_PARAM_ITER, iter)?;
+            let size = out.len() as u32;
+            bld.add_uint(OSSL_KDF_PARAM_SIZE, size)?;
+            if let Some(ad) = ad {
+                bld.add_octet_string(OSSL_KDF_PARAM_ARGON2_AD, ad)?;
+            }
+            if let Some(secret) = secret {
+                bld.add_octet_string(OSSL_KDF_PARAM_SECRET, secret)?;
+            }
+            let params = bld.to_param()?;
+            unsafe {
                 let argon2 = EvpKdf(cvt_p(ffi::EVP_KDF_fetch(
                     libctx,
                     kdf_identifier.as_ptr() as *const c_char,

--- a/openssl/src/kdf.rs
+++ b/openssl/src/kdf.rs
@@ -34,15 +34,19 @@ cfg_if::cfg_if! {
         use crate::error::ErrorStack;
         use crate::ossl_param::OsslParamBuilder;
 
-        const OSSL_KDF_PARAM_PASSWORD: &CStr = c"pass";
-        const OSSL_KDF_PARAM_SALT: &CStr = c"salt";
-        const OSSL_KDF_PARAM_SECRET: &CStr = c"secret";
-        const OSSL_KDF_PARAM_ITER: &CStr = c"iter";
-        const OSSL_KDF_PARAM_SIZE: &CStr = c"size";
-        const OSSL_KDF_PARAM_THREADS: &CStr = c"threads";
-        const OSSL_KDF_PARAM_ARGON2_AD: &CStr = c"ad";
-        const OSSL_KDF_PARAM_ARGON2_LANES: &CStr = c"lanes";
-        const OSSL_KDF_PARAM_ARGON2_MEMCOST: &CStr = c"memcost";
+        // Safety: these all have null terminators.
+        // We cen remove these CStr::from_bytes_with_nul_unchecked calls
+        // when we upgrade to Rust 1.77+ with literal c"" syntax.
+
+        const OSSL_KDF_PARAM_PASSWORD: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"pass\0") };
+        const OSSL_KDF_PARAM_SALT: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"salt\0") };
+        const OSSL_KDF_PARAM_SECRET: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"secret\0") };
+        const OSSL_KDF_PARAM_ITER: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"iter\0") };
+        const OSSL_KDF_PARAM_SIZE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"size\0") };
+        const OSSL_KDF_PARAM_THREADS: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"threads\0") };
+        const OSSL_KDF_PARAM_ARGON2_AD: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"ad\0") };
+        const OSSL_KDF_PARAM_ARGON2_LANES: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"lanes\0") };
+        const OSSL_KDF_PARAM_ARGON2_MEMCOST: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"memcost\0") };
 
         #[allow(clippy::too_many_arguments)]
         pub fn argon2d(

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -177,6 +177,8 @@ pub mod memcmp;
 pub mod nid;
 #[cfg(not(osslconf = "OPENSSL_NO_OCSP"))]
 pub mod ocsp;
+#[cfg(ossl300)]
+mod ossl_param;
 pub mod pkcs12;
 pub mod pkcs5;
 #[cfg(not(any(boringssl, awslc)))]

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -78,7 +78,11 @@ impl OsslParamBuilderRef {
     /// Note, that both key and bn need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_BN)]
     #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
-    pub(crate) fn add_bn(&mut self, key: &CStr, bn: &BigNumRef) -> Result<(), ErrorStack> {
+    pub(crate) fn add_bn<'a>(
+        &'a mut self,
+        key: &'a CStr,
+        bn: &'a BigNumRef,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_BN(
                 self.as_ptr(),
@@ -94,7 +98,11 @@ impl OsslParamBuilderRef {
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_utf8_string)]
     #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
-    pub(crate) fn add_utf8_string(&mut self, key: &CStr, buf: &str) -> Result<(), ErrorStack> {
+    pub(crate) fn add_utf8_string<'a>(
+        &'a mut self,
+        key: &'a CStr,
+        buf: &'a str,
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_utf8_string(
                 self.as_ptr(),
@@ -111,7 +119,11 @@ impl OsslParamBuilderRef {
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_octet_string)]
     #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
-    pub(crate) fn add_octet_string(&mut self, key: &CStr, buf: &[u8]) -> Result<(), ErrorStack> {
+    pub(crate) fn add_octet_string<'a>(
+        &'a mut self,
+        key: &'a CStr,
+        buf: &'a [u8],
+    ) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_octet_string(
                 self.as_ptr(),
@@ -128,7 +140,7 @@ impl OsslParamBuilderRef {
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_uint)]
     #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
-    pub(crate) fn add_uint(&mut self, key: &CStr, val: u32) -> Result<(), ErrorStack> {
+    pub(crate) fn add_uint<'a>(&'a mut self, key: &'a CStr, val: u32) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_uint(
                 self.as_ptr(),

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -44,15 +44,35 @@ impl OsslParamArrayRef {
     /// to it.
     #[corresponds(OSSL_PARAM_locate)]
     #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
-    pub(crate) fn locate(&self, key: &CStr) -> Result<&OsslParamArrayRef, ErrorStack> {
+    pub(crate) fn locate<'a>(&'a self, key: &CStr) -> Result<&'a OsslParam<'a>, ErrorStack> {
         unsafe {
             let param = cvt_p(ffi::OSSL_PARAM_locate(self.as_ptr(), key.as_ptr()))?;
-            Ok(OsslParamArrayRef::from_ptr(param))
+            Ok(OsslParam::from_ptr(param))
         }
     }
+}
 
-    /// Get `BigNum` from the current OSSL_PARAM at the top of this
-    /// `OsslParamArray` reference.
+/// A reference to a single `OSSL_PARAM` structure inside
+/// an `OsslParamArray`.
+pub(crate) struct OsslParam<'a>(&'a ffi::OSSL_PARAM);
+
+impl<'a> OsslParam<'a> {
+    /// Constructs a reference to a single `OSSL_PARAM` structure
+    /// from a pointer to an interior element of an OSSL_PARAM array.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be valid and point to an `OSSL_PARAM` structure.
+    unsafe fn from_ptr(ptr: *const ffi::OSSL_PARAM) -> &'a OsslParam<'a> {
+        &*(ptr as *const OsslParam<'a>)
+    }
+
+    /// Returns a pointer to the underlying `OSSL_PARAM` structure.
+    unsafe fn as_ptr(&self) -> *const ffi::OSSL_PARAM {
+        self.0 as *const ffi::OSSL_PARAM
+    }
+
+    /// Get `BigNum` from this underlying OSSL_PARAM.
     #[corresponds(OSSL_PARAM_get_BN)]
     #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub(crate) fn get_bn(&self) -> Result<BigNum, ErrorStack> {
@@ -63,8 +83,7 @@ impl OsslParamArrayRef {
         }
     }
 
-    /// Get `&str` from the current OSSL_PARAM at the top of this
-    /// `OsslParamArray` reference.
+    /// Get `&str` from this underlying OSSL_PARAM.
     #[corresponds(OSSL_PARAM_get_utf8_string)]
     #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub(crate) fn get_utf8_string(&self) -> Result<&str, ErrorStack> {
@@ -75,8 +94,7 @@ impl OsslParamArrayRef {
         }
     }
 
-    /// Get octet string (as `&[u8]) from the current OSSL_PARAM at the
-    /// top of this `OsslParamArray` reference.
+    /// Get octet string (as `&[u8]) from this underlying OSSL_PARAM.
     #[corresponds(OSSL_PARAM_get_octet_string)]
     #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub(crate) fn get_octet_string(&self) -> Result<&[u8], ErrorStack> {

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -9,10 +9,6 @@
 //! Note, that this module is available only in OpenSSL 3.* and
 //! only internally for this crate!
 
-// Depending on which version of OpenSSL is used, and which algorithms
-// are exposed in the bindings, not all of these functions are used.
-#![allow(dead_code)]
-
 use crate::bn::{BigNum, BigNumRef};
 use crate::error::ErrorStack;
 use crate::util;
@@ -36,6 +32,7 @@ foreign_type_and_impl_send_sync! {
 impl OsslParamRef {
     /// Locates the `OsslParam` in the `OsslParam` array
     #[corresponds(OSSL_PARAM_locate)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub fn locate(&self, key: &CStr) -> Result<&OsslParamRef, ErrorStack> {
         unsafe {
             let param = cvt_p(ffi::OSSL_PARAM_locate(self.as_ptr(), key.as_ptr()))?;
@@ -45,6 +42,7 @@ impl OsslParamRef {
 
     /// Get `BigNum` from the current `OsslParam`
     #[corresponds(OSSL_PARAM_get_BN)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub fn get_bn(&self) -> Result<BigNum, ErrorStack> {
         unsafe {
             let mut bn: *mut ffi::BIGNUM = ptr::null_mut();
@@ -55,6 +53,7 @@ impl OsslParamRef {
 
     /// Get `&str` from the current `OsslParam`
     #[corresponds(OSSL_PARAM_get_utf8_string)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub fn get_utf8_string(&self) -> Result<&str, ErrorStack> {
         unsafe {
             let mut val: *const c_char = ptr::null_mut();
@@ -65,6 +64,7 @@ impl OsslParamRef {
 
     /// Get octet string (as `&[u8]) from the current `OsslParam`
     #[corresponds(OSSL_PARAM_get_octet_string)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub fn get_octet_string(&self) -> Result<&[u8], ErrorStack> {
         unsafe {
             let mut val: *const c_void = ptr::null_mut();
@@ -94,6 +94,7 @@ impl OsslParamBuilder {
     ///
     /// The array is initially empty.
     #[corresponds(OSSL_PARAM_BLD_new)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub fn new() -> Result<OsslParamBuilder, ErrorStack> {
         unsafe {
             ffi::init();
@@ -102,8 +103,10 @@ impl OsslParamBuilder {
         }
     }
 
-    /// Constructs the `OsslParam`.
+    /// Constructs the `OsslParam` and clears this builder.
     #[corresponds(OSSL_PARAM_BLD_to_param)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_param(&mut self) -> Result<OsslParam, ErrorStack> {
         unsafe {
             let params = cvt_p(ffi::OSSL_PARAM_BLD_to_param(self.0))?;
@@ -117,6 +120,7 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both key and bn need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_BN)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub fn add_bn(&mut self, key: &CStr, bn: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_BN(
@@ -132,6 +136,7 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_utf8_string)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub fn add_utf8_string(&mut self, key: &CStr, buf: &str) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_utf8_string(
@@ -148,6 +153,7 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_octet_string)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub fn add_octet_string(&mut self, key: &CStr, buf: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_octet_string(
@@ -164,6 +170,7 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_uint)]
+    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub fn add_uint(&mut self, key: &CStr, val: u32) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_uint(

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -32,7 +32,7 @@ foreign_type_and_impl_send_sync! {
 impl OsslParamRef {
     /// Locates the `OsslParam` in the `OsslParam` array
     #[corresponds(OSSL_PARAM_locate)]
-    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
+    #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub fn locate(&self, key: &CStr) -> Result<&OsslParamRef, ErrorStack> {
         unsafe {
             let param = cvt_p(ffi::OSSL_PARAM_locate(self.as_ptr(), key.as_ptr()))?;
@@ -42,7 +42,7 @@ impl OsslParamRef {
 
     /// Get `BigNum` from the current `OsslParam`
     #[corresponds(OSSL_PARAM_get_BN)]
-    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
+    #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub fn get_bn(&self) -> Result<BigNum, ErrorStack> {
         unsafe {
             let mut bn: *mut ffi::BIGNUM = ptr::null_mut();
@@ -53,7 +53,7 @@ impl OsslParamRef {
 
     /// Get `&str` from the current `OsslParam`
     #[corresponds(OSSL_PARAM_get_utf8_string)]
-    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
+    #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub fn get_utf8_string(&self) -> Result<&str, ErrorStack> {
         unsafe {
             let mut val: *const c_char = ptr::null_mut();
@@ -64,7 +64,7 @@ impl OsslParamRef {
 
     /// Get octet string (as `&[u8]) from the current `OsslParam`
     #[corresponds(OSSL_PARAM_get_octet_string)]
-    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
+    #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub fn get_octet_string(&self) -> Result<&[u8], ErrorStack> {
         unsafe {
             let mut val: *const c_void = ptr::null_mut();
@@ -120,7 +120,7 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both key and bn need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_BN)]
-    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
+    #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub fn add_bn(&mut self, key: &CStr, bn: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_BN(
@@ -136,7 +136,7 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_utf8_string)]
-    #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
+    #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub fn add_utf8_string(&mut self, key: &CStr, buf: &str) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_utf8_string(

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -77,7 +77,7 @@ impl<'a> OsslParamBuilder<'a> {
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_param(&'a mut self) -> Result<OsslParamArray, ErrorStack> {
         unsafe {
-            let params = cvt_p(ffi::OSSL_PARAM_BLD_to_param(self.builder.as_ptr()))?;
+            let params = cvt_p(ffi::OSSL_PARAM_BLD_to_param(self.as_ptr()))?;
             Ok(OsslParamArray::from_ptr(params))
         }
     }
@@ -85,7 +85,7 @@ impl<'a> OsslParamBuilder<'a> {
     /// Adds a `BigNum` to `OsslParamBuilder`.
     #[corresponds(OSSL_PARAM_BLD_push_BN)]
     #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
-    pub(crate) fn add_bn(&'a mut self, key: &'a CStr, bn: &'a BigNumRef) -> Result<(), ErrorStack> {
+    pub(crate) fn add_bn(&mut self, key: &'a CStr, bn: &'a BigNumRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_BN(
                 self.as_ptr(),
@@ -100,7 +100,7 @@ impl<'a> OsslParamBuilder<'a> {
     #[corresponds(OSSL_PARAM_BLD_push_utf8_string)]
     #[allow(dead_code)] // TODO: remove when when used by ML-DSA / ML-KEM
     pub(crate) fn add_utf8_string(
-        &'a mut self,
+        &mut self,
         key: &'a CStr,
         buf: &'a str,
     ) -> Result<(), ErrorStack> {
@@ -119,7 +119,7 @@ impl<'a> OsslParamBuilder<'a> {
     #[corresponds(OSSL_PARAM_BLD_push_octet_string)]
     #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
     pub(crate) fn add_octet_string(
-        &'a mut self,
+        &mut self,
         key: &'a CStr,
         buf: &'a [u8],
     ) -> Result<(), ErrorStack> {
@@ -137,7 +137,7 @@ impl<'a> OsslParamBuilder<'a> {
     /// Adds a unsigned int to `OsslParamBuilder`.
     #[corresponds(OSSL_PARAM_BLD_push_uint)]
     #[cfg_attr(any(not(ossl320), osslconf = "OPENSSL_NO_ARGON2"), allow(dead_code))]
-    pub(crate) fn add_uint(&'a mut self, key: &'a CStr, val: u32) -> Result<(), ErrorStack> {
+    pub(crate) fn add_uint(&mut self, key: &'a CStr, val: u32) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_uint(
                 self.as_ptr(),
@@ -149,7 +149,7 @@ impl<'a> OsslParamBuilder<'a> {
     }
 
     /// Returns a raw pointer to the underlying `OSSL_PARAM_BLD` structure.
-    pub(crate) unsafe fn as_ptr(&self) -> *mut ffi::OSSL_PARAM_BLD {
+    pub(crate) unsafe fn as_ptr(&mut self) -> *mut ffi::OSSL_PARAM_BLD {
         self.builder.as_ptr()
     }
 }

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -33,17 +33,12 @@ foreign_type_and_impl_send_sync! {
     pub struct OsslParamRef;
 }
 
-impl OsslParam {}
-
 impl OsslParamRef {
     /// Locates the `OsslParam` in the `OsslParam` array
     #[corresponds(OSSL_PARAM_locate)]
-    pub fn locate(&self, key: &[u8]) -> Result<&OsslParamRef, ErrorStack> {
+    pub fn locate(&self, key: &CStr) -> Result<&OsslParamRef, ErrorStack> {
         unsafe {
-            let param = cvt_p(ffi::OSSL_PARAM_locate(
-                self.as_ptr(),
-                key.as_ptr() as *const c_char,
-            ))?;
+            let param = cvt_p(ffi::OSSL_PARAM_locate(self.as_ptr(), key.as_ptr()))?;
             Ok(OsslParamRef::from_ptr(param))
         }
     }
@@ -109,7 +104,7 @@ impl OsslParamBuilder {
 
     /// Constructs the `OsslParam`.
     #[corresponds(OSSL_PARAM_BLD_to_param)]
-    pub fn to_param(&self) -> Result<OsslParam, ErrorStack> {
+    pub fn to_param(&mut self) -> Result<OsslParam, ErrorStack> {
         unsafe {
             let params = cvt_p(ffi::OSSL_PARAM_BLD_to_param(self.0))?;
             Ok(OsslParam::from_ptr(params))
@@ -122,11 +117,11 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both key and bn need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_BN)]
-    pub fn add_bn(&self, key: &[u8], bn: &BigNumRef) -> Result<(), ErrorStack> {
+    pub fn add_bn(&mut self, key: &CStr, bn: &BigNumRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_BN(
                 self.as_ptr(),
-                key.as_ptr() as *const c_char,
+                key.as_ptr(),
                 bn.as_ptr(),
             ))
             .map(|_| ())
@@ -137,11 +132,11 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_utf8_string)]
-    pub fn add_utf8_string(&self, key: &[u8], buf: &str) -> Result<(), ErrorStack> {
+    pub fn add_utf8_string(&mut self, key: &CStr, buf: &str) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_utf8_string(
                 self.as_ptr(),
-                key.as_ptr() as *const c_char,
+                key.as_ptr(),
                 buf.as_ptr() as *const c_char,
                 buf.len(),
             ))
@@ -153,11 +148,11 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_octet_string)]
-    pub fn add_octet_string(&self, key: &[u8], buf: &[u8]) -> Result<(), ErrorStack> {
+    pub fn add_octet_string(&mut self, key: &CStr, buf: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_octet_string(
                 self.as_ptr(),
-                key.as_ptr() as *const c_char,
+                key.as_ptr(),
                 buf.as_ptr() as *const c_void,
                 buf.len(),
             ))
@@ -169,11 +164,11 @@ impl OsslParamBuilderRef {
     ///
     /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
     #[corresponds(OSSL_PARAM_BLD_push_uint)]
-    pub fn add_uint(&self, key: &[u8], val: u32) -> Result<(), ErrorStack> {
+    pub fn add_uint(&mut self, key: &CStr, val: u32) -> Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::OSSL_PARAM_BLD_push_uint(
                 self.as_ptr(),
-                key.as_ptr() as *const c_char,
+                key.as_ptr(),
                 val as c_uint,
             ))
             .map(|_| ())

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -1,0 +1,182 @@
+//! OSSL_PARAM management for OpenSSL 3.*
+//!
+//! The OSSL_PARAM structure represents generic attribute that can represent various
+//! properties in OpenSSL, including keys and operations.
+//!
+//! For convinience, the OSSL_PARAM_BLD builder can be used to dynamically construct
+//! these structure.
+//!
+//! Note, that this module is available only in OpenSSL 3.* and
+//! only internally for this crate!
+
+// Depending on which version of OpenSSL is used, and which algorithms
+// are exposed in the bindings, not all of these functions are used.
+#![allow(dead_code)]
+
+use crate::bn::{BigNum, BigNumRef};
+use crate::error::ErrorStack;
+use crate::util;
+use crate::{cvt, cvt_p};
+use foreign_types::{ForeignType, ForeignTypeRef};
+use libc::{c_char, c_uint, c_void};
+use openssl_macros::corresponds;
+use std::ffi::CStr;
+use std::ptr;
+
+foreign_type_and_impl_send_sync! {
+    type CType = ffi::OSSL_PARAM;
+    fn drop = ffi::OSSL_PARAM_free;
+
+    /// `OsslParam` constructed using `OsslParamBuilder`.
+    pub struct OsslParam;
+    /// Reference to `OsslParam`.
+    pub struct OsslParamRef;
+}
+
+impl OsslParam {}
+
+impl OsslParamRef {
+    /// Locates the `OsslParam` in the `OsslParam` array
+    #[corresponds(OSSL_PARAM_locate)]
+    pub fn locate(&self, key: &[u8]) -> Result<&OsslParamRef, ErrorStack> {
+        unsafe {
+            let param = cvt_p(ffi::OSSL_PARAM_locate(
+                self.as_ptr(),
+                key.as_ptr() as *const c_char,
+            ))?;
+            Ok(OsslParamRef::from_ptr(param))
+        }
+    }
+
+    /// Get `BigNum` from the current `OsslParam`
+    #[corresponds(OSSL_PARAM_get_BN)]
+    pub fn get_bn(&self) -> Result<BigNum, ErrorStack> {
+        unsafe {
+            let mut bn: *mut ffi::BIGNUM = ptr::null_mut();
+            cvt(ffi::OSSL_PARAM_get_BN(self.as_ptr(), &mut bn))?;
+            Ok(BigNum::from_ptr(bn))
+        }
+    }
+
+    /// Get `&str` from the current `OsslParam`
+    #[corresponds(OSSL_PARAM_get_utf8_string)]
+    pub fn get_utf8_string(&self) -> Result<&str, ErrorStack> {
+        unsafe {
+            let mut val: *const c_char = ptr::null_mut();
+            cvt(ffi::OSSL_PARAM_get_utf8_string_ptr(self.as_ptr(), &mut val))?;
+            Ok(CStr::from_ptr(val).to_str().unwrap())
+        }
+    }
+
+    /// Get octet string (as `&[u8]) from the current `OsslParam`
+    #[corresponds(OSSL_PARAM_get_octet_string)]
+    pub fn get_octet_string(&self) -> Result<&[u8], ErrorStack> {
+        unsafe {
+            let mut val: *const c_void = ptr::null_mut();
+            let mut val_len: usize = 0;
+            cvt(ffi::OSSL_PARAM_get_octet_string_ptr(
+                self.as_ptr(),
+                &mut val,
+                &mut val_len,
+            ))?;
+            Ok(util::from_raw_parts(val as *const u8, val_len))
+        }
+    }
+}
+
+foreign_type_and_impl_send_sync! {
+    type CType = ffi::OSSL_PARAM_BLD;
+    fn drop = ffi::OSSL_PARAM_BLD_free;
+
+    /// Builder used to construct `OsslParam`.
+    pub struct OsslParamBuilder;
+    /// Reference to `OsslParamBuilder`.
+    pub struct OsslParamBuilderRef;
+}
+
+impl OsslParamBuilder {
+    /// Returns a builder for a OsslParam arrays.
+    ///
+    /// The array is initially empty.
+    #[corresponds(OSSL_PARAM_BLD_new)]
+    pub fn new() -> Result<OsslParamBuilder, ErrorStack> {
+        unsafe {
+            ffi::init();
+
+            cvt_p(ffi::OSSL_PARAM_BLD_new()).map(OsslParamBuilder)
+        }
+    }
+
+    /// Constructs the `OsslParam`.
+    #[corresponds(OSSL_PARAM_BLD_to_param)]
+    pub fn to_param(&self) -> Result<OsslParam, ErrorStack> {
+        unsafe {
+            let params = cvt_p(ffi::OSSL_PARAM_BLD_to_param(self.0))?;
+            Ok(OsslParam::from_ptr(params))
+        }
+    }
+}
+
+impl OsslParamBuilderRef {
+    /// Adds a `BigNum` to `OsslParamBuilder`.
+    ///
+    /// Note, that both key and bn need to exist until the `to_param` is called!
+    #[corresponds(OSSL_PARAM_BLD_push_BN)]
+    pub fn add_bn(&self, key: &[u8], bn: &BigNumRef) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::OSSL_PARAM_BLD_push_BN(
+                self.as_ptr(),
+                key.as_ptr() as *const c_char,
+                bn.as_ptr(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Adds a utf8 string to `OsslParamBuilder`.
+    ///
+    /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
+    #[corresponds(OSSL_PARAM_BLD_push_utf8_string)]
+    pub fn add_utf8_string(&self, key: &[u8], buf: &str) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::OSSL_PARAM_BLD_push_utf8_string(
+                self.as_ptr(),
+                key.as_ptr() as *const c_char,
+                buf.as_ptr() as *const c_char,
+                buf.len(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Adds a octet string to `OsslParamBuilder`.
+    ///
+    /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
+    #[corresponds(OSSL_PARAM_BLD_push_octet_string)]
+    pub fn add_octet_string(&self, key: &[u8], buf: &[u8]) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::OSSL_PARAM_BLD_push_octet_string(
+                self.as_ptr(),
+                key.as_ptr() as *const c_char,
+                buf.as_ptr() as *const c_void,
+                buf.len(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Adds a unsigned int to `OsslParamBuilder`.
+    ///
+    /// Note, that both `key` and `buf` need to exist until the `to_param` is called!
+    #[corresponds(OSSL_PARAM_BLD_push_uint)]
+    pub fn add_uint(&self, key: &[u8], val: u32) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::OSSL_PARAM_BLD_push_uint(
+                self.as_ptr(),
+                key.as_ptr() as *const c_char,
+                val as c_uint,
+            ))
+            .map(|_| ())
+        }
+    }
+}


### PR DESCRIPTION
Splitting up #2405 into a few parts as suggest by @alex.

This adds the param-builder.

Original commit message:

Add internal module to simplify working with OSSL_PARAM structure We discussed that this API is not well suitable for the end users but still, it required for several operations in OpenSSL 3.* so instead of calling to FFI for every use of this API, this introduces simple wrappers that allow building of the params and their usage.