### PR TITLE
SSL{,_CTX}_get_ex_new_index: expose CRYPTO-based definition to LibreSSL

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -735,7 +735,7 @@ extern "C" {
 }
 
 extern "C" {
-    #[cfg(not(ossl110))]
+    #[cfg(not(any(ossl110, libressl)))]
     pub fn SSL_get_ex_new_index(
         argl: c_long,
         argp: *mut c_void,
@@ -747,7 +747,7 @@ extern "C" {
     pub fn SSL_set_ex_data(ssl: *mut SSL, idx: c_int, data: *mut c_void) -> c_int;
     pub fn SSL_get_ex_data(ssl: *const SSL, idx: c_int) -> *mut c_void;
 
-    #[cfg(not(ossl110))]
+    #[cfg(not(any(ossl110, libressl)))]
     pub fn SSL_CTX_get_ex_new_index(
         argl: c_long,
         argp: *mut c_void,

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -560,7 +560,7 @@ pub const SSL_READ_EARLY_DATA_SUCCESS: c_int = 1;
 pub const SSL_READ_EARLY_DATA_FINISH: c_int = 2;
 
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl))] {
         pub unsafe fn SSL_get_ex_new_index(
             l: c_long,
             p: *mut c_void,
@@ -573,7 +573,7 @@ cfg_if! {
     }
 }
 cfg_if! {
-    if #[cfg(ossl110)] {
+    if #[cfg(any(ossl110, libressl))] {
         pub unsafe fn SSL_CTX_get_ex_new_index(
             l: c_long,
             p: *mut c_void,


### PR DESCRIPTION
Not sure how this got missed until some linker errors I experienced now, but this has apparently been the case for time. Present in all currently supported LibreSSL versions.