### PR TITLE
remove unneeded cfg and expose X509::append_entry on boringssl/awslc

### DIFF
--- a/openssl-sys/src/handwritten/cms.rs
+++ b/openssl-sys/src/handwritten/cms.rs
@@ -4,7 +4,6 @@ use libc::*;
 pub enum CMS_ContentInfo {}
 
 extern "C" {
-    #[cfg(ossl101)]
     pub fn CMS_ContentInfo_free(cms: *mut CMS_ContentInfo);
 }
 

--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -307,7 +307,6 @@ const_ptr_api! {
         pub fn X509_NAME_dup(x: #[const_ptr_if(ossl300)] X509_NAME) -> *mut X509_NAME;
         #[cfg(any(ossl110, libressl))]
         pub fn X509_dup(x: #[const_ptr_if(ossl300)] X509) -> *mut X509;
-        #[cfg(any(ossl101, libressl350))]
         pub fn X509_NAME_add_entry(
             name: *mut X509_NAME,
             ne: #[const_ptr_if(any(ossl110, libressl))] X509_NAME_ENTRY,

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1071,7 +1071,6 @@ impl X509NameBuilder {
 
     /// Add a name entry
     #[corresponds(X509_NAME_add_entry)]
-    #[cfg(any(ossl101, libressl350))]
     pub fn append_entry(&mut self, ne: &X509NameEntryRef) -> std::result::Result<(), ErrorStack> {
         unsafe {
             cvt(ffi::X509_NAME_add_entry(

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -1068,7 +1068,6 @@ fn test_set_purpose_fails_verification() {
 }
 
 #[test]
-#[cfg(any(ossl101, libressl350))]
 fn test_add_name_entry() {
     let cert = include_bytes!("../../test/cert.pem");
     let cert = X509::from_pem(cert).unwrap();


### PR DESCRIPTION
this will allow us to eventually remove that `cfg` entirely