### PR TITLE
Implement set_rsa_oaep_label for AWS-LC/BoringSSL

### DIFF
--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -39,8 +39,6 @@
 //! decrypted.truncate(decrypted_len);
 //! assert_eq!(&*decrypted, data);
 //! ```
-#[cfg(any(ossl102, libressl))]
-use libc::c_int;
 use std::{marker::PhantomData, ptr};
 
 use crate::error::ErrorStack;
@@ -151,7 +149,6 @@ impl<'a> Encrypter<'a> {
     ///
     /// This is only useful for RSA keys.
     #[corresponds(EVP_PKEY_CTX_set0_rsa_oaep_label)]
-    #[cfg(any(ossl102, libressl))]
     pub fn set_rsa_oaep_label(&mut self, label: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
             let p = cvt_p(ffi::OPENSSL_malloc(label.len() as _))?;
@@ -159,8 +156,8 @@ impl<'a> Encrypter<'a> {
 
             cvt(ffi::EVP_PKEY_CTX_set0_rsa_oaep_label(
                 self.pctx,
-                p,
-                label.len() as c_int,
+                p.cast(),
+                label.len() as _,
             ))
             .map(|_| ())
             .map_err(|e| {
@@ -336,7 +333,6 @@ impl<'a> Decrypter<'a> {
     ///
     /// This is only useful for RSA keys.
     #[corresponds(EVP_PKEY_CTX_set0_rsa_oaep_label)]
-    #[cfg(any(ossl102, libressl))]
     pub fn set_rsa_oaep_label(&mut self, label: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
             let p = cvt_p(ffi::OPENSSL_malloc(label.len() as _))?;
@@ -344,8 +340,8 @@ impl<'a> Decrypter<'a> {
 
             cvt(ffi::EVP_PKEY_CTX_set0_rsa_oaep_label(
                 self.pctx,
-                p,
-                label.len() as c_int,
+                p.cast(),
+                label.len() as _,
             ))
             .map(|_| ())
             .map_err(|e| {
@@ -505,7 +501,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(any(ossl102, libressl))]
     fn rsa_encrypt_decrypt_oaep_label() {
         let key = include_bytes!("../test/rsa.pem");
         let private_key = Rsa::private_key_from_pem(key).unwrap();


### PR DESCRIPTION
This function works on boringssl derivatives too, just with different integer and pointer types.