### PR TITLE
avoid cancelling sequential jobs on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   RUST_BACKTRACE: 1
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
on PRs we want to cancel a job on new push, but on master we should run all tests