### PR TITLE
X509ReqBuilder: add attribute

### DIFF
--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -400,6 +400,15 @@ extern "C" {
         len: c_int,
     ) -> c_int;
 }
+const_ptr_api! {
+    extern "C" {
+        pub fn X509_REQ_get_attr_by_OBJ(
+            req: *const X509_REQ,
+            obj: #[const_ptr_if(any(ossl110, libressl))] ASN1_OBJECT,
+            lastpos: c_int,
+        ) -> c_int;
+    }
+}
 extern "C" {
     pub fn X509_set_pubkey(x: *mut X509, pkey: *mut EVP_PKEY) -> c_int;
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> c_int;


### PR DESCRIPTION
Add attribute to X509Req.
Check if the attribute of a given type is present in X509Req.

X509 attribute (to be added) is defined by its Asn1Object and Asn1Type of value.

Needed for the IoT enrollment procedures:
-- 'challengePassword' for SCEP, EST, BRSKI,
-- 'changeSubjectName', 'masa-URL'  - EST, BRSKI
...
