### PR TITLE
Support openssl 4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
             - name: openssl
               version: vendored
             - name: openssl
+              version: 4.0.0-beta1
+            - name: openssl
               version: 3.6.0
             - name: openssl
               version: 3.5.0

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -19,6 +19,7 @@ mod run_bindgen;
 
 #[derive(PartialEq)]
 enum Version {
+    Openssl4xx,
     Openssl3xx,
     Openssl11x,
     Libressl,
@@ -226,7 +227,9 @@ fn main() {
             }
         }
         None => match version {
-            Version::Openssl3xx | Version::Openssl11x if target.contains("windows-msvc") => {
+            Version::Openssl4xx | Version::Openssl3xx | Version::Openssl11x
+                if target.contains("windows-msvc") =>
+            {
                 vec!["libssl", "libcrypto"]
             }
             _ => vec!["ssl", "crypto"],
@@ -436,8 +439,10 @@ See rust-openssl documentation for more information:
         let openssl_version = openssl_version.unwrap();
         println!("cargo:version_number={openssl_version:x}");
 
-        if openssl_version >= 0x4_00_00_00_0 {
+        if openssl_version >= 0x4_02_00_00_0 {
             version_error()
+        } else if openssl_version >= 0x4_00_00_00_0 {
+            Version::Openssl4xx
         } else if openssl_version >= 0x3_00_00_00_0 {
             Version::Openssl3xx
         } else if openssl_version >= 0x1_01_01_00_0 {


### PR DESCRIPTION
OpenSSL 4.0.0 beta 1 is out, and 4.0.0 is planned to be released by April 14th