### PR TITLE
Fix dangling stack pointer in custom extension add callback

### DIFF
--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -515,9 +515,6 @@ where
         match (*callback)(ssl, ectx, cert) {
             Ok(None) => 0,
             Ok(Some(buf)) => {
-                *outlen = buf.as_ref().len();
-                *out = buf.as_ref().as_ptr();
-
                 let idx = Ssl::cached_ex_index::<CustomExtAddState<T>>();
                 let mut buf = Some(buf);
                 let new = match ssl.ex_data_mut(idx) {
@@ -530,6 +527,15 @@ where
                 if new {
                     ssl.set_ex_data(idx, CustomExtAddState(buf));
                 }
+
+                // We must captures the out pointer AFTER buf has been moved into
+                // ex_data -- otherwise moving a type like [u8; N] would
+                // invalidate the captured pointer.
+                let stored = ssl.ex_data(idx).unwrap();
+                let data = stored.0.as_ref().unwrap().as_ref();
+                *outlen = data.len();
+                *out = data.as_ptr();
+
                 1
             }
             Err(alert) => {

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -528,9 +528,8 @@ where
                     ssl.set_ex_data(idx, CustomExtAddState(buf));
                 }
 
-                // We must captures the out pointer AFTER buf has been moved into
-                // ex_data -- otherwise moving a type like [u8; N] would
-                // invalidate the captured pointer.
+                // Capture the out pointer AFTER buf has been moved into ex_data.
+                // The move invalidates any previous pointer into buf.
                 let stored = ssl.ex_data(idx).unwrap();
                 let data = stored.0.as_ref().unwrap().as_ref();
                 *outlen = data.len();

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1252,6 +1252,44 @@ fn custom_extensions() {
     assert!(FOUND_EXTENSION.load(Ordering::SeqCst));
 }
 
+#[test]
+#[cfg(ossl111)]
+fn custom_extensions_inline_buffer() {
+    static FOUND_EXTENSION: AtomicBool = AtomicBool::new(false);
+    const EXPECTED: [u8; 128] = [0xAB; 128];
+
+    let mut server = Server::builder();
+    server
+        .ctx()
+        .add_custom_ext(
+            12345,
+            ExtensionContext::CLIENT_HELLO,
+            |_, _, _| -> Result<Option<[u8; 128]>, _> { unreachable!() },
+            |_, _, data, _| {
+                FOUND_EXTENSION.store(data == EXPECTED, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+    let server = server.build();
+
+    let mut client = server.client();
+    client
+        .ctx()
+        .add_custom_ext(
+            12345,
+            ssl::ExtensionContext::CLIENT_HELLO,
+            move |_, _, _| Ok(Some(EXPECTED)),
+            |_, _, _, _| unreachable!(),
+        )
+        .unwrap();
+
+    client.connect();
+
+    assert!(FOUND_EXTENSION.load(Ordering::SeqCst));
+}
+
 fn _check_kinds() {
     fn is_send<T: Send>() {}
     fn is_sync<T: Sync>() {}


### PR DESCRIPTION
The out pointer given to OpenSSL was captured before the buffer was moved into ex_data. For inline-storage types like [u8; N], as_ptr() points into the value itself, so the move invalidated the pointer. Capture it from the final heap location instead.