### PR TITLE
Add {X509Req, X509}::check_private_key

### DIFF
--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -779,3 +779,15 @@ const_ptr_api! {
         pub fn X509_ATTRIBUTE_dup(x: #[const_ptr_if(ossl300)] X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
     }
 }
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_check_private_key(
+            cert: #[const_ptr_if(any(ossl110, libressl280, boringssl, awslc))] X509,
+            pkey: #[const_ptr_if(any(ossl110, libressl280, boringssl, awslc))] EVP_PKEY
+        ) -> c_int;
+        pub fn X509_REQ_check_private_key(
+            req: #[const_ptr_if(any(ossl320, boringssl, awslc))] X509_REQ,
+            pkey: #[const_ptr_if(any(boringssl, awslc))] EVP_PKEY
+        ) -> c_int;
+    }
+}

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -32,7 +32,7 @@ use crate::error::ErrorStack;
 use crate::ex_data::Index;
 use crate::hash::{DigestBytes, MessageDigest};
 use crate::nid::Nid;
-use crate::pkey::{HasPrivate, HasPublic, PKey, PKeyRef, Public};
+use crate::pkey::{HasPrivate, HasPublic, PKey, PKeyRef, Private, Public};
 use crate::ssl::SslRef;
 use crate::stack::{Stack, StackRef, Stackable};
 use crate::string::OpensslString;
@@ -664,6 +664,12 @@ impl X509Ref {
                 Some(util::from_raw_parts(ptr, len as usize))
             }
         }
+    }
+
+    /// Checks for consistency between the private key and this certificate.
+    #[corresponds(X509_check_private_key)]
+    pub fn check_private_key(&self, pkey: &PKeyRef<Private>) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::X509_check_private_key(self.as_ptr(), pkey.as_ptr())).map(|_| ()) }
     }
 
     to_pem! {
@@ -1569,6 +1575,18 @@ impl X509ReqRef {
         unsafe {
             let extensions = cvt_p(ffi::X509_REQ_get_extensions(self.as_ptr()))?;
             Ok(Stack::from_ptr(extensions))
+        }
+    }
+
+    /// Checks for consistency between the private key and this certificate request.
+    #[corresponds(X509_REQ_check_private_key)]
+    pub fn check_private_key(&self, pkey: &PKeyRef<Private>) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::X509_REQ_check_private_key(
+                self.as_ptr(),
+                pkey.as_ptr(),
+            ))
+            .map(|_| ())
         }
     }
 }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -1196,3 +1196,19 @@ fn test_store_all_certificates() {
 
     assert_eq!(store.all_certificates().len(), 1);
 }
+
+#[test]
+fn test_check_private_key() {
+    let ca_cert = include_bytes!("../../test/root-ca.pem");
+    let ca_cert = X509::from_pem(ca_cert).unwrap();
+    let cert = include_bytes!("../../test/cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+    let csr = include_bytes!("../../test/csr.pem");
+    let csr = X509Req::from_pem(csr).unwrap();
+    let pkey = include_bytes!("../../test/key.pem");
+    let pkey = PKey::private_key_from_pem(pkey).unwrap();
+
+    assert!(ca_cert.check_private_key(&pkey).is_err());
+    assert!(cert.check_private_key(&pkey).is_ok());
+    assert!(csr.check_private_key(&pkey).is_ok());
+}


### PR DESCRIPTION
- BoringSSL and AWS-LC marked arguments as const for about a year, which I assume is enough to apply it unconditionally with always-use-git-master kind of libraries.
- Even before constification, the OpenSSL implementation did not mutate the objects in any way. I hope that justifes the use of shared refs.
- The interface is intentionally limited to `PKeyRef<Private>`, as the man page admits that accepting public keys in the underlying functions is a bug.