### PR TITLE
Release openssl v0.10.76 and openssl-sys v0.9.112

### DIFF
--- a/openssl-sys/CHANGELOG.md
+++ b/openssl-sys/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [v0.9.112] - 2026-03-11
+
+### Added
+
+* Added bindings for HKDF support.
+* Added `OSSL_PARAM_BLD_push_int`.
+* Added bindings for `EVP_PKEY_new_raw_public_key_ex`, `EVP_PKEY_new_raw_private_key_ex`, and `EVP_PKEY_is_a`.
+* Added brainpool curve NID constants.
+* Added NID for `AES_*_OCB`.
+* Unconditionally exposed `X509_NAME_dup` and other `*_dup()` functions.
+* Added support for pregenerated Rust bindings from AWS-LC installations.
+* Added support for LibreSSL 4.3.0.
+
+### Changed
+
+* Bumped `aws-lc-sys` from 0.27 to 0.38. 0.38 includes security fixes (CVEs).
+
+### Removed
+
+* Removed `ASN1_STRING_data` for LibreSSL 4.3.0.
+* Removed `X509_VERIFY_PARAM_ID` for LibreSSL 4.3.0.
+* Removed `ASN1_ENCODING` for LibreSSL 4.3.0.
+
 ## [v0.9.111] - 2025-11-07
 
 ### Added
@@ -686,7 +709,8 @@ Fixed builds against OpenSSL built with `no-cast`.
 * Added `X509_verify` and `X509_REQ_verify`.
 * Added `EVP_MD_type` and `EVP_GROUP_get_curve_name`.
 
-[Unreleased]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.111..master
+[Unreleased]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.112..master
+[v0.9.112]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.111...openssl-sys-v0.9.112
 [v0.9.111]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.110...openssl-sys-v0.9.111
 [v0.9.110]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.109...openssl-sys-v0.9.110
 [v0.9.109]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.108...openssl-sys-v0.9.109

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Steven Fackler <sfackler@gmail.com>",

--- a/openssl/CHANGELOG.md
+++ b/openssl/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+## [v0.10.76] - 2026-03-11
+
+### Added
+
+* Added brainpool curve NID constants.
+* Added `SubjectAlternativeName::dir_name2` for constructing directoryName SAN entries.
+* Added HKDF and generic KDF support.
+* Added `UpperHex` implementation for `BigNum` and `BigNumRef`.
+* Added `add_utf8_string` and `add_int` to `OsslParamBuilder`.
+* Added `Debug` implementation for `EcGroup`, `EcGroupRef`, `EcdsaSig` and `EcdsaSigRef`.
+* Enhanced `Debug` implementation for `Nid`.
+* Constified `PKey::from_raw`.
+* Exposed `from_str_x509()` for LibreSSL >= 3.6.0.
+
+### Fixed
+
+* Fixed use-after-free of error strings on BoringSSL/aws-lc.
+* Fixed cipher comparison (`is_ccm`, `is_ocb`) to use NID instead of unreliable pointer comparison. Added NID constants for `AES_*_OCB`.
+* Fixed invalid value parsing of OCSP revocation reason.
+* Fixed `BIO_METHOD` path for AWS-LC to use BoringSSL codepath.
+
 ## [v0.10.75] - 2025-11-07
 
 ### Added
@@ -1022,7 +1043,8 @@
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.75...master
+[Unreleased]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.76...master
+[v0.10.76]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.75...openssl-v0.10.76
 [v0.10.75]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.74...openssl-v0.10.75
 [v0.10.74]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.73...openssl-v0.10.74
 [v0.10.73]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.72...openssl-v0.10.73

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 license = "Apache-2.0"
 description = "OpenSSL bindings"
@@ -33,7 +33,7 @@ libc = "0.2"
 once_cell = "1.5.2"
 
 openssl-macros = { version = "0.1.1", path = "../openssl-macros" }
-ffi = { package = "openssl-sys", version = "0.9.111", path = "../openssl-sys" }
+ffi = { package = "openssl-sys", version = "0.9.112", path = "../openssl-sys" }
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
Mostly followed what it has been done, like <https://github.com/rust-openssl/rust-openssl/pull/2518>. Also generated by Claude and slight hand-crafted.

<details>
<summary>Here are PRs I skipped in openssl-sys changelog (CI-only, build infra, or openssl only):</summary>

* #2518 - Bump for release (post-release cleanup)
* #2523 - Fix OCSP revocation reason parsing (openssl only)
* #2524 - Bump actions/checkout from 5 to 6
* #2528 - dir_name support for subject_alt_names (openssl only)
* #2540 - Debug for EcdsaSig (openssl only)
* #2542 - Bump actions/cache from 4 to 5
* #2546 - Test against OpenSSL 3.6.0 in CI
* #2547 - Enhance Debug for Nid (openssl only)
* #2548 - Debug for EcGroup (openssl only)
* #2550 - UpperHex for BigNum (openssl only)
* #2562 - BIO_METHOD path for AWS-LC (openssl only)
* #2569 - Upgrade ctest to 0.5
* #2572 - Fix use-after-free of error strings (openssl only)
* #2573 - Fix min-version CI
* #2545 - Drop openssl 1.0.2 (cleanup, already announced in v0.9.110)
* #2559 - Remove more OpenSSL 1.0.2 complications (cleanup)
* #2560 - Still more OpenSSL 1.0.2 complications (cleanup)
* #2561 - Remove dead config branches (cleanup)
* #2579 - Pin quote to 1.0.44 for min-version CI
* #2580 - Constify from_raw (openssl only)

</details>

<details>
<summary>Here are PRs I skipped in openssl changelog (CI-only, build infra, or openssl-sys only):</summary>


* #2518 - Bump for release (post-release cleanup)
* #2521 - EVP_PKEY_new_raw_*_key_ex and EVP_PKEY_is_a (openssl-sys only)
* #2524 - Bump actions/checkout from 5 to 6
* #2526 - Bump aws-lc-sys from 0.27 to 0.34 (openssl-sys only)
* #2529 - Expose X509_NAME_dup (openssl-sys only)
* #2530 - Unconditionally expose *_dup() functions (openssl-sys only)
* #2534 - Remove ASN1_STRING_data for LibreSSL 4.3.0 (openssl-sys only)
* #2542 - Bump actions/cache from 4 to 5
* #2546 - Test against OpenSSL 3.6.0 in CI
* #2549 - Remove X509_VERIFY_PARAM_ID for LibreSSL 4.3.0 (openssl-sys only)
* #2569 - Upgrade ctest to 0.5
* #2573 - Fix min-version CI
* #2578 - Pregenerated Rust bindings from AWS-LC (openssl-sys only)
* #2545 - Drop openssl 1.0.2 (cleanup, already announced in v0.10.74)
* #2559 - Remove more OpenSSL 1.0.2 complications (cleanup)
* #2560 - Still more OpenSSL 1.0.2 complications (cleanup)
* #2561 - Remove dead config branches (cleanup)
* #2579 - Pin quote to 1.0.44 for min-version CI
* #2581 - Bump aws-lc-sys to 0.38 (openssl-sys only)
</details>
