### PR TITLE
Set timeout for package installation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
           id: rust-version
         - run: rustup target add ${{ matrix.target }}
         - name: Install packages
+          timeout-minutes: 3
           run: |
             case "${{ matrix.target }}" in
             "x86_64-unknown-linux-gnu")


### PR DESCRIPTION
Sometimes the network is cursed and it takes forever. In these cases it's better to fail quickly and retry it.