### PR TITLE
Remove ASN1_STRING_data for LibreSSL 4.3.0

### DIFF
--- a/openssl-sys/build/cfgs.rs
+++ b/openssl-sys/build/cfgs.rs
@@ -47,6 +47,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
         if libressl_version >= 0x4_02_00_00_0 {
             cfgs.push("libressl420");
         }
+        if libressl_version >= 0x4_03_00_00_0 {
+            cfgs.push("libressl430");
+        }
     } else {
         let openssl_version = openssl_version.unwrap();
         cfgs.push("ossl101");

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -161,6 +161,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(libressl400)");
     println!("cargo:rustc-check-cfg=cfg(libressl410)");
     println!("cargo:rustc-check-cfg=cfg(libressl420)");
+    println!("cargo:rustc-check-cfg=cfg(libressl430)");
 
     println!("cargo:rustc-check-cfg=cfg(ossl101)");
     println!("cargo:rustc-check-cfg=cfg(ossl102)");

--- a/openssl-sys/src/handwritten/asn1.rs
+++ b/openssl-sys/src/handwritten/asn1.rs
@@ -49,7 +49,7 @@ extern "C" {
     pub fn ASN1_STRING_type_new(ty: c_int) -> *mut ASN1_STRING;
     #[cfg(any(ossl110, libressl))]
     pub fn ASN1_STRING_get0_data(x: *const ASN1_STRING) -> *const c_uchar;
-    #[cfg(any(all(ossl102, not(ossl110)), libressl))]
+    #[cfg(any(all(ossl102, not(ossl110)), all(libressl, not(libressl430))))]
     pub fn ASN1_STRING_data(x: *mut ASN1_STRING) -> *mut c_uchar;
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;


### PR DESCRIPTION
This API has been deprecated since forever and will be removed.

I'd actually prefer doing this for rust-openssl, so we can remove this API when we drop support for OpenSSL 1.0.2:

```diff
-    #[cfg(any(all(ossl102, not(ossl110)), libressl))]
+    #[cfg(all(ossl102, not(ossl110)))]
```

But of course doing this would be a semver breaking change.

Really the only reason for `ASN1_STRING_data` to be bound at all is the lack of the const-correct `ASN1_STRING_get0_data` in very old Open/LibreSSLs