### PR TITLE
ec-point: add set_affine_coordinates

### DIFF
--- a/openssl-sys/src/handwritten/ec.rs
+++ b/openssl-sys/src/handwritten/ec.rs
@@ -116,6 +116,14 @@ extern "C" {
         y: *mut BIGNUM,
         ctx: *mut BN_CTX,
     ) -> c_int;
+    #[cfg(any(ossl111, boringssl, libressl350, awslc))]
+    pub fn EC_POINT_set_affine_coordinates(
+        group: *const EC_GROUP,
+        p: *mut EC_POINT,
+        x: *const BIGNUM,
+        y: *const BIGNUM,
+        ctx: *mut BN_CTX,
+    ) -> c_int;
 
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,

--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -561,6 +561,29 @@ impl EcPointRef {
         }
     }
 
+    /// Sets affine coordinates of a point on an elliptic curve using the provided
+    /// `x` and `y` `BigNum`s
+    #[corresponds(EC_POINT_set_affine_coordinates)]
+    #[cfg(any(ossl111, boringssl, libressl350, awslc))]
+    pub fn set_affine_coordinates(
+        &mut self,
+        group: &EcGroupRef,
+        x: &BigNumRef,
+        y: &BigNumRef,
+        ctx: &mut BigNumContextRef,
+    ) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::EC_POINT_set_affine_coordinates(
+                group.as_ptr(),
+                self.as_ptr(),
+                x.as_ptr(),
+                y.as_ptr(),
+                ctx.as_ptr(),
+            ))
+            .map(|_| ())
+        }
+    }
+
     /// Sets affine coordinates of a curve over a prime field using the provided
     /// `x` and `y` `BigNum`s
     #[corresponds(EC_POINT_set_affine_coordinates_GFp)]
@@ -1062,8 +1085,15 @@ mod test {
         let _curve = EcGroup::from_components(p, a, b, &mut ctx).unwrap();
     }
 
-    #[test]
-    fn ec_point_set_affine() {
+    fn set_affine_coords_test(
+        set_affine_coords: fn(
+            &mut EcPointRef,
+            &EcGroupRef,
+            &BigNumRef,
+            &BigNumRef,
+            &mut BigNumContextRef,
+        ) -> Result<(), ErrorStack>,
+    ) {
         // parameters are from secp256r1
         let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
         let mut ctx = BigNumContext::new().unwrap();
@@ -1076,10 +1106,20 @@ mod test {
             "4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5",
         )
         .unwrap();
-        gen_point
-            .set_affine_coordinates_gfp(&group, &gen_x, &gen_y, &mut ctx)
-            .unwrap();
+        set_affine_coords(&mut gen_point, &group, &gen_x, &gen_y, &mut ctx).unwrap();
+
         assert!(gen_point.is_on_curve(&group, &mut ctx).unwrap());
+    }
+
+    #[test]
+    fn ec_point_set_affine_gfp() {
+        set_affine_coords_test(EcPointRef::set_affine_coordinates_gfp)
+    }
+
+    #[test]
+    #[cfg(any(ossl111, boringssl, libressl350, awslc))]
+    fn ec_point_set_affine() {
+        set_affine_coords_test(EcPointRef::set_affine_coordinates)
     }
 
     #[test]


### PR DESCRIPTION
`EC_POINT_set_affine_coordinates_GFp` is deprecated, `EC_POINT_set_affine_coordinates` is the replacement for the deprecated symbol.

- **sys/ec: add EC_POINT_set_affine_coordinates**
- **EcPointRef: add set_affine_coordinates**
