### PR TITLE
Fix use-after-free of error strings on BoringSSL/aws-lc

### DIFF
--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -127,14 +127,11 @@ impl Error {
                     let data = if flags & ffi::ERR_TXT_STRING != 0 {
                         let bytes = CStr::from_ptr(data as *const _).to_bytes();
                         let data = str::from_utf8(bytes).unwrap();
-                        #[cfg(not(any(boringssl, awslc)))]
                         let data = if flags & ffi::ERR_TXT_MALLOCED != 0 {
                             Cow::Owned(data.to_string())
                         } else {
                             Cow::Borrowed(data)
                         };
-                        #[cfg(any(boringssl, awslc))]
-                        let data = Cow::Borrowed(data);
                         Some(data)
                     } else {
                         None


### PR DESCRIPTION
The boringssl/awslc cfg gate unconditionally used Cow::Borrowed for error data, treating it as 'static. However, BoringSSL and aws-lc dynamically allocate error strings and may free them on the next error queue operation. Both libraries set ERR_TXT_MALLOCED as a workaround to signal that the string should be copied, but the cfg gate bypassed that check entirely.

Remove the cfg gates and use the same ERR_TXT_MALLOCED check for all backends.

Fixes #2470