### PR TITLE
md_ctx: enable sign/verify/reset on BoringSSL, LibreSSL, and AWS-LC

### DIFF
--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -246,7 +246,7 @@ cfg_if! {
     }
 }
 cfg_if! {
-    if #[cfg(any(ossl111, libressl370))] {
+    if #[cfg(any(ossl111, libressl))] {
         extern "C" {
             pub fn EVP_DigestSign(
                 ctx: *mut EVP_MD_CTX,
@@ -273,7 +273,7 @@ extern "C" {
     pub fn EVP_CIPHER_CTX_copy(dst: *mut EVP_CIPHER_CTX, src: *const EVP_CIPHER_CTX) -> c_int;
 
     pub fn EVP_MD_CTX_copy_ex(dst: *mut EVP_MD_CTX, src: *const EVP_MD_CTX) -> c_int;
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, libressl))]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> c_int;
     pub fn EVP_CIPHER_CTX_set_key_length(ctx: *mut EVP_CIPHER_CTX, keylen: c_int) -> c_int;
     pub fn EVP_CIPHER_CTX_set_padding(ctx: *mut EVP_CIPHER_CTX, padding: c_int) -> c_int;

--- a/openssl/src/md_ctx.rs
+++ b/openssl/src/md_ctx.rs
@@ -334,7 +334,7 @@ impl MdCtxRef {
     ///
     /// Requires OpenSSL 1.1.1 or newer.
     #[corresponds(EVP_DigestSign)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, boringssl, awslc, libressl))]
     #[inline]
     pub fn digest_sign(&mut self, from: &[u8], to: Option<&mut [u8]>) -> Result<usize, ErrorStack> {
         let mut len = to.as_ref().map_or(0, |b| b.len());
@@ -353,7 +353,7 @@ impl MdCtxRef {
     }
 
     /// Like [`Self::digest_sign`] but appends the signature to a [`Vec`].
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, boringssl, awslc, libressl))]
     pub fn digest_sign_to_vec(
         &mut self,
         from: &[u8],
@@ -374,7 +374,7 @@ impl MdCtxRef {
     ///
     /// Requires OpenSSL 1.1.1 or newer.
     #[corresponds(EVP_DigestVerify)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, boringssl, awslc, libressl))]
     #[inline]
     pub fn digest_verify(&mut self, data: &[u8], signature: &[u8]) -> Result<bool, ErrorStack> {
         unsafe {
@@ -398,7 +398,7 @@ impl MdCtxRef {
 
     /// Resets the underlying EVP_MD_CTX instance
     #[corresponds(EVP_MD_CTX_reset)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, boringssl, awslc, libressl))]
     #[inline]
     pub fn reset(&mut self) -> Result<(), ErrorStack> {
         unsafe {
@@ -515,7 +515,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, boringssl, awslc, libressl))]
     fn verify_md_ctx_reset() {
         let hello_expected =
             hex::decode("185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969")


### PR DESCRIPTION
EVP_DigestSign, EVP_DigestVerify, and EVP_MD_CTX_reset are all available on BoringSSL, AWS-LC, and LibreSSL (since 3.4.0 for the former two, and 2.7.0 for reset, well under the 3.5.0 minimum).

Also add libressl to the openssl-sys binding for EVP_MD_CTX_reset, which was previously only exposed for ossl111.

EVP_DigestFinalXOF is intentionally left out for BoringSSL: it is declared only as a stub that always fails, since BoringSSL does not support any XOF digests.

https://claude.ai/code/session_01KXL6oJAqpTNfMUmgS36yFZ