### PR TITLE
Remove support for LibreSSL < 2.8

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -8,19 +8,11 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         cfgs.push("libressl251");
         cfgs.push("libressl252");
         cfgs.push("libressl261");
+        cfgs.push("libressl270");
+        cfgs.push("libressl271");
+        cfgs.push("libressl273");
+        cfgs.push("libressl280");
 
-        if libressl_version >= 0x2_07_00_00_0 {
-            cfgs.push("libressl270");
-        }
-        if libressl_version >= 0x2_07_01_00_0 {
-            cfgs.push("libressl271");
-        }
-        if libressl_version >= 0x2_07_03_00_0 {
-            cfgs.push("libressl273");
-        }
-        if libressl_version >= 0x2_08_00_00_0 {
-            cfgs.push("libressl280");
-        }
         if libressl_version >= 0x2_08_01_00_0 {
             cfgs.push("libressl281");
         }

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -418,7 +418,6 @@ See rust-openssl documentation for more information:
         let minor = (libressl_version >> 20) as u8;
         let fix = (libressl_version >> 12) as u8;
         let (major, minor, fix) = match (major, minor, fix) {
-            (2, 7, _) => ('2', '7', 'x'),
             (2, 8, 0) => ('2', '8', '0'),
             (2, 8, 1) => ('2', '8', '1'),
             (2, 8, _) => ('2', '8', 'x'),
@@ -493,7 +492,7 @@ fn version_error() -> ! {
     panic!(
         "
 
-This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3), or LibreSSL 2.7
+This crate is only compatible with OpenSSL (version 1.0.1 through 1.1.1, or 3), or LibreSSL 2.8
 through 4.1.x, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 

--- a/openssl-sys/src/bio.rs
+++ b/openssl-sys/src/bio.rs
@@ -34,37 +34,37 @@ pub unsafe fn BIO_get_mem_data(b: *mut BIO, pp: *mut *mut c_char) -> c_long {
 
 extern "C" {
     #[deprecated(note = "use BIO_meth_set_write__fixed_rust instead")]
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_meth_set_write(
         biom: *mut BIO_METHOD,
         write: unsafe extern "C" fn(*mut BIO, *const c_char, c_int) -> c_int,
     ) -> c_int;
     #[deprecated(note = "use BIO_meth_set_read__fixed_rust instead")]
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_meth_set_read(
         biom: *mut BIO_METHOD,
         read: unsafe extern "C" fn(*mut BIO, *mut c_char, c_int) -> c_int,
     ) -> c_int;
     #[deprecated(note = "use BIO_meth_set_puts__fixed_rust instead")]
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_meth_set_puts(
         biom: *mut BIO_METHOD,
         read: unsafe extern "C" fn(*mut BIO, *const c_char) -> c_int,
     ) -> c_int;
     #[deprecated(note = "use BIO_meth_set_ctrl__fixed_rust instead")]
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_meth_set_ctrl(
         biom: *mut BIO_METHOD,
         read: unsafe extern "C" fn(*mut BIO, c_int, c_long, *mut c_void) -> c_long,
     ) -> c_int;
     #[deprecated(note = "use BIO_meth_set_create__fixed_rust instead")]
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_meth_set_create(
         biom: *mut BIO_METHOD,
         create: unsafe extern "C" fn(*mut BIO) -> c_int,
     ) -> c_int;
     #[deprecated(note = "use BIO_meth_set_destroy__fixed_rust instead")]
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_meth_set_destroy(
         biom: *mut BIO_METHOD,
         destroy: unsafe extern "C" fn(*mut BIO) -> c_int,

--- a/openssl-sys/src/crypto.rs
+++ b/openssl-sys/src/crypto.rs
@@ -116,7 +116,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl271))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub const OPENSSL_VERSION: c_int = 0;
         pub const OPENSSL_CFLAGS: c_int = 1;
         pub const OPENSSL_BUILT_ON: c_int = 2;

--- a/openssl-sys/src/handwritten/asn1.rs
+++ b/openssl-sys/src/handwritten/asn1.rs
@@ -47,7 +47,7 @@ pub union ASN1_TYPE_value {
 
 extern "C" {
     pub fn ASN1_STRING_type_new(ty: c_int) -> *mut ASN1_STRING;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn ASN1_STRING_get0_data(x: *const ASN1_STRING) -> *const c_uchar;
     #[cfg(any(all(ossl101, not(ossl110)), libressl))]
     pub fn ASN1_STRING_data(x: *mut ASN1_STRING) -> *mut c_uchar;
@@ -107,9 +107,9 @@ extern "C" {
 
 const_ptr_api! {
     extern "C" {
-        pub fn ASN1_STRING_to_UTF8(out: *mut *mut c_uchar, s: #[const_ptr_if(any(ossl110, libressl280))] ASN1_STRING) -> c_int;
-        pub fn ASN1_STRING_type(x: #[const_ptr_if(any(ossl110, libressl280))]  ASN1_STRING) -> c_int;
-        pub fn ASN1_generate_v3(str: #[const_ptr_if(any(ossl110, libressl280))] c_char, cnf: *mut X509V3_CTX) -> *mut ASN1_TYPE;
+        pub fn ASN1_STRING_to_UTF8(out: *mut *mut c_uchar, s: #[const_ptr_if(any(ossl110, libressl))] ASN1_STRING) -> c_int;
+        pub fn ASN1_STRING_type(x: #[const_ptr_if(any(ossl110, libressl))]  ASN1_STRING) -> c_int;
+        pub fn ASN1_generate_v3(str: #[const_ptr_if(any(ossl110, libressl))] c_char, cnf: *mut X509V3_CTX) -> *mut ASN1_TYPE;
         pub fn i2d_ASN1_TYPE(a: #[const_ptr_if(ossl300)] ASN1_TYPE, pp: *mut *mut c_uchar) -> c_int;
     }
 }

--- a/openssl-sys/src/handwritten/bio.rs
+++ b/openssl-sys/src/handwritten/bio.rs
@@ -10,7 +10,7 @@ pub type bio_info_cb =
     Option<unsafe extern "C" fn(*mut BIO, c_int, *const c_char, c_int, c_long, c_long)>;
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum BIO_METHOD {}
     } else {
         #[repr(C)]
@@ -31,18 +31,18 @@ cfg_if! {
 
 const_ptr_api! {
     extern "C" {
-        pub fn BIO_s_file() -> #[const_ptr_if(any(ossl110, libressl280))] BIO_METHOD;
-        pub fn BIO_new(type_: #[const_ptr_if(any(ossl110, libressl280))] BIO_METHOD) -> *mut BIO;
+        pub fn BIO_s_file() -> #[const_ptr_if(any(ossl110, libressl))] BIO_METHOD;
+        pub fn BIO_new(type_: #[const_ptr_if(any(ossl110, libressl))] BIO_METHOD) -> *mut BIO;
     }
 }
 extern "C" {
     #[cfg(not(osslconf = "OPENSSL_NO_STDIO"))]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: c_int) -> *mut BIO;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_set_data(a: *mut BIO, data: *mut c_void);
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_get_data(a: *mut BIO) -> *mut c_void;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_set_init(a: *mut BIO, init: c_int);
     pub fn BIO_write(b: *mut BIO, buf: *const c_void, len: c_int) -> c_int;
     pub fn BIO_read(b: *mut BIO, buf: *mut c_void, len: c_int) -> c_int;
@@ -52,8 +52,8 @@ extern "C" {
 
 const_ptr_api! {
     extern "C" {
-        pub fn BIO_s_mem() -> #[const_ptr_if(any(ossl110, libressl280))] BIO_METHOD;
-        pub fn BIO_new_mem_buf(buf: #[const_ptr_if(any(ossl102, libressl280))] c_void, len: c_int) -> *mut BIO;
+        pub fn BIO_s_mem() -> #[const_ptr_if(any(ossl110, libressl))] BIO_METHOD;
+        pub fn BIO_new_mem_buf(buf: #[const_ptr_if(any(ossl102, libressl))] c_void, len: c_int) -> *mut BIO;
     }
 }
 
@@ -61,45 +61,45 @@ extern "C" {
     #[cfg(not(osslconf = "OPENSSL_NO_SOCK"))]
     pub fn BIO_new_socket(sock: c_int, close_flag: c_int) -> *mut BIO;
 
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_meth_new(type_: c_int, name: *const c_char) -> *mut BIO_METHOD;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn BIO_meth_free(biom: *mut BIO_METHOD);
 }
 
 #[allow(clashing_extern_declarations)]
 extern "C" {
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     #[link_name = "BIO_meth_set_write"]
     pub fn BIO_meth_set_write__fixed_rust(
         biom: *mut BIO_METHOD,
         write: Option<unsafe extern "C" fn(*mut BIO, *const c_char, c_int) -> c_int>,
     ) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     #[link_name = "BIO_meth_set_read"]
     pub fn BIO_meth_set_read__fixed_rust(
         biom: *mut BIO_METHOD,
         read: Option<unsafe extern "C" fn(*mut BIO, *mut c_char, c_int) -> c_int>,
     ) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     #[link_name = "BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts__fixed_rust(
         biom: *mut BIO_METHOD,
         read: Option<unsafe extern "C" fn(*mut BIO, *const c_char) -> c_int>,
     ) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     #[link_name = "BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl__fixed_rust(
         biom: *mut BIO_METHOD,
         read: Option<unsafe extern "C" fn(*mut BIO, c_int, c_long, *mut c_void) -> c_long>,
     ) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     #[link_name = "BIO_meth_set_create"]
     pub fn BIO_meth_set_create__fixed_rust(
         biom: *mut BIO_METHOD,
         create: Option<unsafe extern "C" fn(*mut BIO) -> c_int>,
     ) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     #[link_name = "BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy__fixed_rust(
         biom: *mut BIO_METHOD,

--- a/openssl-sys/src/handwritten/crypto.rs
+++ b/openssl-sys/src/handwritten/crypto.rs
@@ -4,7 +4,7 @@ use libc::*;
 stack!(stack_st_void);
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl271))] {
+    if #[cfg(any(ossl110, libressl))] {
         extern "C" {
             pub fn OpenSSL_version_num() -> c_ulong;
             pub fn OpenSSL_version(key: c_int) -> *const c_char;

--- a/openssl-sys/src/handwritten/dh.rs
+++ b/openssl-sys/src/handwritten/dh.rs
@@ -41,9 +41,9 @@ extern "C" {
     #[cfg(ossl102)]
     pub fn DH_get_2048_256() -> *mut DH;
 
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DH_set0_pqg(dh: *mut DH, p: *mut BIGNUM, q: *mut BIGNUM, g: *mut BIGNUM) -> c_int;
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DH_get0_pqg(
         dh: *const DH,
         p: *mut *const BIGNUM,
@@ -51,9 +51,9 @@ extern "C" {
         g: *mut *const BIGNUM,
     );
 
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DH_set0_key(dh: *mut DH, pub_key: *mut BIGNUM, priv_key: *mut BIGNUM) -> c_int;
 
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DH_get0_key(dh: *const DH, pub_key: *mut *const BIGNUM, priv_key: *mut *const BIGNUM);
 }

--- a/openssl-sys/src/handwritten/dsa.rs
+++ b/openssl-sys/src/handwritten/dsa.rs
@@ -8,7 +8,7 @@ extern "C" {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum DSA_SIG {}
     } else {
       #[repr(C)]
@@ -60,18 +60,18 @@ extern "C" {
     pub fn i2d_DSAPublicKey(a: *const DSA, pp: *mut *mut c_uchar) -> c_int;
     pub fn i2d_DSAPrivateKey(a: *const DSA, pp: *mut *mut c_uchar) -> c_int;
 
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DSA_get0_pqg(
         d: *const DSA,
         p: *mut *const BIGNUM,
         q: *mut *const BIGNUM,
         q: *mut *const BIGNUM,
     );
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DSA_set0_pqg(d: *mut DSA, p: *mut BIGNUM, q: *mut BIGNUM, q: *mut BIGNUM) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DSA_get0_key(d: *const DSA, pub_key: *mut *const BIGNUM, priv_key: *mut *const BIGNUM);
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DSA_set0_key(d: *mut DSA, pub_key: *mut BIGNUM, priv_key: *mut BIGNUM) -> c_int;
 }
 
@@ -86,9 +86,9 @@ extern "C" {
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, pr: *mut *const BIGNUM, ps: *mut *const BIGNUM);
 
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, pr: *mut BIGNUM, ps: *mut BIGNUM) -> c_int;
 }

--- a/openssl-sys/src/handwritten/ec.rs
+++ b/openssl-sys/src/handwritten/ec.rs
@@ -246,7 +246,7 @@ extern "C" {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum ECDSA_SIG {}
     } else {
         #[repr(C)]
@@ -262,10 +262,10 @@ extern "C" {
 
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn ECDSA_SIG_get0(sig: *const ECDSA_SIG, pr: *mut *const BIGNUM, ps: *mut *const BIGNUM);
 
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn ECDSA_SIG_set0(sig: *mut ECDSA_SIG, pr: *mut BIGNUM, ps: *mut BIGNUM) -> c_int;
 
     pub fn d2i_ECDSA_SIG(

--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -235,7 +235,7 @@ cfg_if! {
     } else {
         const_ptr_api! {
             extern "C" {
-                pub fn EVP_PKEY_size(pkey: #[const_ptr_if(any(ossl111b, libressl280))] EVP_PKEY) -> c_int;
+                pub fn EVP_PKEY_size(pkey: #[const_ptr_if(any(ossl111b, libressl))] EVP_PKEY) -> c_int;
             }
         }
     }
@@ -265,7 +265,7 @@ const_ptr_api! {
     extern "C" {
         pub fn EVP_DigestVerifyFinal(
             ctx: *mut EVP_MD_CTX,
-            sigret: #[const_ptr_if(any(ossl102, libressl280))] c_uchar,
+            sigret: #[const_ptr_if(any(ossl102, libressl))] c_uchar,
             siglen: size_t,
         ) -> c_int;
     }
@@ -465,9 +465,9 @@ cfg_if! {
         }
         const_ptr_api! {
             extern "C" {
-                pub fn EVP_PKEY_bits(key: #[const_ptr_if(any(ossl110, libressl280))] EVP_PKEY) -> c_int;
+                pub fn EVP_PKEY_bits(key: #[const_ptr_if(any(ossl110, libressl))] EVP_PKEY) -> c_int;
                 #[cfg(any(ossl110, libressl360))]
-                pub fn EVP_PKEY_security_bits(pkey: #[const_ptr_if(any(ossl110, libressl280))] EVP_PKEY) -> c_int;
+                pub fn EVP_PKEY_security_bits(pkey: #[const_ptr_if(any(ossl110, libressl))] EVP_PKEY) -> c_int;
             }
         }
     }
@@ -496,7 +496,7 @@ extern "C" {
 extern "C" {
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
     pub fn EVP_PKEY_free(k: *mut EVP_PKEY);
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> c_int;
 
     #[cfg(ossl300)]
@@ -713,7 +713,7 @@ extern "C" {
 
 const_ptr_api! {
     extern "C" {
-        pub fn EVP_PKCS82PKEY(p8: #[const_ptr_if(any(ossl110, libressl280))] PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
+        pub fn EVP_PKCS82PKEY(p8: #[const_ptr_if(any(ossl110, libressl))] PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
         pub fn EVP_PKEY2PKCS8(pkey: #[const_ptr_if(any(ossl300))] EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
     }
 }

--- a/openssl-sys/src/handwritten/pkcs12.rs
+++ b/openssl-sys/src/handwritten/pkcs12.rs
@@ -36,8 +36,8 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn PKCS12_create(
-            pass: #[const_ptr_if(any(ossl110, libressl280))] c_char,
-            friendly_name: #[const_ptr_if(any(ossl110, libressl280))] c_char,
+            pass: #[const_ptr_if(any(ossl110, libressl))] c_char,
+            friendly_name: #[const_ptr_if(any(ossl110, libressl))] c_char,
             pkey: *mut EVP_PKEY,
             cert: *mut X509,
             ca: *mut stack_st_X509,

--- a/openssl-sys/src/handwritten/rsa.rs
+++ b/openssl-sys/src/handwritten/rsa.rs
@@ -21,27 +21,27 @@ extern "C" {
     pub fn RSA_new() -> *mut RSA;
     pub fn RSA_size(k: *const RSA) -> c_int;
 
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn RSA_set0_key(r: *mut RSA, n: *mut BIGNUM, e: *mut BIGNUM, d: *mut BIGNUM) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn RSA_set0_factors(r: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn RSA_set0_crt_params(
         r: *mut RSA,
         dmp1: *mut BIGNUM,
         dmq1: *mut BIGNUM,
         iqmp: *mut BIGNUM,
     ) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn RSA_get0_key(
         r: *const RSA,
         n: *mut *const BIGNUM,
         e: *mut *const BIGNUM,
         d: *mut *const BIGNUM,
     );
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn RSA_get0_factors(r: *const RSA, p: *mut *const BIGNUM, q: *mut *const BIGNUM);
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn RSA_get0_crt_params(
         r: *const RSA,
         dmp1: *mut *const BIGNUM,

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -4,32 +4,8 @@ use libc::*;
 pub enum SSL_METHOD {}
 pub enum SSL_CIPHER {}
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum SSL_SESSION {}
-    } else if #[cfg(libressl)] {
-        #[repr(C)]
-        pub struct SSL_SESSION {
-            ssl_version: c_int,
-            pub master_key_length: c_int,
-            pub master_key: [c_uchar; 48],
-            session_id_length: c_uint,
-            session_id: [c_uchar; SSL_MAX_SSL_SESSION_ID_LENGTH as usize],
-            sid_ctx_length: c_uint,
-            sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH as usize],
-            peer: *mut X509,
-            verify_result: c_long,
-            timeout: c_long,
-            time: time_t,
-            pub references: c_int,
-            cipher: *const SSL_CIPHER,
-            cipher_id: c_long,
-            ciphers: *mut stack_st_SSL_CIPHER,
-            tlsext_hostname: *mut c_char,
-            tlsext_tick: *mut c_uchar,
-            tlsext_ticklen: size_t,
-            tlsext_tick_lifetime_int: c_long,
-            internal: *mut c_void,
-        }
     } else {
         #[repr(C)]
         pub struct SSL_SESSION {
@@ -193,7 +169,7 @@ extern "C" {
 }
 cfg_if! {
     // const change in passed function pointer signature
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         extern "C" {
             pub fn SSL_CTX_sess_set_get_cb(
                 ctx: *mut SSL_CTX,
@@ -225,7 +201,7 @@ extern "C" {
 
 cfg_if! {
     // const change in passed function pointer signature
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         extern "C" {
             pub fn SSL_CTX_set_cookie_verify_cb(
                 s: *mut SSL_CTX,
@@ -411,13 +387,7 @@ cfg_if! {
             pub fn SSL_CTX_set_max_proto_version(ctx: *mut SSL_CTX, version: u16) -> c_int;
             pub fn SSL_set_min_proto_version(s: *mut SSL, version: u16) -> c_int;
             pub fn SSL_set_max_proto_version(s: *mut SSL, version: u16) -> c_int;
-        }
-    }
-}
 
-cfg_if! {
-    if #[cfg(libressl270)] {
-        extern "C" {
             pub fn SSL_CTX_get_min_proto_version(ctx: *mut SSL_CTX) -> c_int;
             pub fn SSL_CTX_get_max_proto_version(ctx: *mut SSL_CTX) -> c_int;
             pub fn SSL_get_min_proto_version(s: *mut SSL) -> c_int;
@@ -430,7 +400,7 @@ extern "C" {
     pub fn SSL_CTX_set_cipher_list(ssl: *mut SSL_CTX, s: *const c_char) -> c_int;
     pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
     pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn SSL_CTX_up_ref(x: *mut SSL_CTX) -> c_int;
     pub fn SSL_CTX_get_cert_store(ctx: *const SSL_CTX) -> *mut X509_STORE;
     pub fn SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE);
@@ -440,7 +410,7 @@ extern "C" {
 }
 const_ptr_api! {
     extern "C" {
-        pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> #[const_ptr_if(any(ossl110, libressl280))] c_char;
+        pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> #[const_ptr_if(any(ossl110, libressl))] c_char;
     }
 }
 extern "C" {
@@ -503,7 +473,7 @@ extern "C" {
 
     pub fn SSL_SESSION_get_time(s: *const SSL_SESSION) -> c_long;
     pub fn SSL_SESSION_get_timeout(s: *const SSL_SESSION) -> c_long;
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn SSL_SESSION_get_protocol_version(s: *const SSL_SESSION) -> c_int;
 
     #[cfg(any(ossl111, libressl340))]
@@ -512,7 +482,7 @@ extern "C" {
     pub fn SSL_SESSION_get_max_early_data(ctx: *const SSL_SESSION) -> u32;
 
     pub fn SSL_SESSION_get_id(s: *const SSL_SESSION, len: *mut c_uint) -> *const c_uchar;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn SSL_SESSION_up_ref(ses: *mut SSL_SESSION) -> c_int;
     pub fn SSL_SESSION_free(s: *mut SSL_SESSION);
 }
@@ -743,12 +713,12 @@ extern "C" {
 }
 const_ptr_api! {
     extern "C" {
-        pub fn SSL_get_privatekey(ssl: #[const_ptr_if(any(ossl102, libressl280))] SSL) -> *mut EVP_PKEY;
+        pub fn SSL_get_privatekey(ssl: #[const_ptr_if(any(ossl102, libressl))] SSL) -> *mut EVP_PKEY;
     }
 }
 
 extern "C" {
-    #[cfg(any(ossl102, libressl270))]
+    #[cfg(any(ossl102, libressl))]
     pub fn SSL_CTX_get0_certificate(ctx: *const SSL_CTX) -> *mut X509;
     #[cfg(any(ossl102, libressl340))]
     pub fn SSL_CTX_get0_privatekey(ctx: *const SSL_CTX) -> *mut EVP_PKEY;
@@ -764,11 +734,11 @@ extern "C" {
     #[cfg(ossl110)]
     pub fn SSL_get0_verified_chain(ssl: *const SSL) -> *mut stack_st_X509;
 
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn SSL_get_client_random(ssl: *const SSL, out: *mut c_uchar, len: size_t) -> size_t;
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn SSL_get_server_random(ssl: *const SSL, out: *mut c_uchar, len: size_t) -> size_t;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn SSL_SESSION_get_master_key(
         session: *const SSL_SESSION,
         out: *mut c_uchar,
@@ -870,9 +840,9 @@ extern "C" {
 }
 
 extern "C" {
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn SSL_CIPHER_get_cipher_nid(c: *const SSL_CIPHER) -> c_int;
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn SSL_CIPHER_get_digest_nid(c: *const SSL_CIPHER) -> c_int;
 }
 
@@ -885,8 +855,8 @@ const_ptr_api! {
 
 const_ptr_api! {
     extern "C" {
-        #[cfg(any(ossl102, libressl273))]
-        pub fn SSL_is_server(s: #[const_ptr_if(any(ossl110f, libressl273))] SSL) -> c_int;
+        #[cfg(any(ossl102, libressl))]
+        pub fn SSL_is_server(s: #[const_ptr_if(any(ossl110f, libressl))] SSL) -> c_int;
     }
 }
 

--- a/openssl-sys/src/handwritten/types.rs
+++ b/openssl-sys/src/handwritten/types.rs
@@ -27,7 +27,7 @@ pub enum ASN1_UTF8STRING {}
 
 pub enum bio_st {} // FIXME remove
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum BIO {}
     } else {
         #[repr(C)]
@@ -87,7 +87,7 @@ pub enum BN_CTX {}
 pub enum BN_GENCB {}
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum EVP_CIPHER {}
     } else {
         #[repr(C)]
@@ -118,7 +118,7 @@ cfg_if! {
 pub enum EVP_CIPHER_CTX {}
 pub enum EVP_MD {}
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum EVP_MD_CTX {}
     } else {
         #[repr(C)]
@@ -142,7 +142,7 @@ pub enum EVP_PKEY_CTX {}
 pub enum CMAC_CTX {}
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum HMAC_CTX {}
     } else {
         #[repr(C)]
@@ -158,7 +158,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum DH {}
     } else {
         #[repr(C)]
@@ -187,7 +187,7 @@ cfg_if! {
 pub enum DH_METHOD {}
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum DSA {}
     } else {
         #[repr(C)]
@@ -216,36 +216,8 @@ cfg_if! {
 pub enum DSA_METHOD {}
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum RSA {}
-    } else if #[cfg(libressl)] {
-        #[repr(C)]
-        pub struct RSA {
-            pub pad: c_int,
-            pub version: c_long,
-            pub meth: *const RSA_METHOD,
-
-            pub engine: *mut ENGINE,
-            pub n: *mut BIGNUM,
-            pub e: *mut BIGNUM,
-            pub d: *mut BIGNUM,
-            pub p: *mut BIGNUM,
-            pub q: *mut BIGNUM,
-            pub dmp1: *mut BIGNUM,
-            pub dmq1: *mut BIGNUM,
-            pub iqmp: *mut BIGNUM,
-
-            pub ex_data: CRYPTO_EX_DATA,
-            pub references: c_int,
-            pub flags: c_int,
-
-            pub _method_mod_n: *mut BN_MONT_CTX,
-            pub _method_mod_p: *mut BN_MONT_CTX,
-            pub _method_mod_q: *mut BN_MONT_CTX,
-
-            pub blinding: *mut BN_BLINDING,
-            pub mt_blinding: *mut BN_BLINDING,
-        }
     } else {
         #[repr(C)]
         pub struct RSA {
@@ -282,34 +254,8 @@ pub enum RSA_METHOD {}
 pub enum EC_KEY {}
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum X509 {}
-    } else if #[cfg(libressl)] {
-        #[repr(C)]
-        pub struct X509 {
-            pub cert_info: *mut X509_CINF,
-            pub sig_alg: *mut X509_ALGOR,
-            pub signature: *mut ASN1_BIT_STRING,
-            pub valid: c_int,
-            pub references: c_int,
-            pub name: *mut c_char,
-            pub ex_data: CRYPTO_EX_DATA,
-            pub ex_pathlen: c_long,
-            pub ex_pcpathlen: c_long,
-            pub ex_flags: c_ulong,
-            pub ex_kusage: c_ulong,
-            pub ex_xkusage: c_ulong,
-            pub ex_nscert: c_ulong,
-            skid: *mut c_void,
-            akid: *mut c_void,
-            policy_cache: *mut c_void,
-            crldp: *mut c_void,
-            altname: *mut c_void,
-            nc: *mut c_void,
-            #[cfg(not(osslconf = "OPENSSL_NO_SHA"))]
-            sha1_hash: [c_uchar; 20],
-            aux: *mut c_void,
-        }
     } else {
         #[repr(C)]
         pub struct X509 {
@@ -361,7 +307,7 @@ pub enum X509_LOOKUP_METHOD {}
 pub enum X509_NAME {}
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl270))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum X509_STORE {}
     } else {
         #[repr(C)]
@@ -399,21 +345,8 @@ cfg_if! {
 pub enum X509_STORE_CTX {}
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum X509_VERIFY_PARAM {}
-    } else if #[cfg(libressl)] {
-        #[repr(C)]
-        pub struct X509_VERIFY_PARAM {
-            pub name: *mut c_char,
-            pub check_time: time_t,
-            pub inh_flags: c_ulong,
-            pub flags: c_ulong,
-            pub purpose: c_int,
-            pub trust: c_int,
-            pub depth: c_int,
-            pub policies: *mut stack_st_ASN1_OBJECT,
-            id: *mut c_void,
-        }
     } else {
         #[repr(C)]
         pub struct X509_VERIFY_PARAM {
@@ -432,7 +365,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl270))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum X509_OBJECT {}
     } else {
         #[repr(C)]
@@ -473,40 +406,8 @@ pub enum OPENSSL_INIT_SETTINGS {}
 
 pub enum ENGINE {}
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum SSL {}
-    } else if #[cfg(libressl)] {
-        #[repr(C)]
-        pub struct SSL {
-            version: c_int,
-            method: *const SSL_METHOD,
-            rbio: *mut BIO,
-            wbio: *mut BIO,
-            bbio: *mut BIO,
-            pub server: c_int,
-            s3: *mut c_void,
-            d1: *mut c_void,
-            param: *mut c_void,
-            cipher_list: *mut stack_st_SSL_CIPHER,
-            cert: *mut c_void,
-            sid_ctx_length: c_uint,
-            sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH as usize],
-            session: *mut SSL_SESSION,
-            verify_mode: c_int,
-            error: c_int,
-            error_code: c_int,
-            ctx: *mut SSL_CTX,
-            verify_result: c_long,
-            references: c_int,
-            client_version: c_int,
-            max_send_fragment: c_uint,
-            tlsext_hostname: *mut c_char,
-            tlsext_status_type: c_int,
-            initial_ctx: *mut SSL_CTX,
-            enc_read_ctx: *mut EVP_CIPHER_CTX,
-            read_hash: *mut EVP_MD_CTX,
-            internal: *mut c_void,
-        }
     } else {
         #[repr(C)]
         pub struct SSL {
@@ -672,25 +573,8 @@ cfg_if! {
     }
 }
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum SSL_CTX {}
-    } else if #[cfg(libressl)] {
-        #[repr(C)]
-        pub struct SSL_CTX {
-            method: *const SSL_METHOD,
-            cipher_list: *mut stack_st_SSL_CIPHER,
-            cert_store: *mut c_void,
-            session_timeout: c_long,
-            pub references: c_int,
-            extra_certs: *mut stack_st_X509,
-            verify_mode: c_int,
-            sid_ctx_length: c_uint,
-            sid_ctx: [c_uchar; SSL_MAX_SID_CTX_LENGTH as usize],
-            param: *mut X509_VERIFY_PARAM,
-            default_passwd_callback: *mut c_void,
-            default_passwd_callback_userdata: *mut c_void,
-            internal: *mut c_void,
-        }
     } else {
         #[repr(C)]
         pub struct SSL_CTX {
@@ -920,13 +804,8 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum CRYPTO_EX_DATA {}
-    } else if #[cfg(libressl)] {
-        #[repr(C)]
-        pub struct CRYPTO_EX_DATA {
-            pub sk: *mut stack_st_void,
-        }
     } else {
         #[repr(C)]
         pub struct CRYPTO_EX_DATA {

--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -227,7 +227,7 @@ extern "C" {
 }
 const_ptr_api! {
     extern "C" {
-        #[cfg(any(ossl110, libressl270))]
+        #[cfg(any(ossl110, libressl))]
         pub fn X509_REVOKED_dup(rev: #[const_ptr_if(ossl300)] X509_REVOKED) -> *mut X509_REVOKED;
     }
 }
@@ -256,7 +256,7 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn i2d_X509_CRL(x: #[const_ptr_if(ossl300)] X509_CRL, buf: *mut *mut u8) -> c_int;
-        #[cfg(any(ossl110, libressl270))]
+        #[cfg(any(ossl110, libressl))]
         pub fn X509_CRL_dup(x: #[const_ptr_if(ossl300)] X509_CRL) -> *mut X509_CRL;
     }
 }
@@ -274,14 +274,14 @@ const_ptr_api! {
     extern "C" {
         pub fn i2d_X509_REQ(x: #[const_ptr_if(ossl300)] X509_REQ, buf: *mut *mut u8) -> c_int;
 
-        #[cfg(any(ossl102, libressl273))]
+        #[cfg(any(ossl102, libressl))]
         pub fn X509_get0_signature(
-            psig: *mut #[const_ptr_if(any(ossl110, libressl273))] ASN1_BIT_STRING,
-            palg: *mut #[const_ptr_if(any(ossl110, libressl273))] X509_ALGOR,
+            psig: *mut #[const_ptr_if(any(ossl110, libressl))] ASN1_BIT_STRING,
+            palg: *mut #[const_ptr_if(any(ossl110, libressl))] X509_ALGOR,
             x: *const X509,
         );
 
-        #[cfg(any(ossl110, libressl270))]
+        #[cfg(any(ossl110, libressl))]
         pub fn X509_REQ_dup(x: #[const_ptr_if(ossl300)] X509_REQ) -> *mut X509_REQ;
     }
 }
@@ -303,9 +303,9 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn i2d_X509(x: #[const_ptr_if(ossl300)] X509, buf: *mut *mut u8) -> c_int;
-        #[cfg(any(ossl110, libressl270))]
+        #[cfg(any(ossl110, libressl))]
         pub fn X509_NAME_dup(x: #[const_ptr_if(ossl300)] X509_NAME) -> *mut X509_NAME;
-        #[cfg(any(ossl110, libressl270))]
+        #[cfg(any(ossl110, libressl))]
         pub fn X509_dup(x: #[const_ptr_if(ossl300)] X509) -> *mut X509;
         #[cfg(any(ossl101, libressl350))]
         pub fn X509_NAME_add_entry(
@@ -340,9 +340,9 @@ extern "C" {
 }
 const_ptr_api! {
     extern "C" {
-        pub fn X509_get_issuer_name(x: #[const_ptr_if(any(ossl110, libressl280))] X509) -> *mut X509_NAME;
+        pub fn X509_get_issuer_name(x: #[const_ptr_if(any(ossl110, libressl))] X509) -> *mut X509_NAME;
         pub fn X509_set_subject_name(x: *mut X509, name: #[const_ptr_if(ossl300)] X509_NAME) -> c_int;
-        pub fn X509_get_subject_name(x: #[const_ptr_if(any(ossl110, libressl280))] X509) -> *mut X509_NAME;
+        pub fn X509_get_subject_name(x: #[const_ptr_if(any(ossl110, libressl))] X509) -> *mut X509_NAME;
     }
 }
 cfg_if! {
@@ -411,18 +411,18 @@ extern "C" {
 extern "C" {
     pub fn X509_set_pubkey(x: *mut X509, pkey: *mut EVP_PKEY) -> c_int;
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> c_int;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn X509_getm_notBefore(x: *const X509) -> *mut ASN1_TIME;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn X509_getm_notAfter(x: *const X509) -> *mut ASN1_TIME;
-    #[cfg(any(ossl110, libressl273))]
+    #[cfg(any(ossl110, libressl))]
     pub fn X509_up_ref(x: *mut X509) -> c_int;
 
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn X509_REVOKED_get0_serialNumber(req: *const X509_REVOKED) -> *const ASN1_INTEGER;
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn X509_REVOKED_get0_revocationDate(req: *const X509_REVOKED) -> *const ASN1_TIME;
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 
     pub fn X509_REVOKED_set_serialNumber(r: *mut X509_REVOKED, serial: *mut ASN1_INTEGER) -> c_int;
@@ -475,18 +475,18 @@ const_ptr_api! {
 extern "C" {
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> c_int;
 
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> c_int;
     pub fn X509_CRL_add0_revoked(crl: *mut X509_CRL, rev: *mut X509_REVOKED) -> c_int;
 }
 cfg_if! {
-    if #[cfg(any(ossl110, libressl270))] {
+    if #[cfg(any(ossl110, libressl))] {
         extern "C" {
             pub fn X509_CRL_set1_lastUpdate(crl: *mut X509_CRL, tm: *const ASN1_TIME) -> c_int;
             pub fn X509_CRL_set1_nextUpdate(crl: *mut X509_CRL, tm: *const ASN1_TIME) -> c_int;
         }
     } else {
-        // libressl270 kept them, ossl110 "#define"s them to the variants above
+        // ossl110 "#define"s these to the variants above
         extern "C" {
             pub fn X509_CRL_set_lastUpdate(crl: *mut X509_CRL, tm: *const ASN1_TIME) -> c_int;
             pub fn X509_CRL_set_nextUpdate(crl: *mut X509_CRL, tm: *const ASN1_TIME) -> c_int;
@@ -496,21 +496,21 @@ cfg_if! {
 
 const_ptr_api! {
     extern "C" {
-        pub fn X509_NAME_entry_count(n: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME) -> c_int;
-        pub fn X509_NAME_get_index_by_NID(n: #[const_ptr_if(any(ossl300, libressl280))] X509_NAME, nid: c_int, last_pos: c_int) -> c_int;
-        pub fn X509_NAME_get_entry(n: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME, loc: c_int) -> *mut X509_NAME_ENTRY;
+        pub fn X509_NAME_entry_count(n: #[const_ptr_if(any(ossl110, libressl))] X509_NAME) -> c_int;
+        pub fn X509_NAME_get_index_by_NID(n: #[const_ptr_if(any(ossl300, libressl))] X509_NAME, nid: c_int, last_pos: c_int) -> c_int;
+        pub fn X509_NAME_get_entry(n: #[const_ptr_if(any(ossl110, libressl))] X509_NAME, loc: c_int) -> *mut X509_NAME_ENTRY;
         pub fn X509_NAME_add_entry_by_NID(
             x: *mut X509_NAME,
             field: c_int,
             ty: c_int,
-            bytes: #[const_ptr_if(any(ossl110, libressl280))] c_uchar,
+            bytes: #[const_ptr_if(any(ossl110, libressl))] c_uchar,
             len: c_int,
             loc: c_int,
             set: c_int,
         ) -> c_int;
         pub fn i2d_X509_NAME(n: #[const_ptr_if(ossl300)] X509_NAME, buf: *mut *mut u8) -> c_int;
-        pub fn X509_NAME_ENTRY_get_object(ne: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
-        pub fn X509_NAME_ENTRY_get_data(ne: #[const_ptr_if(any(ossl110, libressl280))] X509_NAME_ENTRY) -> *mut ASN1_STRING;
+        pub fn X509_NAME_ENTRY_get_object(ne: #[const_ptr_if(any(ossl110, libressl))] X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
+        pub fn X509_NAME_ENTRY_get_data(ne: #[const_ptr_if(any(ossl110, libressl))] X509_NAME_ENTRY) -> *mut ASN1_STRING;
     }
 }
 extern "C" {
@@ -609,47 +609,47 @@ const_ptr_api! {
 const_ptr_api! {
     extern "C" {
         // in X509
-        pub fn X509_get_ext_count(x: #[const_ptr_if(any(ossl110, libressl280))] X509) -> c_int;
-        pub fn X509_get_ext_by_NID(x: #[const_ptr_if(any(ossl110, libressl280))] X509, nid: c_int, lastpos: c_int) -> c_int;
-        pub fn X509_get_ext_by_OBJ(x: #[const_ptr_if(any(ossl110, libressl280))] X509, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, lastpos: c_int) -> c_int;
-        pub fn X509_get_ext_by_critical(x: #[const_ptr_if(any(ossl110, libressl280))] X509, crit: c_int, lastpos: c_int) -> c_int;
-        pub fn X509_get_ext(x: #[const_ptr_if(any(ossl110, libressl280))] X509, loc: c_int) -> *mut X509_EXTENSION;
+        pub fn X509_get_ext_count(x: #[const_ptr_if(any(ossl110, libressl))] X509) -> c_int;
+        pub fn X509_get_ext_by_NID(x: #[const_ptr_if(any(ossl110, libressl))] X509, nid: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_get_ext_by_OBJ(x: #[const_ptr_if(any(ossl110, libressl))] X509, obj: #[const_ptr_if(any(ossl110, libressl))] ASN1_OBJECT, lastpos: c_int) -> c_int;
+        pub fn X509_get_ext_by_critical(x: #[const_ptr_if(any(ossl110, libressl))] X509, crit: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_get_ext(x: #[const_ptr_if(any(ossl110, libressl))] X509, loc: c_int) -> *mut X509_EXTENSION;
         pub fn X509_get_ext_d2i(
-            x: #[const_ptr_if(any(ossl110, libressl280))] X509,
+            x: #[const_ptr_if(any(ossl110, libressl))] X509,
             nid: c_int,
             crit: *mut c_int,
             idx: *mut c_int,
         ) -> *mut c_void;
         // in X509_CRL
-        pub fn X509_CRL_get_ext_count(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL) -> c_int;
-        pub fn X509_CRL_get_ext_by_NID(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL, nid: c_int, lastpos: c_int) -> c_int;
-        pub fn X509_CRL_get_ext_by_OBJ(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, lastpos: c_int) -> c_int;
-        pub fn X509_CRL_get_ext_by_critical(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL, crit: c_int, lastpos: c_int) -> c_int;
-        pub fn X509_CRL_get_ext(x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL, loc: c_int) -> *mut X509_EXTENSION;
+        pub fn X509_CRL_get_ext_count(x: #[const_ptr_if(any(ossl110, libressl))] X509_CRL) -> c_int;
+        pub fn X509_CRL_get_ext_by_NID(x: #[const_ptr_if(any(ossl110, libressl))] X509_CRL, nid: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_CRL_get_ext_by_OBJ(x: #[const_ptr_if(any(ossl110, libressl))] X509_CRL, obj: #[const_ptr_if(any(ossl110, libressl))] ASN1_OBJECT, lastpos: c_int) -> c_int;
+        pub fn X509_CRL_get_ext_by_critical(x: #[const_ptr_if(any(ossl110, libressl))] X509_CRL, crit: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_CRL_get_ext(x: #[const_ptr_if(any(ossl110, libressl))] X509_CRL, loc: c_int) -> *mut X509_EXTENSION;
         pub fn X509_CRL_get_ext_d2i(
-            x: #[const_ptr_if(any(ossl110, libressl280))] X509_CRL,
+            x: #[const_ptr_if(any(ossl110, libressl))] X509_CRL,
             nid: c_int,
             crit: *mut c_int,
             idx: *mut c_int,
         ) -> *mut c_void;
         // in X509_REVOKED
-        pub fn X509_REVOKED_get_ext_count(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED) -> c_int;
-        pub fn X509_REVOKED_get_ext_by_NID(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED, nid: c_int, lastpos: c_int) -> c_int;
-        pub fn X509_REVOKED_get_ext_by_OBJ(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, lastpos: c_int) -> c_int;
-        pub fn X509_REVOKED_get_ext_by_critical(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED, crit: c_int, lastpos: c_int) -> c_int;
-        pub fn X509_REVOKED_get_ext(x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED, loc: c_int) -> *mut X509_EXTENSION;
+        pub fn X509_REVOKED_get_ext_count(x: #[const_ptr_if(any(ossl110, libressl))] X509_REVOKED) -> c_int;
+        pub fn X509_REVOKED_get_ext_by_NID(x: #[const_ptr_if(any(ossl110, libressl))] X509_REVOKED, nid: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_REVOKED_get_ext_by_OBJ(x: #[const_ptr_if(any(ossl110, libressl))] X509_REVOKED, obj: #[const_ptr_if(any(ossl110, libressl))] ASN1_OBJECT, lastpos: c_int) -> c_int;
+        pub fn X509_REVOKED_get_ext_by_critical(x: #[const_ptr_if(any(ossl110, libressl))] X509_REVOKED, crit: c_int, lastpos: c_int) -> c_int;
+        pub fn X509_REVOKED_get_ext(x: #[const_ptr_if(any(ossl110, libressl))] X509_REVOKED, loc: c_int) -> *mut X509_EXTENSION;
         pub fn X509_REVOKED_get_ext_d2i(
-            x: #[const_ptr_if(any(ossl110, libressl280))] X509_REVOKED,
+            x: #[const_ptr_if(any(ossl110, libressl))] X509_REVOKED,
             nid: c_int,
             crit: *mut c_int,
             idx: *mut c_int,
         ) -> *mut c_void;
         // X509_EXTENSION stack
-        pub fn X509v3_get_ext_by_OBJ(x: *const stack_st_X509_EXTENSION, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, lastpos: c_int) -> c_int;
+        pub fn X509v3_get_ext_by_OBJ(x: *const stack_st_X509_EXTENSION, obj: #[const_ptr_if(any(ossl110, libressl))] ASN1_OBJECT, lastpos: c_int) -> c_int;
         // X509_EXTENSION itself
-        pub fn X509_EXTENSION_create_by_OBJ(ex: *mut *mut X509_EXTENSION, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT, crit: c_int, data: *mut ASN1_OCTET_STRING) -> *mut X509_EXTENSION;
-        pub fn X509_EXTENSION_set_object(ex: *mut X509_EXTENSION, obj: #[const_ptr_if(any(ossl110, libressl280))] ASN1_OBJECT) -> c_int;
-        pub fn X509_EXTENSION_get_critical(ex: #[const_ptr_if(any(ossl110, libressl280))] X509_EXTENSION) -> c_int;
+        pub fn X509_EXTENSION_create_by_OBJ(ex: *mut *mut X509_EXTENSION, obj: #[const_ptr_if(any(ossl110, libressl))] ASN1_OBJECT, crit: c_int, data: *mut ASN1_OCTET_STRING) -> *mut X509_EXTENSION;
+        pub fn X509_EXTENSION_set_object(ex: *mut X509_EXTENSION, obj: #[const_ptr_if(any(ossl110, libressl))] ASN1_OBJECT) -> c_int;
+        pub fn X509_EXTENSION_get_critical(ex: #[const_ptr_if(any(ossl110, libressl))] X509_EXTENSION) -> c_int;
     }
 }
 
@@ -659,14 +659,14 @@ extern "C" {
 
 const_ptr_api! {
     extern "C" {
-        #[cfg(any(ossl110, libressl270))]
+        #[cfg(any(ossl110, libressl))]
         pub fn X509_STORE_get0_objects(ctx: #[const_ptr_if(ossl300)] X509_STORE) -> *mut stack_st_X509_OBJECT;
         #[cfg(ossl300)]
         pub fn X509_STORE_get1_all_certs(ctx: *mut X509_STORE) -> *mut stack_st_X509;
     }
 }
 
-#[cfg(any(ossl110, libressl270))]
+#[cfg(any(ossl110, libressl))]
 extern "C" {
     pub fn X509_OBJECT_get0_X509(x: *const X509_OBJECT) -> *mut X509;
 }
@@ -724,8 +724,8 @@ cfg_if! {
 
 const_ptr_api! {
     extern "C" {
-        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl280))] c_char) -> c_int;
-        pub fn X509_PURPOSE_get_id(purpose: #[const_ptr_if(any(ossl110, libressl280))] X509_PURPOSE) -> c_int;
+        pub fn X509_PURPOSE_get_by_sname(sname: #[const_ptr_if(any(ossl110, libressl))] c_char) -> c_int;
+        pub fn X509_PURPOSE_get_id(purpose: #[const_ptr_if(any(ossl110, libressl))] X509_PURPOSE) -> c_int;
         pub fn X509_PURPOSE_get0(idx: c_int) -> #[const_ptr_if(libressl390)] X509_PURPOSE;
     }
 }
@@ -783,7 +783,7 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn X509_ATTRIBUTE_count(
-            attr: #[const_ptr_if(any(ossl110, libressl280))] X509_ATTRIBUTE // const since OpenSSL v1.1.0
+            attr: #[const_ptr_if(any(ossl110, libressl))] X509_ATTRIBUTE // const since OpenSSL v1.1.0
         ) -> c_int;
         pub fn i2d_X509_ATTRIBUTE(x: #[const_ptr_if(ossl300)] X509_ATTRIBUTE, buf: *mut *mut u8) -> c_int;
         pub fn X509_ATTRIBUTE_dup(x: #[const_ptr_if(ossl300)] X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;

--- a/openssl-sys/src/handwritten/x509v3.rs
+++ b/openssl-sys/src/handwritten/x509v3.rs
@@ -42,13 +42,13 @@ const_ptr_api! {
             conf: *mut CONF,
             ctx: *mut X509V3_CTX,
             ext_nid: c_int,
-            value: #[const_ptr_if(any(ossl110, libressl280))] c_char,
+            value: #[const_ptr_if(any(ossl110, libressl))] c_char,
         ) -> *mut X509_EXTENSION;
         pub fn X509V3_EXT_nconf(
             conf: *mut CONF,
             ctx: *mut X509V3_CTX,
-            name: #[const_ptr_if(any(ossl110, libressl280))] c_char,
-            value: #[const_ptr_if(any(ossl110, libressl280))] c_char,
+            name: #[const_ptr_if(any(ossl110, libressl))] c_char,
+            value: #[const_ptr_if(any(ossl110, libressl))] c_char,
         ) -> *mut X509_EXTENSION;
     }
 }
@@ -74,12 +74,12 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn X509V3_get_d2i(
-            x: #[const_ptr_if(any(ossl110, libressl280))] stack_st_X509_EXTENSION,
+            x: #[const_ptr_if(any(ossl110, libressl))] stack_st_X509_EXTENSION,
             nid: c_int,
             crit: *mut c_int,
             idx: *mut c_int,
         ) -> *mut c_void;
-        pub fn X509V3_extensions_print(out: *mut BIO, title: #[const_ptr_if(any(ossl110, libressl280))] c_char, exts: #[const_ptr_if(any(ossl110, libressl280))] stack_st_X509_EXTENSION, flag: c_ulong, indent: c_int) -> c_int;
+        pub fn X509V3_extensions_print(out: *mut BIO, title: #[const_ptr_if(any(ossl110, libressl))] c_char, exts: #[const_ptr_if(any(ossl110, libressl))] stack_st_X509_EXTENSION, flag: c_ulong, indent: c_int) -> c_int;
     }
 }
 

--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -1012,7 +1012,7 @@ pub const NID_shake128: c_int = 1100;
 pub const NID_shake256: c_int = 1101;
 #[cfg(ossl110)]
 pub const NID_chacha20_poly1305: c_int = 1018;
-#[cfg(libressl271)]
+#[cfg(libressl)]
 pub const NID_chacha20_poly1305: c_int = 967;
 cfg_if! {
     if #[cfg(ossl340)] {

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -114,7 +114,7 @@ pub const SSL_OP_PRIORITIZE_CHACHA: ssl_op_type!() = 0x00200000;
 
 pub const SSL_OP_CIPHER_SERVER_PREFERENCE: ssl_op_type!() = 0x00400000;
 cfg_if! {
-    if #[cfg(libressl280)] {
+    if #[cfg(libressl)] {
         pub const SSL_OP_TLS_ROLLBACK_BUG: ssl_op_type!() = 0;
     } else {
         pub const SSL_OP_TLS_ROLLBACK_BUG: ssl_op_type!() = 0x00800000;

--- a/openssl-sys/src/types.rs
+++ b/openssl-sys/src/types.rs
@@ -3,7 +3,7 @@ use libc::*;
 use super::*;
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         pub enum EVP_PKEY {}
     } else {
         #[repr(C)]

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -73,19 +73,11 @@ fn main() {
         println!("cargo:rustc-cfg=libressl250");
         println!("cargo:rustc-cfg=libressl251");
         println!("cargo:rustc-cfg=libressl261");
+        println!("cargo:rustc-cfg=libressl270");
+        println!("cargo:rustc-cfg=libressl271");
+        println!("cargo:rustc-cfg=libressl273");
+        println!("cargo:rustc-cfg=libressl280");
 
-        if version >= 0x2_07_00_00_0 {
-            println!("cargo:rustc-cfg=libressl270");
-        }
-        if version >= 0x2_07_01_00_0 {
-            println!("cargo:rustc-cfg=libressl271");
-        }
-        if version >= 0x2_07_03_00_0 {
-            println!("cargo:rustc-cfg=libressl273");
-        }
-        if version >= 0x2_08_00_00_0 {
-            println!("cargo:rustc-cfg=libressl280");
-        }
         if version >= 0x2_09_01_00_0 {
             println!("cargo:rustc-cfg=libressl291");
         }

--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -737,7 +737,7 @@ impl fmt::Debug for Asn1ObjectRef {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273, boringssl, awslc))] {
+    if #[cfg(any(ossl110, libressl, boringssl, awslc))] {
         use ffi::ASN1_STRING_get0_data;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/cipher.rs
+++ b/openssl/src/cipher.rs
@@ -17,7 +17,7 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 
 cfg_if! {
-    if #[cfg(any(boringssl, ossl110, libressl273, awslc))] {
+    if #[cfg(any(boringssl, ossl110, libressl, awslc))] {
         use ffi::{EVP_CIPHER_block_size, EVP_CIPHER_iv_length, EVP_CIPHER_key_length};
     } else {
         use libc::c_int;

--- a/openssl/src/dh.rs
+++ b/openssl/src/dh.rs
@@ -269,7 +269,7 @@ where
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl270, boringssl, awslc))] {
+    if #[cfg(any(ossl110, libressl, boringssl, awslc))] {
         use ffi::{DH_set0_pqg, DH_get0_pqg, DH_get0_key, DH_set0_key};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -315,7 +315,7 @@ impl<T> fmt::Debug for Dsa<T> {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273, boringssl, awslc))] {
+    if #[cfg(any(ossl110, libressl, boringssl, awslc))] {
         use ffi::{DSA_get0_key, DSA_get0_pqg, DSA_set0_key, DSA_set0_pqg};
     } else {
         #[allow(bad_style)]
@@ -494,7 +494,7 @@ impl DsaSigRef {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273, boringssl, awslc))] {
+    if #[cfg(any(ossl110, libressl, boringssl, awslc))] {
         use ffi::{DSA_SIG_set0, DSA_SIG_get0};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/ecdsa.rs
+++ b/openssl/src/ecdsa.rs
@@ -110,7 +110,7 @@ impl EcdsaSigRef {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273, boringssl, awslc))] {
+    if #[cfg(any(ossl110, libressl, boringssl, awslc))] {
         use ffi::{ECDSA_SIG_set0, ECDSA_SIG_get0};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -1,7 +1,7 @@
 //! Bindings to OpenSSL
 //!
 //! This crate provides a safe interface to the popular OpenSSL cryptography library. OpenSSL versions 1.0.1 through
-//! 3.x.x and LibreSSL versions 2.7 through 4.1.x are supported.
+//! 3.x.x and LibreSSL versions 2.8 through 4.1.x are supported.
 //!
 //! # Building
 //!

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -1090,7 +1090,7 @@ impl Nid {
     pub const SHAKE128: Nid = Nid(ffi::NID_shake128);
     #[cfg(any(ossl111, awslc))]
     pub const SHAKE256: Nid = Nid(ffi::NID_shake256);
-    #[cfg(any(ossl110, libressl271, awslc))]
+    #[cfg(any(ossl110, libressl, awslc))]
     pub const CHACHA20_POLY1305: Nid = Nid(ffi::NID_chacha20_poly1305);
 }
 

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -833,7 +833,7 @@ impl PKey<Public> {
 }
 
 cfg_if! {
-    if #[cfg(any(boringssl, ossl110, libressl270, awslc))] {
+    if #[cfg(any(boringssl, ossl110, libressl, awslc))] {
         use ffi::EVP_PKEY_up_ref;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -585,7 +585,7 @@ impl<T> fmt::Debug for Rsa<T> {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273, boringssl, awslc))] {
+    if #[cfg(any(ossl110, libressl, boringssl, awslc))] {
         use ffi::{
             RSA_get0_key, RSA_get0_factors, RSA_get0_crt_params, RSA_set0_key, RSA_set0_factors,
             RSA_set0_crt_params,

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -189,7 +189,7 @@ unsafe extern "C" fn destroy<S>(bio: *mut BIO) -> c_int {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl273, boringssl))] {
+    if #[cfg(any(ossl110, libressl, boringssl))] {
         use ffi::{BIO_get_data, BIO_set_data, BIO_set_flags, BIO_set_init};
         use crate::cvt;
 

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -391,7 +391,7 @@ pub unsafe extern "C" fn raw_remove_session<F>(
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280, boringssl, awslc))] {
+    if #[cfg(any(ossl110, libressl, boringssl, awslc))] {
         type DataPtr = *const c_uchar;
     } else {
         type DataPtr = *mut c_uchar;
@@ -527,7 +527,7 @@ where
 
 #[cfg(not(any(boringssl, awslc)))]
 cfg_if! {
-    if #[cfg(any(ossl110, libressl280))] {
+    if #[cfg(any(ossl110, libressl))] {
         type CookiePtr = *const c_uchar;
     } else {
         type CookiePtr = *mut c_uchar;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -67,7 +67,7 @@ use crate::error::ErrorStack;
 use crate::ex_data::Index;
 #[cfg(ossl111)]
 use crate::hash::MessageDigest;
-#[cfg(any(ossl110, libressl270))]
+#[cfg(any(ossl110, libressl))]
 use crate::nid::Nid;
 use crate::pkey::{HasPrivate, PKeyRef, Params, Private};
 #[cfg(ossl300)]
@@ -1209,9 +1209,9 @@ impl SslContextBuilder {
     /// A value of `None` indicates that all versions down to the lowest version supported by
     /// OpenSSL are enabled.
     ///
-    /// Requires OpenSSL 1.1.0g or LibreSSL 2.7.0 or newer.
+    /// Requires LibreSSL or OpenSSL 1.1.0g or newer.
     #[corresponds(SSL_CTX_get_min_proto_version)]
-    #[cfg(any(ossl110g, libressl270))]
+    #[cfg(any(ossl110g, libressl))]
     pub fn min_proto_version(&mut self) -> Option<SslVersion> {
         unsafe {
             let r = ffi::SSL_CTX_get_min_proto_version(self.as_ptr());
@@ -1228,9 +1228,9 @@ impl SslContextBuilder {
     /// A value of `None` indicates that all versions up to the highest version supported by
     /// OpenSSL are enabled.
     ///
-    /// Requires OpenSSL 1.1.0g or LibreSSL 2.7.0 or newer.
+    /// Requires LibreSSL or OpenSSL 1.1.0g or newer.
     #[corresponds(SSL_CTX_get_max_proto_version)]
-    #[cfg(any(ossl110g, libressl270))]
+    #[cfg(any(ossl110g, libressl))]
     pub fn max_proto_version(&mut self) -> Option<SslVersion> {
         unsafe {
             let r = ffi::SSL_CTX_get_max_proto_version(self.as_ptr());
@@ -1873,9 +1873,9 @@ impl SslContext {
 impl SslContextRef {
     /// Returns the certificate associated with this `SslContext`, if present.
     ///
-    /// Requires OpenSSL 1.0.2 or LibreSSL 2.7.0 or newer.
+    /// Requires LibreSSL or OpenSSL 1.0.2 or newer.
     #[corresponds(SSL_CTX_get0_certificate)]
-    #[cfg(any(ossl102, libressl270))]
+    #[cfg(any(ossl102, libressl))]
     pub fn certificate(&self) -> Option<&X509Ref> {
         unsafe {
             let ptr = ffi::SSL_CTX_get0_certificate(self.as_ptr());
@@ -2132,9 +2132,9 @@ impl SslCipherRef {
 
     /// Returns the NID corresponding to the cipher.
     ///
-    /// Requires OpenSSL 1.1.0 or LibreSSL 2.7.0 or newer.
+    /// Requires LibreSSL or OpenSSL 1.1.0 or newer.
     #[corresponds(SSL_CIPHER_get_cipher_nid)]
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn cipher_nid(&self) -> Option<Nid> {
         let n = unsafe { ffi::SSL_CIPHER_get_cipher_nid(self.as_ptr()) };
         if n == 0 {
@@ -2265,9 +2265,9 @@ impl SslSessionRef {
 
     /// Returns the session's TLS protocol version.
     ///
-    /// Requires OpenSSL 1.1.0 or LibreSSL 2.7.0 or newer.
+    /// Requires LibreSSL or OpenSSL 1.1.0 or newer.
     #[corresponds(SSL_SESSION_get_protocol_version)]
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn protocol_version(&self) -> SslVersion {
         unsafe {
             let version = ffi::SSL_SESSION_get_protocol_version(self.as_ptr());
@@ -2824,9 +2824,9 @@ impl SslRef {
     /// Returns the number of bytes copied, or if the buffer is empty, the size of the `client_random`
     /// value.
     ///
-    /// Requires OpenSSL 1.1.0 or LibreSSL 2.7.0 or newer.
+    /// Requires LibreSSL or OpenSSL 1.1.0 or newer.
     #[corresponds(SSL_get_client_random)]
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn client_random(&self, buf: &mut [u8]) -> usize {
         unsafe {
             ffi::SSL_get_client_random(self.as_ptr(), buf.as_mut_ptr() as *mut c_uchar, buf.len())
@@ -2838,9 +2838,9 @@ impl SslRef {
     /// Returns the number of bytes copied, or if the buffer is empty, the size of the `server_random`
     /// value.
     ///
-    /// Requires OpenSSL 1.1.0 or LibreSSL 2.7.0 or newer.
+    /// Requires LibreSSL or OpenSSL 1.1.0 or newer.
     #[corresponds(SSL_get_server_random)]
-    #[cfg(any(ossl110, libressl270))]
+    #[cfg(any(ossl110, libressl))]
     pub fn server_random(&self, buf: &mut [u8]) -> usize {
         unsafe {
             ffi::SSL_get_server_random(self.as_ptr(), buf.as_mut_ptr() as *mut c_uchar, buf.len())
@@ -4260,7 +4260,7 @@ bitflags! {
 }
 
 cfg_if! {
-    if #[cfg(any(boringssl, ossl110, libressl273, awslc))] {
+    if #[cfg(any(boringssl, ossl110, libressl, awslc))] {
         use ffi::{SSL_CTX_up_ref, SSL_SESSION_get_master_key, SSL_SESSION_up_ref, SSL_is_server};
     } else {
         #[allow(bad_style)]

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1250,7 +1250,7 @@ fn no_version_overlap() {
         .ctx()
         .set_max_proto_version(Some(SslVersion::TLS1_1))
         .unwrap();
-    #[cfg(any(ossl110g, libressl270))]
+    #[cfg(any(ossl110g, libressl))]
     assert_eq!(server.ctx().max_proto_version(), Some(SslVersion::TLS1_1));
     server.should_error();
     let server = server.build();

--- a/openssl/src/symm.rs
+++ b/openssl/src/symm.rs
@@ -919,7 +919,7 @@ pub fn decrypt_aead(
 }
 
 cfg_if! {
-    if #[cfg(any(boringssl, ossl110, libressl273, awslc))] {
+    if #[cfg(any(boringssl, ossl110, libressl, awslc))] {
         use ffi::{EVP_CIPHER_block_size, EVP_CIPHER_iv_length, EVP_CIPHER_key_length};
     } else {
         use crate::LenType;

--- a/openssl/src/version.rs
+++ b/openssl/src/version.rs
@@ -18,7 +18,7 @@ use openssl_macros::corresponds;
 use std::ffi::CStr;
 
 cfg_if! {
-    if #[cfg(any(ossl110, libressl271))] {
+    if #[cfg(any(ossl110, libressl))] {
         use ffi::{
             OPENSSL_VERSION, OPENSSL_CFLAGS, OPENSSL_BUILT_ON, OPENSSL_PLATFORM, OPENSSL_DIR,
             OpenSSL_version_num, OpenSSL_version,

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1253,7 +1253,7 @@ impl X509NameRef {
 
     /// Copies the name to a new `X509Name`.
     #[corresponds(X509_NAME_dup)]
-    #[cfg(any(boringssl, ossl110, libressl270, awslc))]
+    #[cfg(any(boringssl, ossl110, libressl, awslc))]
     pub fn to_owned(&self) -> Result<X509Name, ErrorStack> {
         unsafe { cvt_p(ffi::X509_NAME_dup(self.as_ptr())).map(|n| X509Name::from_ptr(n)) }
     }
@@ -1635,7 +1635,7 @@ impl X509RevokedRef {
 
     /// Copies the entry to a new `X509Revoked`.
     #[corresponds(X509_NAME_dup)]
-    #[cfg(any(boringssl, ossl110, libressl270, awslc))]
+    #[cfg(any(boringssl, ossl110, libressl, awslc))]
     pub fn to_owned(&self) -> Result<X509Revoked, ErrorStack> {
         unsafe { cvt_p(ffi::X509_REVOKED_dup(self.as_ptr())).map(|n| X509Revoked::from_ptr(n)) }
     }
@@ -2306,7 +2306,7 @@ impl Stackable for X509Object {
 }
 
 cfg_if! {
-    if #[cfg(any(boringssl, ossl110, libressl273, awslc))] {
+    if #[cfg(any(boringssl, ossl110, libressl, awslc))] {
         use ffi::{X509_getm_notAfter, X509_getm_notBefore, X509_up_ref, X509_get0_signature};
     } else {
         #[allow(bad_style)]
@@ -2387,7 +2387,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(any(ossl110, boringssl, libressl270, awslc))] {
+    if #[cfg(any(ossl110, boringssl, libressl, awslc))] {
         use ffi::X509_OBJECT_get0_X509;
     } else {
         #[allow(bad_style)]
@@ -2502,7 +2502,7 @@ impl X509PurposeRef {
         unsafe {
             let sname = CString::new(sname).unwrap();
             cfg_if! {
-                if #[cfg(any(ossl110, libressl280, boringssl, awslc))] {
+                if #[cfg(any(ossl110, libressl, boringssl, awslc))] {
                     let purpose = cvt_n(ffi::X509_PURPOSE_get_by_sname(sname.as_ptr() as *const _))?;
                 } else {
                     let purpose = cvt_n(ffi::X509_PURPOSE_get_by_sname(sname.as_ptr() as *mut _))?;
@@ -2534,7 +2534,7 @@ impl X509PurposeRef {
     pub fn purpose(&self) -> X509PurposeId {
         unsafe {
             cfg_if! {
-                if #[cfg(any(ossl110, libressl280, boringssl, awslc))] {
+                if #[cfg(any(ossl110, libressl, boringssl, awslc))] {
                     let x509_purpose = self.as_ptr() as *const ffi::X509_PURPOSE;
                 } else {
                     let x509_purpose = self.as_ptr() as *mut ffi::X509_PURPOSE;

--- a/openssl/src/x509/store.rs
+++ b/openssl/src/x509/store.rs
@@ -284,7 +284,7 @@ impl X509StoreRef {
 }
 
 cfg_if! {
-    if #[cfg(any(boringssl, ossl110, libressl270, awslc))] {
+    if #[cfg(any(boringssl, ossl110, libressl, awslc))] {
         use ffi::X509_STORE_get0_objects;
     } else {
         #[allow(bad_style)]

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -836,7 +836,7 @@ fn test_name_cmp() {
 }
 
 #[test]
-#[cfg(any(boringssl, ossl110, libressl270, awslc))]
+#[cfg(any(boringssl, ossl110, libressl, awslc))]
 fn test_name_to_owned() {
     let cert = include_bytes!("../../test/cert.pem");
     let cert = X509::from_pem(cert).unwrap();


### PR DESCRIPTION
This is a rather big one. I also replaced libressl280 with plain libressl since that mops up some dead cfg branches