### PR TITLE
Replace X509 Debug BigNum::to_hex_str() use by format!("{:X}", ...)

### DIFF
--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -799,15 +799,10 @@ impl Clone for X509 {
 
 impl fmt::Debug for X509 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let serial = match &self.serial_number().to_bn() {
-            Ok(bn) => match bn.to_hex_str() {
-                Ok(hex) => hex.to_string(),
-                Err(_) => "".to_string(),
-            },
-            Err(_) => "".to_string(),
-        };
         let mut debug_struct = formatter.debug_struct("X509");
-        debug_struct.field("serial_number", &serial);
+        if let Ok(serial) = self.serial_number().to_bn() {
+            debug_struct.field("serial_number", &format!("{:X}", serial));
+        }
         debug_struct.field("signature_algorithm", &self.signature_algorithm().object());
         debug_struct.field("issuer", &self.issuer_name());
         debug_struct.field("subject", &self.subject_name());

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -54,10 +54,7 @@ fn test_debug() {
     let cert = include_bytes!("../../test/cert.pem");
     let cert = X509::from_pem(cert).unwrap();
     let debugged = format!("{:#?}", cert);
-    assert!(
-        debugged.contains(r#"serial_number: "8771F7BDEE982FA5""#)
-            || debugged.contains(r#"serial_number: "8771f7bdee982fa5""#)
-    );
+    assert!(debugged.contains(r#"serial_number: "8771F7BDEE982FA5""#));
     assert!(debugged.contains(r#"signature_algorithm: sha256WithRSAEncryption"#));
     assert!(debugged.contains(r#"countryName = "AU""#));
     assert!(debugged.contains(r#"stateOrProvinceName = "Some-State""#));


### PR DESCRIPTION
Depending on the specific *SSL library being used, BigNum::to_hex_str()
can return either an upper-case hexadecimal string or a lower-case
hexadecimal string, and this can produce inconsistent X509 Debug output,
as the X509 Debug impl currently uses BigNum::to_hex_str() to print the
X509 certificate's serial number.

Since commit 7dda804d ("Add UpperHex implementation for BigNum{,Ref}"),
we can use format!("{:X}", ...) to format BigNums consistently across
*SSL libraries, so use that instead of BigNum::to_hex_str() to format
the X509 certificate's serial number.