### PR TITLE
sys/evp: add EVP_PKEY_eq and EVP_PKEY_parameters_eq

### DIFF
--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -520,7 +520,12 @@ extern "C" {
         length: c_long,
     ) -> *mut EVP_PKEY;
 
+    #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> c_int;
+    #[cfg(ossl300)]
+    pub fn EVP_PKEY_eq(a: *const EVP_PKEY, b: *const EVP_PKEY) -> c_int;
+    #[cfg(ossl300)]
+    pub fn EVP_PKEY_parameters_eq(a: *const EVP_PKEY, b: *const EVP_PKEY) -> c_int;
 
     pub fn EVP_PKEY_copy_parameters(to: *mut EVP_PKEY, from: *const EVP_PKEY) -> c_int;
 


### PR DESCRIPTION
`EVP_PKEY_eq` is the replacement for the deprecated `EVP_PKEY_cmp`