### PR TITLE
Add bindings for SSL_CIPHER_get_protocol_id

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -478,6 +478,7 @@ const_ptr_api! {
 extern "C" {
     #[cfg(ossl111)]
     pub fn SSL_CIPHER_get_handshake_digest(cipher: *const SSL_CIPHER) -> *const EVP_MD;
+    pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const c_char;
     #[cfg(ossl111)]
     pub fn SSL_CIPHER_standard_name(cipher: *const SSL_CIPHER) -> *const c_char;

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -478,6 +478,7 @@ const_ptr_api! {
 extern "C" {
     #[cfg(ossl111)]
     pub fn SSL_CIPHER_get_handshake_digest(cipher: *const SSL_CIPHER) -> *const EVP_MD;
+    #[cfg(ossl111)]
     pub fn SSL_CIPHER_get_protocol_id(cipher: *const SSL_CIPHER) -> u16;
     pub fn SSL_CIPHER_get_name(cipher: *const SSL_CIPHER) -> *const c_char;
     #[cfg(ossl111)]

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -2143,6 +2143,15 @@ impl SslCipherRef {
             Some(Nid::from_raw(n))
         }
     }
+
+    /// Returns the two-byte ID of the cipher
+    #[corresponds(SSL_CIPHER_get_protocol_id)]
+    pub fn protocol_id(&self) -> [u8; 2] {
+        unsafe {
+            let id = ffi::SSL_CIPHER_get_protocol_id(self.as_ptr());
+            id.to_be_bytes()
+        }
+    }
 }
 
 impl fmt::Debug for SslCipherRef {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -2146,6 +2146,7 @@ impl SslCipherRef {
 
     /// Returns the two-byte ID of the cipher
     #[corresponds(SSL_CIPHER_get_protocol_id)]
+    #[cfg(ossl111)]
     pub fn protocol_id(&self) -> [u8; 2] {
         unsafe {
             let id = ffi::SSL_CIPHER_get_protocol_id(self.as_ptr());

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -2145,6 +2145,8 @@ impl SslCipherRef {
     }
 
     /// Returns the two-byte ID of the cipher
+    ///
+    /// Requires OpenSSL 1.1.1 or newer.
     #[corresponds(SSL_CIPHER_get_protocol_id)]
     #[cfg(ossl111)]
     pub fn protocol_id(&self) -> [u8; 2] {

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1692,7 +1692,10 @@ fn ssl_ex_data_leak() {
 #[cfg(ossl111)]
 fn cipher_id() {
     let mut server = Server::builder();
-    server.ctx().set_ciphersuites("TLS_AES_256_GCM_SHA384").unwrap();
+    server
+        .ctx()
+        .set_ciphersuites("TLS_AES_256_GCM_SHA384")
+        .unwrap();
     let server = server.build();
 
     let client = server.client();

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1687,3 +1687,18 @@ fn ssl_ex_data_leak() {
     drop(ssl);
     assert_eq!(DROPS.load(Ordering::Relaxed), 2);
 }
+
+#[test]
+#[cfg(ossl111)]
+fn cipher_id() {
+    let mut server = Server::builder();
+    server.ctx().set_ciphersuites("TLS_AES_256_GCM_SHA384").unwrap();
+    let server = server.build();
+
+    let client = server.client();
+    let s = client.connect();
+    let ssl = s.ssl();
+    let cipher = ssl.current_cipher().unwrap();
+    let cipher_id = cipher.protocol_id();
+    assert_eq!(cipher_id, [0x13, 0x02]);
+}


### PR DESCRIPTION
[`SSL_CIPHER_get_protocol_id`](https://docs.openssl.org/master/man3/SSL_CIPHER_get_name/)

This includes both bindings for `openssl-sys` and high-level bindings for `openssl`. I wasn't sure whether to use `[u8; 2]` or `u16` for the high-level return type, decided on `[u8; 2]` for now as it feels more natural, I can change this if `u16` (the same as in C) is better.