### PR TITLE
Reject oversized length returns from password callback trampoline

### DIFF
--- a/openssl/src/ec.rs
+++ b/openssl/src/ec.rs
@@ -1098,6 +1098,7 @@ mod test {
     use super::*;
     use crate::bn::{BigNum, BigNumContext};
     use crate::nid::Nid;
+    use crate::symm::Cipher;
 
     #[test]
     fn key_new_by_curve_name() {
@@ -1108,6 +1109,25 @@ mod test {
     fn generate() {
         let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
         EcKey::generate(&group).unwrap();
+    }
+
+    #[test]
+    fn test_password_callback_oversize_return_is_rejected() {
+        // The password callback trampoline must reject a user-returned
+        // length that exceeds the size of the buffer it handed out.
+        // Otherwise some versions of OpenSSL read past the buffer when
+        // deriving the decryption key.
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let key = EcKey::generate(&group).unwrap();
+        let encrypted = key
+            .private_key_to_pem_passphrase(Cipher::aes_128_cbc(), b"correct-pw")
+            .unwrap();
+
+        let result = EcKey::private_key_from_pem_callback(&encrypted, |buf| {
+            buf[..10].copy_from_slice(b"correct-pw");
+            Ok(buf.len() * 10)
+        });
+        assert!(result.is_err());
     }
 
     #[test]

--- a/openssl/src/util.rs
+++ b/openssl/src/util.rs
@@ -55,6 +55,7 @@ where
     }));
 
     match result {
+        Ok(Ok(len)) if len > size as usize => 0,
         Ok(Ok(len)) => len as c_int,
         Ok(Err(_)) => {
             // FIXME restore error stack


### PR DESCRIPTION
The invoke_passwd_cb trampoline passed the user closure's returned usize straight to OpenSSL as the password length, without checking it against the size of the scratch buffer it handed out. A safe Rust callback that returned a value larger than buf.len() (for example, the length of an external secret rather than the number of bytes written) caused EVP_BytesToKey to read past the buffer during key derivation on OpenSSL 1.1 and LibreSSL, leaking adjacent stack bytes into the derived key.

Now treat an oversized return as a callback error (return 0 to OpenSSL), matching the existing behavior when the closure returns Err.