### PR TITLE
Expose X509_NAME_dup on all versions of OpenSSL

### DIFF
--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -301,7 +301,6 @@ extern "C" {
 const_ptr_api! {
     extern "C" {
         pub fn i2d_X509(x: #[const_ptr_if(ossl300)] X509, buf: *mut *mut u8) -> c_int;
-        #[cfg(any(ossl110, libressl))]
         pub fn X509_NAME_dup(x: #[const_ptr_if(ossl300)] X509_NAME) -> *mut X509_NAME;
         #[cfg(any(ossl110, libressl))]
         pub fn X509_dup(x: #[const_ptr_if(ossl300)] X509) -> *mut X509;

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -1251,7 +1251,6 @@ impl X509NameRef {
 
     /// Copies the name to a new `X509Name`.
     #[corresponds(X509_NAME_dup)]
-    #[cfg(any(boringssl, ossl110, libressl, awslc))]
     pub fn to_owned(&self) -> Result<X509Name, ErrorStack> {
         unsafe { cvt_p(ffi::X509_NAME_dup(self.as_ptr())).map(|n| X509Name::from_ptr(n)) }
     }

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -830,7 +830,6 @@ fn test_name_cmp() {
 }
 
 #[test]
-#[cfg(any(boringssl, ossl110, libressl, awslc))]
 fn test_name_to_owned() {
     let cert = include_bytes!("../../test/cert.pem");
     let cert = X509::from_pem(cert).unwrap();


### PR DESCRIPTION
Remove the version restriction (#[cfg(any(ossl110, libressl))]) from X509_NAME_dup in openssl-sys and the corresponding X509NameRef::to_owned() method in openssl. This function has been available since early versions of OpenSSL, so there's no need to restrict it to 1.1.0+.

Also removes the version restriction from the test_name_to_owned test.