### PR TITLE
Add Debug implementation for EcPoint{,Ref}

### DIFF
--- a/openssl-sys/src/handwritten/ec.rs
+++ b/openssl-sys/src/handwritten/ec.rs
@@ -292,3 +292,13 @@ extern "C" {
         eckey: *mut EC_KEY,
     ) -> c_int;
 }
+
+#[repr(C)]
+pub struct EC_builtin_curve {
+    pub nid: c_int,
+    pub comment: *const c_char,
+}
+
+extern "C" {
+    pub fn EC_get_builtin_curves(r: *mut EC_builtin_curve, nitems: usize) -> usize;
+}


### PR DESCRIPTION
This allows deriving Debug on user-defined structs that contain
instances of EcPoint{,Ref}, and is the final Debug impl necessary to
allow an application I wrote that uses rust-openssl to derive Debug
on all of its internal structs.

Implementing Debug for EcPoint is a little annoying, since the OpenSSL
function that you need to use to extract the point's coordinates,
EC_POINT_get_affine_coordinates(), takes an EC_GROUP * argument which
has to correspond to the point's curve, and the function will fail if
you pass it the wrong EC_GROUP, and OpenSSL seems to provide no way to
obtain the corresponding EC_GROUP for a given EC_POINT even though it
has that information internally.

What we do here is use OpenSSL's EC_get_builtin_curves() to retrieve a
list of built-in EC curves, and try EC_POINT_get_affine_coordinates()
for each of the returned curves.  This seems to work fine, and it's OK
that this is a little inefficient, since the number of built-in curves
should be on the order of a hundred or so at most, and this is not
performance-critical.

For the secp224r1 generator point, this will print:

```
    EcPoint {
        group: EcGroup {
            curve_name: "secp224r1",
        },
        x: "B70E0CBD6BB4BF7F321390B94A03C1D356C21122343280D6115C1D21",
        y: "BD376388B5F723FB4C22DFE6CD4375A05A07476444D5819985007E34",
    }
```

If we can't find the correct EC_GROUP for a given EC_POINT, we will
instead print:

```
    EcPoint {
        group: "unknown",
        ..
    }
```