### PR TITLE
x509: add minimal support for CRL building

### DIFF
--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -22,7 +22,7 @@ use std::ptr;
 use std::str;
 
 use crate::asn1::{
-    Asn1BitStringRef, Asn1Enumerated, Asn1IntegerRef, Asn1Object, Asn1ObjectRef,
+    Asn1BitStringRef, Asn1Enumerated, Asn1Integer, Asn1IntegerRef, Asn1Object, Asn1ObjectRef,
     Asn1OctetStringRef, Asn1StringRef, Asn1TimeRef, Asn1Type,
 };
 use crate::bio::MemBioSlice;
@@ -38,6 +38,8 @@ use crate::string::OpensslString;
 use crate::util::{self, ForeignTypeExt, ForeignTypeRefExt};
 use crate::{cvt, cvt_n, cvt_p, cvt_p_const};
 use openssl_macros::corresponds;
+
+pub use crate::x509::extension::CrlNumber;
 
 pub mod verify;
 
@@ -1612,6 +1614,49 @@ impl CrlReason {
     }
 }
 
+/// A builder used to construct an `X509Revoked`.
+pub struct X509RevokedBuilder(X509Revoked);
+
+impl X509RevokedBuilder {
+    /// Creates a new builder.
+    #[corresponds(X509_REVOKED_new)]
+    pub fn new() -> Result<Self, ErrorStack> {
+        unsafe {
+            ffi::init();
+            cvt_p(ffi::X509_REVOKED_new()).map(|p| X509RevokedBuilder(X509Revoked(p)))
+        }
+    }
+
+    /// Set the revocation date of the `X509Revoked`.
+    #[corresponds(X509_REVOKED_set_revocationDate)]
+    pub fn set_revocation_date(&mut self, date: &Asn1TimeRef) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::X509_REVOKED_set_revocationDate(
+                self.0.as_ptr(),
+                date.as_ptr(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Set the serial number of the `X509Revoked`.
+    #[corresponds(X509_REVOKED_set_serialNumber)]
+    pub fn set_serial_number(&mut self, serial: &Asn1IntegerRef) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::X509_REVOKED_set_serialNumber(
+                self.0.as_ptr(),
+                serial.as_ptr(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Consumes the builder, returning the `X509Revoked`.
+    pub fn build(self) -> X509Revoked {
+        self.0
+    }
+}
+
 foreign_type_and_impl_send_sync! {
     type CType = ffi::X509_REVOKED;
     fn drop = ffi::X509_REVOKED_free;
@@ -1705,7 +1750,7 @@ impl X509RevokedRef {
 /// this is as defined in RFC 5280 Section 5.3.1.
 pub enum ReasonCode {}
 
-// SAFETY: CertificateIssuer is defined to be a stack of GeneralName in the RFC
+// SAFETY: ReasonCode is defined to be an Asn1Enumerated in the RFC
 // and in OpenSSL.
 unsafe impl ExtensionType for ReasonCode {
     const NID: Nid = Nid::from_raw(ffi::NID_crl_reason);
@@ -1734,6 +1779,158 @@ unsafe impl ExtensionType for AuthorityInformationAccess {
     const NID: Nid = Nid::from_raw(ffi::NID_info_access);
 
     type Output = Stack<AccessDescription>;
+}
+
+// SAFETY: CrlNumber is defined to be an Asn1Integer in the RFC
+// and in OpenSSL.
+unsafe impl ExtensionType for CrlNumber {
+    const NID: Nid = Nid::CRL_NUMBER;
+
+    type Output = Asn1Integer;
+}
+
+/// A builder used to construct a version 2 `X509Crl`.
+pub struct X509CrlBuilder(X509Crl);
+
+impl X509CrlBuilder {
+    /// Creates a new builder.
+    #[corresponds(X509_CRL_new)]
+    pub fn new() -> Result<Self, ErrorStack> {
+        unsafe {
+            ffi::init();
+            let ptr = cvt_p(ffi::X509_CRL_new())?;
+            cvt(ffi::X509_CRL_set_version(ptr, 1)).map(|_| ())?;
+
+            Ok(Self(X509Crl(ptr)))
+        }
+    }
+
+    /// Set the issuer name of the CRL.
+    #[corresponds(X509_CRL_set_issuer_name)]
+    pub fn set_issuer_name(&mut self, issuer_name: &X509NameRef) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::X509_CRL_set_issuer_name(
+                self.0.as_ptr(),
+                issuer_name.as_ptr(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Set the lastUpdate (thisUpdate) time indicating when the CRL was issued.
+    #[corresponds(X509_CRL_set1_lastUpdate)]
+    pub fn set_last_update(&mut self, t: &Asn1TimeRef) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::X509_CRL_set1_lastUpdate(self.0.as_ptr(), t.as_ptr())).map(|_| ()) }
+    }
+
+    /// Set the nextUpdate timestamp indicating when a newer CRL is expected.
+    #[corresponds(X509_CRL_set1_nextUpdate)]
+    pub fn set_next_update(&mut self, t: &Asn1TimeRef) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::X509_CRL_set1_nextUpdate(self.0.as_ptr(), t.as_ptr())).map(|_| ()) }
+    }
+
+    /// Add an X509 extension value to the CRL.
+    ///
+    /// This works just as `append_extension` except it takes ownership of the `X509Extension`.
+    pub fn append_extension(&mut self, extension: X509Extension) -> Result<(), ErrorStack> {
+        self.append_extension2(&extension)
+    }
+
+    /// Add an X509 extension value to the CRL.
+    #[corresponds(X509_CRL_add_ext)]
+    pub fn append_extension2(&mut self, extension: &X509ExtensionRef) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::X509_CRL_add_ext(
+                self.0.as_ptr(),
+                extension.as_ptr(),
+                -1,
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Add a revoked certificate to the CRL.
+    #[corresponds(X509_CRL_add0_revoked)]
+    pub fn add_revoked(&mut self, revoked: X509Revoked) -> Result<(), ErrorStack> {
+        unsafe {
+            let r = cvt(ffi::X509_CRL_add0_revoked(
+                self.0.as_ptr(),
+                revoked.as_ptr(),
+            ))
+            .map(|_| ());
+            std::mem::forget(revoked);
+            r
+        }
+    }
+
+    /// Sort the CRL.
+    #[corresponds(X509_CRL_sort)]
+    pub fn sort(&mut self) -> Result<(), ErrorStack> {
+        unsafe { cvt(ffi::X509_CRL_sort(self.0.as_ptr())).map(|_| ()) }
+    }
+
+    /// Signs the CRL with a private key.
+    #[corresponds(X509_CRL_sign)]
+    pub fn sign<T>(&mut self, key: &PKeyRef<T>, hash: MessageDigest) -> Result<(), ErrorStack>
+    where
+        T: HasPrivate,
+    {
+        unsafe {
+            cvt(ffi::X509_CRL_sign(
+                self.0.as_ptr(),
+                key.as_ptr(),
+                hash.as_ptr(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Consumes the builder, returning the CRL.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of nextUpdate, revoked, AuthorityKeyIdentifier or CrlNumber is missing
+    pub fn build(self) -> Result<X509Crl, ErrorStack> {
+        unsafe {
+            let loc = ffi::X509_CRL_get_ext_by_NID(
+                self.0.as_ptr(),
+                Nid::AUTHORITY_KEY_IDENTIFIER.as_raw(),
+                -1,
+            );
+            assert!(
+                loc >= 0,
+                "CRL must have an Authority Key Identifier extension"
+            );
+            let ext = ffi::X509_CRL_get_ext(self.0.as_ptr(), loc);
+            assert_eq!(
+                ffi::X509_EXTENSION_get_critical(ext),
+                0,
+                "Authority Key Identifier extension must not be critical"
+            );
+
+            let loc = ffi::X509_CRL_get_ext_by_NID(self.0.as_ptr(), Nid::CRL_NUMBER.as_raw(), -1);
+            assert!(loc >= 0, "CRL must have a Crl Number extension");
+            let ext = ffi::X509_CRL_get_ext(self.0.as_ptr(), loc);
+            assert_eq!(
+                ffi::X509_EXTENSION_get_critical(ext),
+                0,
+                "Crl Number extension must not be critical"
+            );
+
+            assert!(
+                !X509_CRL_get0_nextUpdate(self.0.as_ptr()).is_null(),
+                "CRL must have nextUpdate time set"
+            );
+            let revoked = self.0.get_revoked();
+            assert!(
+                // XXX - switch to is_none_or() once MSRV is 1.82.
+                revoked.is_none() || revoked.is_some_and(|r| !r.is_empty()),
+                "Revoked must be absent or non-empty"
+            );
+        }
+
+        Ok(self.0)
+    }
 }
 
 foreign_type_and_impl_send_sync! {

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -2,9 +2,10 @@ use std::cmp::Ordering;
 
 use crate::asn1::{Asn1Object, Asn1OctetString, Asn1Time};
 use crate::bn::{BigNum, MsbOption};
+use crate::error::ErrorStack;
 use crate::hash::MessageDigest;
 use crate::nid::Nid;
-use crate::pkey::{PKey, Private};
+use crate::pkey::{PKey, PKeyRef, Private};
 use crate::rsa::Rsa;
 #[cfg(not(any(boringssl, awslc)))]
 use crate::ssl::SslFiletype;
@@ -19,7 +20,7 @@ use crate::x509::store::X509StoreBuilder;
 use crate::x509::verify::{X509VerifyFlags, X509VerifyParam};
 #[cfg(any(ossl110, boringssl, awslc))]
 use crate::x509::X509PurposeId;
-use crate::x509::X509PurposeRef;
+use crate::x509::{CrlNumber, X509CrlBuilder, X509PurposeRef, X509Ref, X509RevokedBuilder};
 #[cfg(ossl110)]
 use crate::x509::{CrlReason, X509Builder};
 use crate::x509::{
@@ -379,6 +380,7 @@ fn x509_extension_new_from_der() {
 #[test]
 fn x509_extension_to_der() {
     let builder = X509::builder().unwrap();
+    let bn = BigNum::from_u32(42).unwrap();
 
     for (ext, expected) in [
         (
@@ -408,6 +410,13 @@ fn x509_extension_to_der() {
                 .build()
                 .unwrap(),
             b"0\x22\x06\x03U\x1d%\x04\x1b0\x19\x06\x08+\x06\x01\x05\x05\x07\x03\x01\x06\x03\x887\x01\x06\x08+\x06\x01\x05\x05\x07\x03\x02",
+        ),
+        (
+            CrlNumber::new(bn)
+                .unwrap()
+                .build()
+                .unwrap(),
+            b"\x30\x0a\x06\x03\x55\x1d\x14\x04\x03\x02\x01\x2a",
         ),
     ] {
         assert_eq!(&ext.to_der().unwrap(), expected);
@@ -1257,4 +1266,119 @@ fn test_ocsp_responders_invalid_utf8() {
     let cert = include_bytes!("../../test/aia_bad_utf8_cert.pem");
     let cert = X509::from_pem(cert).unwrap();
     assert!(cert.ocsp_responders().is_err());
+}
+
+#[test]
+fn test_x509_revoked_builder() {
+    let mut builder = X509RevokedBuilder::new().unwrap();
+    let bn = BigNum::from_u32(1024).unwrap();
+    let d = Asn1Time::from_unix(0).unwrap();
+
+    builder
+        .set_serial_number(&bn.to_asn1_integer().unwrap())
+        .unwrap();
+    builder.set_revocation_date(&d).unwrap();
+
+    let revoked = builder.build();
+
+    assert_eq!(revoked.serial_number().to_bn().unwrap(), bn);
+    assert_eq!(
+        revoked.revocation_date().compare(&d).unwrap(),
+        Ordering::Equal
+    )
+}
+
+fn build_ca() -> Result<(PKey<Private>, X509), ErrorStack> {
+    let rsa = Rsa::generate(2048)?;
+    let pkey = PKey::from_rsa(rsa)?;
+
+    let mut name = X509Name::builder()?;
+    name.append_entry_by_nid(Nid::COMMONNAME, "foorbar.com")?;
+    let name = name.build();
+
+    // Build certificate
+    let mut builder = X509::builder()?;
+    builder.set_version(2)?;
+    builder.set_subject_name(&name)?;
+    builder.set_issuer_name(&name)?;
+    builder.set_pubkey(&pkey)?;
+    builder.set_not_before(&*Asn1Time::days_from_now(0)?)?;
+    builder.set_not_after(&*Asn1Time::days_from_now(365)?)?;
+
+    let exts = {
+        let ctx = builder.x509v3_context(None, None);
+        let san = SubjectAlternativeName::new()
+            .dns("foobar.com")
+            .build(&ctx)?;
+        vec![san]
+    };
+
+    for ext in exts {
+        builder.append_extension(ext)?;
+    }
+
+    builder.sign(&pkey, MessageDigest::sha256())?;
+    let ca_cert = builder.build();
+    Ok((pkey, ca_cert))
+}
+
+fn build_crl(
+    key: &PKeyRef<Private>,
+    cert: &X509Ref,
+    extensions: Vec<X509Extension>,
+) -> Result<X509Crl, ErrorStack> {
+    let mut builder = X509RevokedBuilder::new()?;
+    let bn = BigNum::from_u32(1024)?;
+    let d = Asn1Time::from_unix(0)?;
+
+    builder.set_serial_number(&*bn.to_asn1_integer()?)?;
+    builder.set_revocation_date(&d)?;
+    let revoked = builder.build();
+    let revokeds = vec![revoked];
+
+    let mut builder = X509CrlBuilder::new()?;
+
+    builder.set_issuer_name(cert.issuer_name())?;
+    builder.set_last_update(&*Asn1Time::days_from_now(0)?)?;
+    builder.set_next_update(&*Asn1Time::days_from_now(30)?)?;
+
+    for ext in extensions {
+        builder.append_extension(ext)?;
+    }
+    for revoked in revokeds {
+        builder.add_revoked(revoked)?;
+    }
+
+    builder.sign(key, MessageDigest::sha256())?;
+
+    builder.build()
+}
+
+#[test]
+fn test_x509_crl_builder() {
+    let (pkey, ca_cert) = build_ca().unwrap();
+
+    let dummy = X509::builder().unwrap();
+    let ctx = dummy.x509v3_context(Some(ca_cert.as_ref()), None);
+    let aki = AuthorityKeyIdentifier::new()
+        .issuer(true)
+        .build(&ctx)
+        .unwrap();
+    let n = CrlNumber::new(BigNum::from_u32(42).unwrap())
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let exts = vec![aki, n];
+    let crl = build_crl(&pkey, &ca_cert, exts).unwrap();
+    assert!(crl.verify(&pkey).unwrap());
+
+    assert_eq!(crl.get_revoked().unwrap().len(), 1);
+
+    let (critical, n) = crl
+        .extension::<CrlNumber>()
+        .unwrap()
+        .expect("Crl Number extension should be present");
+    assert!(!critical, "Crl Number extension is not critical");
+    assert_eq!(n.to_bn().unwrap().to_string(), "42");
 }


### PR DESCRIPTION
**Summary**

This pull request introduces initial support for Certificate Revocation List (CRL) functionality. The current implementation of the library exposes many X.509 certificate features, but the APIs related to CRL creation and manipulation are still missing. This PR fills part of that gap by adding the essential types and extensions required to build and manage CRLs programmatically.

**Motivation**

The OpenSSL C API provides full support for generating, parsing, and extending CRLs. However, rust-openssl currently lacks high-level Rust bindings for these components. As a result, users cannot create CRLs, add revoked certificate entries, or include the standard CRL-related extensions expected in real-world PKI workflows. This PR aims to improve feature parity with OpenSSL and enable broader CRL use cases within Rust applications.

**What’s Added**

This contribution introduces wrappers and bindings for several key X.509 structures used in CRL creation:

- `X509RevokedBuilder`
- `AccessDescriptionBuilder`
- `DistributionPointBuilder`
- `DistributionPointNameBuilder`

Additionally, the PR adds support for CRL extensions and CRL entry extensions, which are necessary for producing standards-compliant CRLs (e.g., CRL Number, Authority Key Identifier, CRL Reason Codes, Issuing Distribution Point).

**Benefits**

Enables programmatic creation and customization of CRLs in Rust
Improves parity with the OpenSSL CRL API
Helps developers build complete PKI workflows without relying on external tools