### PR TITLE
remove branch for libressl 2.6.1

### DIFF
--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -40,7 +40,7 @@ use crate::util::{self, ForeignTypeExt, ForeignTypeRefExt};
 use crate::{cvt, cvt_n, cvt_p, cvt_p_const};
 use openssl_macros::corresponds;
 
-#[cfg(any(ossl102, boringssl, libressl261, awslc))]
+#[cfg(any(ossl102, boringssl, libressl, awslc))]
 pub mod verify;
 
 pub mod extension;


### PR DESCRIPTION
(our minimum libressl is above that)