### PR TITLE
Expose Pkey underlying pointer and add EVP_PKEY_set_alias_type ffi call

### DIFF
--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -623,7 +623,8 @@ extern "C" {
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> c_int;
     pub fn EVP_PKEY_keygen(ctx: *mut EVP_PKEY_CTX, key: *mut *mut EVP_PKEY) -> c_int;
     pub fn EVP_PKEY_paramgen(ctx: *mut EVP_PKEY_CTX, key: *mut *mut EVP_PKEY) -> c_int;
-
+    #[cfg(ossl111)]
+    pub fn EVP_PKEY_set_alias_type(k: *mut EVP_PKEY, id: c_int) -> c_int;
     #[cfg(ossl111)]
     pub fn EVP_PKEY_param_check(ctx: *mut EVP_PKEY_CTX) -> c_int;
     #[cfg(ossl111)]

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -229,6 +229,11 @@ where
         ffi::i2d_PUBKEY
     }
 
+    /// Returns the pointer of underlying [`ffi::EVP_PKEY`]
+    pub fn as_ptr(&self) -> *mut ffi::EVP_PKEY {
+        ForeignTypeRef::as_ptr(self)
+    }
+
     /// Returns the size of the key.
     ///
     /// This corresponds to the bit length of the modulus of an RSA key, and the bit length of the


### PR DESCRIPTION
Hi, I want to add two api

1. Add `as_ptr` on PKey<Private>, so we can get underlying pointer of it.
2. Add [EVP_PKEY_set_alias_type](https://docs.openssl.org/1.1.1/man3/EVP_PKEY_set1_RSA/) for openssl 1.1.1 usage, which was removed in openssl 3.0.

```rust
let inner = pkey.as_ptr();
unsafe {
    if EVP_PKEY_set_alias_type(inner, EVP_PKEY_SM2) == 0 {
        panic!("set alias error")
    }
}
```