### PR TITLE
Bump aws-lc-sys to 0.38

### DIFF
--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -24,7 +24,7 @@ aws-lc-fips = ['dep:aws-lc-fips-sys']
 [dependencies]
 libc = "0.2"
 bssl-sys = { version = "0.1.0", optional = true }
-aws-lc-sys = { version = "0.34", features = ["ssl"], optional = true }
+aws-lc-sys = { version = "0.38", features = ["ssl"], optional = true }
 aws-lc-fips-sys = { version = "0.13", features = ["ssl", "bindgen"], optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
0.38 includes AWS-LC 1.69 which addresses a few CVEs:
- https://github.com/aws/aws-lc-rs/security/advisories/GHSA-vw5v-4f2q-w9xf
- https://github.com/aws/aws-lc-rs/security/advisories/GHSA-65p9-r9h6-22vj
- https://github.com/aws/aws-lc-rs/security/advisories/GHSA-hfpc-8r3f-gw53