### PR TITLE
reintroduce dir_name support for subject_alt_names

### DIFF
--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -2087,6 +2087,35 @@ impl GeneralName {
             Ok(GeneralName::from_ptr(gn))
         }
     }
+
+    pub(crate) fn new_dir_name(name: &X509NameRef) -> Result<GeneralName, ErrorStack> {
+        unsafe {
+            ffi::init();
+            let gn = cvt_p(ffi::GENERAL_NAME_new())?;
+            (*gn).type_ = ffi::GEN_DIRNAME;
+
+            let dup = match name.to_owned() {
+                Ok(dup) => dup,
+                Err(e) => {
+                    ffi::GENERAL_NAME_free(gn);
+                    return Err(e);
+                }
+            };
+
+            #[cfg(any(boringssl, awslc))]
+            {
+                (*gn).d.directoryName = dup.as_ptr();
+            }
+            #[cfg(not(any(boringssl, awslc)))]
+            {
+                (*gn).d = dup.as_ptr().cast();
+            }
+
+            std::mem::forget(dup);
+
+            Ok(GeneralName::from_ptr(gn))
+        }
+    }
 }
 
 impl GeneralNameRef {

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -25,7 +25,6 @@ use crate::x509::{CrlReason, X509Builder};
 use crate::x509::{
     CrlStatus, X509Crl, X509Extension, X509Name, X509Req, X509StoreContext, X509VerifyResult, X509,
 };
-
 #[cfg(ossl110)]
 use foreign_types::ForeignType;
 use hex::{self, FromHex};
@@ -1142,6 +1141,74 @@ fn other_name_as_subject_alternative_name() {
     unsafe {
         assert_eq!((*general_name.as_ptr()).type_, 0);
     }
+}
+
+#[cfg(ossl110)]
+#[test]
+fn dir_name_as_subject_alternative_name() {
+    // Build original name
+    let mut b = X509Name::builder().unwrap();
+    b.append_entry_by_nid(Nid::COMMONNAME, "dir.example")
+        .unwrap();
+    b.append_entry_by_nid(Nid::COUNTRYNAME, "US").unwrap();
+    let name = b.build();
+
+    // Build a separate literal copy for the SAN
+    let mut b2 = X509Name::builder().unwrap();
+    b2.append_entry_by_nid(Nid::COMMONNAME, "dir.example")
+        .unwrap();
+    b2.append_entry_by_nid(Nid::COUNTRYNAME, "US").unwrap();
+    let name_copy = b2.build();
+
+    // Build certificate with the SAN entry
+    let mut builder = X509Builder::new().unwrap();
+    let san = SubjectAlternativeName::new()
+        .dir_name2(name_copy)
+        .build(&builder.x509v3_context(None, None))
+        .unwrap();
+    builder.append_extension(san).unwrap();
+    let cert = builder.build();
+
+    // Original X509Name still intact
+    assert_eq!(
+        name.entries_by_nid(Nid::COMMONNAME)
+            .next()
+            .unwrap()
+            .data()
+            .as_slice(),
+        b"dir.example"
+    );
+    assert_eq!(
+        name.entries_by_nid(Nid::COUNTRYNAME)
+            .next()
+            .unwrap()
+            .data()
+            .as_slice(),
+        b"US"
+    );
+
+    // Extract SAN directoryName
+    let alt_names = cert.subject_alt_names().unwrap();
+    let dirname = alt_names.iter().find_map(|n| n.directory_name()).unwrap();
+
+    assert_eq!(
+        dirname
+            .entries_by_nid(Nid::COMMONNAME)
+            .next()
+            .unwrap()
+            .data()
+            .as_slice(),
+        b"dir.example"
+    );
+    assert_eq!(
+        dirname
+            .entries_by_nid(Nid::COUNTRYNAME)
+            .next()
+            .unwrap()
+            .data()
+            .as_slice(),
+        b"US"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This reintroduces support for `GENERAL_NAME` values of type `GEN_DIRNAME` without relying on OpenSSL’s configuration mini-language. The deprecated `dir_name(&str)` constructor remains unchanged and continues to panic.

A new method, dir_name2(X509Name), is added to construct `directoryName` SAN entries using an owned X509Name. Internally, this uses safe duplication (`X509_NAME_dup` or `.to_owned()`) and manually builds a `GENERAL_NAME` with G`EN_DIRNAME`, following the same pattern used for `other_name2` in #1915.

This avoids the vulnerability described in RUSTSEC-2023-0023 while restoring needed functionality for consumers that rely on DirectoryName SANs (e.g., government CSR specifications). New tests verify correctness, pointer ownership, and OpenSSL/BoringSSL/AWS-LC union handling.

Addresses #2527 