### PR TITLE
Add support for LibreSSL 4.3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,17 +211,17 @@ jobs:
               bindgen: true
               library:
                 name: libressl
-                version: 4.0.1
-            - target: x86_64-unknown-linux-gnu
-              bindgen: true
-              library:
-                name: libressl
                 version: 4.1.2
             - target: x86_64-unknown-linux-gnu
               bindgen: true
               library:
                 name: libressl
                 version: 4.2.1
+            - target: x86_64-unknown-linux-gnu
+              bindgen: true
+              library:
+                name: libressl
+                version: 4.3.1
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:
@@ -231,17 +231,17 @@ jobs:
               bindgen: false
               library:
                 name: libressl
-                version: 4.0.1
-            - target: x86_64-unknown-linux-gnu
-              bindgen: false
-              library:
-                name: libressl
                 version: 4.1.2
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:
                 name: libressl
                 version: 4.2.1
+            - target: x86_64-unknown-linux-gnu
+              bindgen: false
+              library:
+                name: libressl
+                version: 4.3.1
             - target: x86_64-unknown-linux-gnu
               bindgen: false
               library:

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -429,6 +429,7 @@ See rust-openssl documentation for more information:
             (4, 1, 0) => ('4', '1', '0'),
             (4, 1, _) => ('4', '1', 'x'),
             (4, 2, _) => ('4', '2', 'x'),
+            (4, 3, _) => ('4', '3', 'x'),
             _ => version_error(),
         };
 
@@ -467,7 +468,7 @@ fn version_error() -> ! {
         "
 
 This crate is only compatible with OpenSSL (version 1.1.0, 1.1.1, 3.x, or 4.x), or LibreSSL 3.5.0
-through 4.2.x, but a different version of OpenSSL was found. The build is now aborting
+through 4.3.x, but a different version of OpenSSL was found. The build is now aborting
 due to this version mismatch.
 
 "

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -85,7 +85,10 @@ pub const SSL_OP_SAFARI_ECDHE_ECDSA_BUG: ssl_op_type!() = 0x00000040;
 #[cfg(ossl300)]
 pub const SSL_OP_IGNORE_UNEXPECTED_EOF: ssl_op_type!() = 0x00000080;
 
+#[cfg(not(libressl430))]
 pub const SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS: ssl_op_type!() = 0x00000800;
+#[cfg(libressl430)]
+pub const SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS: ssl_op_type!() = 0x00000000;
 
 pub const SSL_OP_NO_QUERY_MTU: ssl_op_type!() = 0x00001000;
 pub const SSL_OP_COOKIE_EXCHANGE: ssl_op_type!() = 0x00002000;

--- a/openssl/build.rs
+++ b/openssl/build.rs
@@ -36,6 +36,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(libressl400)");
     println!("cargo:rustc-check-cfg=cfg(libressl410)");
     println!("cargo:rustc-check-cfg=cfg(libressl420)");
+    println!("cargo:rustc-check-cfg=cfg(libressl430)");
 
     println!("cargo:rustc-check-cfg=cfg(ossl101)");
     println!("cargo:rustc-check-cfg=cfg(ossl102)");
@@ -112,6 +113,9 @@ fn main() {
         }
         if version >= 0x4_02_00_00_0 {
             println!("cargo:rustc-cfg=libressl420");
+        }
+        if version >= 0x4_03_00_00_0 {
+            println!("cargo:rustc-cfg=libressl430");
         }
     }
 

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -1,7 +1,7 @@
 //! Bindings to OpenSSL
 //!
 //! This crate provides a safe interface to the popular OpenSSL cryptography library. OpenSSL versions 1.0.2 through
-//! 4.x.x and LibreSSL versions 3.5 through 4.2.x are supported.
+//! 4.x.x and LibreSSL versions 3.5 through 4.3.x are supported.
 //!
 //! # Building
 //!


### PR DESCRIPTION
The 4.3.0 and 4.3.1 releases are dev releases for testing and the definite stable release will be in about a month.

There will be no API and ABI changes on 4.3.x, so allow it.

https://marc.info/?l=libressl&m=177656691217255&w=2