### PR TITLE
add more brainpool curve NID constants

### DIFF
--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -117,15 +117,23 @@ pub const NID_brainpoolP512r1: c_int = 934;
 
 #[cfg(ossl110)]
 pub const NID_brainpoolP256t1: c_int = 928;
+#[cfg(libressl)]
+pub const NID_brainpoolP256t1: c_int = 929;
 
 #[cfg(ossl110)]
 pub const NID_brainpoolP320t1: c_int = 930;
+#[cfg(libressl)]
+pub const NID_brainpoolP320t1: c_int = 931;
 
 #[cfg(ossl110)]
 pub const NID_brainpoolP384t1: c_int = 932;
+#[cfg(libressl)]
+pub const NID_brainpoolP384t1: c_int = 933;
 
 #[cfg(ossl110)]
 pub const NID_brainpoolP512t1: c_int = 934;
+#[cfg(libressl)]
+pub const NID_brainpoolP512t1: c_int = 935;
 
 pub const NID_wap_wsg_idm_ecid_wtls1: c_int = 735;
 pub const NID_wap_wsg_idm_ecid_wtls3: c_int = 736;

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -222,13 +222,13 @@ impl Nid {
     pub const BRAINPOOL_P384R1: Nid = Nid(ffi::NID_brainpoolP384r1);
     #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P512R1: Nid = Nid(ffi::NID_brainpoolP512r1);
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P256T1: Nid = Nid(ffi::NID_brainpoolP256t1);
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P320T1: Nid = Nid(ffi::NID_brainpoolP320t1);
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P384T1: Nid = Nid(ffi::NID_brainpoolP384t1);
-    #[cfg(ossl110)]
+    #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P512T1: Nid = Nid(ffi::NID_brainpoolP512t1);
     pub const WAP_WSG_IDM_ECID_WTLS1: Nid = Nid(ffi::NID_wap_wsg_idm_ecid_wtls1);
     pub const WAP_WSG_IDM_ECID_WTLS3: Nid = Nid(ffi::NID_wap_wsg_idm_ecid_wtls3);


### PR DESCRIPTION
This PR adds more NID constants for additional brainpool curves defined in [RFC5639](https://datatracker.ietf.org/doc/html/rfc5639), which are available in openssl, but not rust-openssl.

These curves included are:
- brainpoolP256t1
- brainpoolP320t1
- brainpoolP384t1
- brainpoolP512t1