### PR TITLE
Use SHA256 test variant instead of SHA1

### DIFF
--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -1284,12 +1284,12 @@ mxJ7imIrEg9nIQ==
         let key1 = EcKey::private_key_from_pem(private_key_pem.as_bytes()).unwrap();
         let key1 = PKey::from_ec_key(key1).unwrap();
         let input = "sample";
-        let expected_output = hex::decode("3044022061340C88C3AAEBEB4F6D667F672CA9759A6CCAA9FA8811313039EE4A35471D3202206D7F147DAC089441BB2E2FE8F7A3FA264B9C475098FDCF6E00D7C996E1B8B7EB").unwrap();
+        let expected_output = hex::decode("3046022100EFD48B2AACB6A8FD1140DD9CD45E81D69D2C877B56AAF991C34D0EA84EAF3716022100F7CB1C942D657C41D436C7A1B6E29F65F3E900DBB9AFF4064DC4AB2F843ACDA8").unwrap();
 
-        let hashed_input = hash(MessageDigest::sha1(), input.as_bytes()).unwrap();
+        let hashed_input = hash(MessageDigest::sha256(), input.as_bytes()).unwrap();
         let mut ctx = PkeyCtx::new(&key1).unwrap();
         ctx.sign_init().unwrap();
-        ctx.set_signature_md(Md::sha1()).unwrap();
+        ctx.set_signature_md(Md::sha256()).unwrap();
         ctx.set_nonce_type(NonceType::DETERMINISTIC_K).unwrap();
 
         let mut output = vec![];


### PR DESCRIPTION
Fedora and RHEL default to disable SHA1 signatures. Use a different test vector from the https://github.com/openssl/openssl/blob/openssl-3.2.0/test/recipes/30-test_evp_data/evppkey_ecdsa_rfc6979.txt instead of SHA1 signatures in the test:

DigestSign = SHA256
Key = P-256_PRIV
NonceType = deterministic
Input = "sample"
Output = 3046022100EFD48B2AACB6A8FD1140DD9CD45E81D69D2C877B56AAF991C34D0EA84EAF3716022100F7CB1C942D657C41D436C7A1B6E29F65F3E900DBB9AFF4064DC4AB2F843ACDA8