### PR TITLE
Mark BIO_get_mem_data on AWS-LC to be unsafe

### DIFF
--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -52,8 +52,8 @@ mod aws_lc {
     }
 
     // BIO_get_mem_data is a C preprocessor macro by definition
-    #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
-    pub fn BIO_get_mem_data(b: *mut BIO, pp: *mut *mut c_char) -> c_long {
+    #[allow(non_snake_case)]
+    pub unsafe fn BIO_get_mem_data(b: *mut BIO, pp: *mut *mut c_char) -> c_long {
         unsafe { BIO_ctrl(b, BIO_CTRL_INFO, 0, pp.cast::<c_void>()) }
     }
 


### PR DESCRIPTION
This is _technically_ a semver violation, but in practice it's already unsafe on all other platforms, and is unsound otherwise.