### PR TITLE
Adds bindings for SSL(_CTX)_use_psk_identity_hint

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -230,6 +230,9 @@ extern "C" {
     );
     pub fn SSL_get_psk_identity_hint(ssl: *const SSL) -> *const c_char;
     pub fn SSL_get_psk_identity(ssl: *const SSL) -> *const c_char;
+
+    pub fn SSL_CTX_use_psk_identity_hint(ctx: *mut SSL_CTX, hint: *const c_char) -> c_int;
+    pub fn SSL_use_psk_identity_hint(ssl: *mut SSL, hint: *const c_char) -> c_int;
 }
 
 extern "C" {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1336,6 +1336,22 @@ impl SslContextBuilder {
         }
     }
 
+    // Sets the pre-shared key identity hint the server sends in the ServerKeyExchange
+    // message during handshake.
+    #[corresponds(SSL_CTX_use_psk_identity_hint)]
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+    pub fn use_psk_identity_hint(&mut self, hint: &str) -> Result<c_int, c_int> {
+        let hint = CString::new(hint).unwrap();
+        unsafe {
+            let res = ffi::SSL_CTX_use_psk_identity_hint(self.as_ptr(), hint.as_ptr());
+            if res == 0 {
+                Ok(res)
+            } else {
+                Err(res)
+            }
+        }
+    }
+
     /// Sets the callback for providing an identity and pre-shared key for a TLS-PSK client.
     ///
     /// The callback will be called with the SSL context, an identity hint if one was provided
@@ -3188,6 +3204,22 @@ impl SslRef {
                 None
             } else {
                 Some(CStr::from_ptr(ptr).to_bytes())
+            }
+        }
+    }
+
+    // Sets the pre-shared key identity hint the server sends in the ServerKeyExchange
+    // message during handshake.
+    #[corresponds(SSL_use_psk_identity_hint)]
+    #[cfg(not(osslconf = "OPENSSL_NO_PSK"))]
+    pub fn use_psk_identity_hint(&mut self, hint: &str) -> Result<c_int, c_int> {
+        let hint = CString::new(hint).unwrap();
+        unsafe {
+            let res = ffi::SSL_use_psk_identity_hint(self.as_ptr(), hint.as_ptr());
+            if res == 0 {
+                Ok(res)
+            } else {
+                Err(res)
             }
         }
     }


### PR DESCRIPTION
This PR adds bindings for `SSL_use_psk_identity_hint` and `SSL_CTX_use_psk_identity_hint`.