### PR TITLE
Add support for `SSL_CIPHER_get_kx_nid`, `SSL_CIPHER_get_auth_nid` and  `SSL_CIPHER_is_aead`

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -307,6 +307,9 @@ extern "C" {
     pub fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
     pub fn SSL_CIPHER_get_bits(cipher: *const SSL_CIPHER, alg_bits: *mut c_int) -> c_int;
     pub fn SSL_CIPHER_get_version(cipher: *const SSL_CIPHER) -> *const c_char;
+    pub fn SSL_CIPHER_get_kx_nid(cipher: *const SSL_CIPHER) -> c_int;
+    pub fn SSL_CIPHER_get_auth_nid(cipher: *const SSL_CIPHER) -> c_int;
+    pub fn SSL_CIPHER_is_aead(cipher: *const SSL_CIPHER) -> c_int;
 }
 extern "C" {
     #[cfg(ossl111)]

--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -1047,3 +1047,25 @@ cfg_if! {
         pub const NID_ac_auditEntity: c_int = 287;
     }
 }
+
+pub const NID_kx_rsa: c_int = 1037;
+pub const NID_kx_ecdhe: c_int = 1038;
+pub const NID_kx_dhe: c_int = 1039;
+pub const NID_kx_ecdhe_psk: c_int = 1040;
+pub const NID_kx_dhe_psk: c_int = 1041;
+pub const NID_kx_rsa_psk: c_int = 1042;
+pub const NID_kx_psk: c_int = 1043;
+pub const NID_kx_srp: c_int = 1044;
+pub const NID_kx_gost: c_int = 1045;
+pub const NID_kx_gost18: c_int = 1218;
+pub const NID_kx_any: c_int = 1063;
+
+pub const NID_auth_rsa: c_int = 1046;
+pub const NID_auth_ecdsa: c_int = 1047;
+pub const NID_auth_psk: c_int = 1048;
+pub const NID_auth_dss: c_int = 1049;
+pub const NID_auth_gost01: c_int = 1050;
+pub const NID_auth_gost12: c_int = 1051;
+pub const NID_auth_srp: c_int = 1052;
+pub const NID_auth_null: c_int = 1053;
+pub const NID_auth_any: c_int = 1064;

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -1107,6 +1107,28 @@ impl Nid {
     pub const SHAKE256: Nid = Nid(ffi::NID_shake256);
     #[cfg(any(ossl110, libressl, awslc))]
     pub const CHACHA20_POLY1305: Nid = Nid(ffi::NID_chacha20_poly1305);
+
+    pub const KX_RSA: Nid = Nid(ffi::NID_kx_rsa);
+    pub const KX_ECDHE: Nid = Nid(ffi::NID_kx_ecdhe);
+    pub const KX_DHE: Nid = Nid(ffi::NID_kx_dhe);
+    pub const KX_ECDHE_PSK: Nid = Nid(ffi::NID_kx_ecdhe_psk);
+    pub const KX_DHE_PSK: Nid = Nid(ffi::NID_kx_dhe_psk);
+    pub const KX_RSA_PSK: Nid = Nid(ffi::NID_kx_rsa_psk);
+    pub const KX_PSK: Nid = Nid(ffi::NID_kx_psk);
+    pub const KX_SRP: Nid = Nid(ffi::NID_kx_srp);
+    pub const KX_GOST: Nid = Nid(ffi::NID_kx_gost);
+    pub const KX_GOST18: Nid = Nid(ffi::NID_kx_gost18);
+    pub const KX_ANY: Nid = Nid(ffi::NID_kx_any);
+
+    pub const AUTH_RSA: Nid = Nid(ffi::NID_auth_rsa);
+    pub const AUTH_ECDSA: Nid = Nid(ffi::NID_auth_ecdsa);
+    pub const AUTH_PSK: Nid = Nid(ffi::NID_auth_psk);
+    pub const AUTH_DSS: Nid = Nid(ffi::NID_auth_dss);
+    pub const AUTH_GOST01: Nid = Nid(ffi::NID_auth_gost01);
+    pub const AUTH_GOST12: Nid = Nid(ffi::NID_auth_gost12);
+    pub const AUTH_SRP: Nid = Nid(ffi::NID_auth_srp);
+    pub const AUTH_NULL: Nid = Nid(ffi::NID_auth_null);
+    pub const AUTH_ANY: Nid = Nid(ffi::NID_auth_any);
 }
 
 impl fmt::Debug for Nid {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -2101,6 +2101,42 @@ impl SslCipherRef {
         }
     }
 
+    /// Returns the NID corresponding to the key exchange.
+    ///
+    /// If any appropriate key exchange algorithm can be used (as in the case of TLS 1.3
+    /// cipher suites) `Nid::KX_ANY` is returned.
+    #[corresponds(SSL_CIPHER_get_kx_nid)]
+    pub fn kx_nid(&self) -> Option<Nid> {
+        let n = unsafe { ffi::SSL_CIPHER_get_kx_nid(self.as_ptr()) };
+        if n == 0 {
+            None
+        } else {
+            Some(Nid::from_raw(n))
+        }
+    }
+
+    /// Returns the NID corresponding to the authentication.
+    ///
+    /// If any appropriate authentication algorithm can be used (as in the case of TLS 1.3
+    /// cipher suites) `Nid::AUTH_ANY` is returned.
+    #[corresponds(SSL_CIPHER_get_auth_nid)]
+    pub fn auth_nid(&self) -> Option<Nid> {
+        let n = unsafe { ffi::SSL_CIPHER_get_auth_nid(self.as_ptr()) };
+        if n == 0 {
+            None
+        } else {
+            Some(Nid::from_raw(n))
+        }
+    }
+
+    /// Returns the NID corresponding to the authentication.
+    ///
+    /// Returns whether the cipher is AEAD (e.g. GCM or ChaCha20/Poly1305).
+    #[corresponds(SSL_CIPHER_is_aead)]
+    pub fn is_aead(&self) -> bool {
+        unsafe { ffi::SSL_CIPHER_is_aead(self.as_ptr()) != 0 }
+    }
+
     /// Returns the two-byte ID of the cipher
     ///
     /// Requires OpenSSL 1.1.1 or newer.


### PR DESCRIPTION
I don't know what the best way to test these is. Is there any specific cipher that is guaranteed to be enabled in an openssl build?