### PR TITLE
Bump aws-lc-sys from 0.27 to 0.34

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
             index-${{ runner.os }}-
       - run: cargo generate-lockfile
       - run: |
-          cargo update -p home --precise 0.5.11
           cargo update -p once_cell --precise 1.20.3
       - uses: actions/cache@v4
         with:

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -24,7 +24,7 @@ aws-lc-fips = ['dep:aws-lc-fips-sys']
 [dependencies]
 libc = "0.2"
 bssl-sys = { version = "0.1.0", optional = true }
-aws-lc-sys = { version = "0.27", features = ["ssl"], optional = true }
+aws-lc-sys = { version = "0.34", features = ["ssl"], optional = true }
 aws-lc-fips-sys = { version = "0.13", features = ["ssl", "bindgen"], optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
Bumps the underlying AWS-LC library from 1.48 to 1.65.

ref #2501