### PR TITLE
Replace `use libc::*;` with targeted imports in openssl-sys

### DIFF
--- a/openssl-sys/src/aes.rs
+++ b/openssl-sys/src/aes.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_int;
 
 #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
 pub const AES_ENCRYPT: c_int = 1;

--- a/openssl-sys/src/asn1.rs
+++ b/openssl-sys/src/asn1.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_int;
 
 use super::*;
 

--- a/openssl-sys/src/bio.rs
+++ b/openssl-sys/src/bio.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_uint, c_void};
 
 use super::*;
 

--- a/openssl-sys/src/bn.rs
+++ b/openssl-sys/src/bn.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_int, c_uint, c_ulonglong};
 
 #[cfg(target_pointer_width = "64")]
 pub type BN_ULONG = c_ulonglong;

--- a/openssl-sys/src/cms.rs
+++ b/openssl-sys/src/cms.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_uint;
 
 pub const CMS_TEXT: c_uint = 0x1;
 pub const CMS_NOCERTS: c_uint = 0x2;

--- a/openssl-sys/src/core_dispatch.rs
+++ b/openssl-sys/src/core_dispatch.rs
@@ -1,5 +1,5 @@
 use super::*;
-use libc::*;
+use std::ffi::c_int;
 
 /* OpenSSL 3.* only */
 

--- a/openssl-sys/src/crypto.rs
+++ b/openssl-sys/src/crypto.rs
@@ -1,5 +1,5 @@
 use super::*;
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_ulong, c_void};
 
 extern "C" {
     #[deprecated(note = "use CRYPTO_set_locking_callback__fixed_rust instead")]

--- a/openssl-sys/src/dh.rs
+++ b/openssl-sys/src/dh.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_int;
 use std::ptr;
 
 use super::super::*;

--- a/openssl-sys/src/dsa.rs
+++ b/openssl-sys/src/dsa.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_int;
 use std::ptr;
 
 use super::super::*;

--- a/openssl-sys/src/dtls1.rs
+++ b/openssl-sys/src/dtls1.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_uint;
 
 cfg_if! {
     if #[cfg(ossl300)] {

--- a/openssl-sys/src/ec.rs
+++ b/openssl-sys/src/ec.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_char, c_int};
 use std::ptr;
 
 use super::*;

--- a/openssl-sys/src/err.rs
+++ b/openssl-sys/src/err.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_int, c_ulong};
 
 pub const ERR_TXT_MALLOCED: c_int = 0x01;
 pub const ERR_TXT_STRING: c_int = 0x02;

--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -1,5 +1,6 @@
 use super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_int, c_uint, c_void};
 
 pub const EVP_MAX_MD_SIZE: c_uint = 64;
 

--- a/openssl-sys/src/handwritten/aes.rs
+++ b/openssl-sys/src/handwritten/aes.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_int, c_uchar, c_uint};
 
 #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
 #[repr(C)]

--- a/openssl-sys/src/handwritten/asn1.rs
+++ b/openssl-sys/src/handwritten/asn1.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::time_t;
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_void};
 
 #[repr(C)]
 #[cfg(not(libressl430))]

--- a/openssl-sys/src/handwritten/bio.rs
+++ b/openssl-sys/src/handwritten/bio.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::FILE;
+use std::ffi::{c_char, c_int, c_long, c_uint, c_void};
 
 extern "C" {
     pub fn BIO_set_flags(b: *mut BIO, flags: c_int);

--- a/openssl-sys/src/handwritten/bn.rs
+++ b/openssl-sys/src/handwritten/bn.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_char, c_int};
 
 extern "C" {
     pub fn BN_CTX_new() -> *mut BN_CTX;

--- a/openssl-sys/src/handwritten/cmac.rs
+++ b/openssl-sys/src/handwritten/cmac.rs
@@ -1,4 +1,5 @@
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_int, c_uchar, c_void};
 
 use super::super::*;
 

--- a/openssl-sys/src/handwritten/cms.rs
+++ b/openssl-sys/src/handwritten/cms.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_int, c_long, c_uchar, c_uint};
 
 pub enum CMS_ContentInfo {}
 

--- a/openssl-sys/src/handwritten/crypto.rs
+++ b/openssl-sys/src/handwritten/crypto.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_char, c_int, c_long, c_ulong, c_void};
 
 stack!(stack_st_void);
 

--- a/openssl-sys/src/handwritten/decoder.rs
+++ b/openssl-sys/src/handwritten/decoder.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::{size_t, FILE};
+use std::ffi::{c_char, c_int, c_uchar, c_void};
 
 extern "C" {
     pub fn OSSL_DECODER_CTX_new() -> *mut OSSL_DECODER_CTX;

--- a/openssl-sys/src/handwritten/dh.rs
+++ b/openssl-sys/src/handwritten/dh.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use std::ffi::{c_int, c_long, c_uchar, c_void};
 
 #[cfg(ossl300)]
 extern "C" {

--- a/openssl-sys/src/handwritten/dsa.rs
+++ b/openssl-sys/src/handwritten/dsa.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_int, c_long, c_uchar, c_uint, c_ulong};
 
 use super::super::*;
 

--- a/openssl-sys/src/handwritten/ec.rs
+++ b/openssl-sys/src/handwritten/ec.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_char, c_int, c_long, c_uchar};
 
 #[cfg(ossl300)]
 extern "C" {

--- a/openssl-sys/src/handwritten/encoder.rs
+++ b/openssl-sys/src/handwritten/encoder.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::{size_t, FILE};
+use std::ffi::{c_char, c_int, c_uchar, c_void};
 
 #[cfg(ossl300)]
 extern "C" {

--- a/openssl-sys/src/handwritten/err.rs
+++ b/openssl-sys/src/handwritten/err.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_char, c_int, c_ulong};
 
 #[repr(C)]
 pub struct ERR_STRING_DATA {

--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_void};
 
 cfg_if! {
     if #[cfg(ossl300)] {

--- a/openssl-sys/src/handwritten/hmac.rs
+++ b/openssl-sys/src/handwritten/hmac.rs
@@ -1,4 +1,5 @@
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_int, c_uchar, c_uint, c_void};
 
 use super::super::*;
 

--- a/openssl-sys/src/handwritten/kdf.rs
+++ b/openssl-sys/src/handwritten/kdf.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_char, c_int};
 
 cfg_if! {
     if #[cfg(ossl300)] {

--- a/openssl-sys/src/handwritten/object.rs
+++ b/openssl-sys/src/handwritten/object.rs
@@ -1,4 +1,5 @@
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_char, c_int, c_uchar};
 
 use super::super::*;
 
@@ -16,15 +17,11 @@ extern "C" {
 
     pub fn OBJ_find_sigid_algs(signid: c_int, pdig_nid: *mut c_int, ppkey_nid: *mut c_int)
         -> c_int;
-    pub fn OBJ_sn2nid(sn: *const libc::c_char) -> libc::c_int;
-    pub fn OBJ_txt2obj(s: *const libc::c_char, no_name: libc::c_int) -> *mut ASN1_OBJECT;
-    pub fn OBJ_create(
-        oid: *const libc::c_char,
-        sn: *const libc::c_char,
-        ln: *const libc::c_char,
-    ) -> c_int;
+    pub fn OBJ_sn2nid(sn: *const c_char) -> c_int;
+    pub fn OBJ_txt2obj(s: *const c_char, no_name: c_int) -> *mut ASN1_OBJECT;
+    pub fn OBJ_create(oid: *const c_char, sn: *const c_char, ln: *const c_char) -> c_int;
     #[cfg(ossl111)]
-    pub fn OBJ_length(obj: *const ASN1_OBJECT) -> libc::size_t;
+    pub fn OBJ_length(obj: *const ASN1_OBJECT) -> size_t;
     #[cfg(ossl111)]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const c_uchar;
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> c_int;

--- a/openssl-sys/src/handwritten/ocsp.rs
+++ b/openssl-sys/src/handwritten/ocsp.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_int, c_long, c_uchar, c_ulong};
 
 pub enum OCSP_CERTID {}
 

--- a/openssl-sys/src/handwritten/params.rs
+++ b/openssl-sys/src/handwritten/params.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_char, c_int, c_uint, c_void};
 
 extern "C" {
     pub fn OSSL_PARAM_free(p: *mut OSSL_PARAM);

--- a/openssl-sys/src/handwritten/pem.rs
+++ b/openssl-sys/src/handwritten/pem.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_void};
 
 pub type pem_password_cb = Option<
     unsafe extern "C" fn(

--- a/openssl-sys/src/handwritten/pkcs12.rs
+++ b/openssl-sys/src/handwritten/pkcs12.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_uchar};
 
 use super::super::*;
 

--- a/openssl-sys/src/handwritten/pkcs7.rs
+++ b/openssl-sys/src/handwritten/pkcs7.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_void};
 
 #[cfg(ossl300)]
 #[repr(C)]

--- a/openssl-sys/src/handwritten/poly1305.rs
+++ b/openssl-sys/src/handwritten/poly1305.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::c_uchar;
 
 cfg_if! {
     if #[cfg(libressl)] {
@@ -7,17 +7,17 @@ cfg_if! {
         #[derive(Debug, Copy, Clone)]
         pub struct poly1305_context {
             pub aligner: usize,
-            pub opaque: [::libc::c_uchar; 136usize],
+            pub opaque: [c_uchar; 136usize],
         }
         pub type poly1305_state = poly1305_context;
         extern "C" {
-            pub fn CRYPTO_poly1305_init(ctx: *mut poly1305_context, key: *const ::libc::c_uchar);
+            pub fn CRYPTO_poly1305_init(ctx: *mut poly1305_context, key: *const c_uchar);
             pub fn CRYPTO_poly1305_update(
                 ctx: *mut poly1305_context,
-                in_: *const ::libc::c_uchar,
+                in_: *const c_uchar,
                 len: usize,
             );
-            pub fn CRYPTO_poly1305_finish(ctx: *mut poly1305_context, mac: *mut ::libc::c_uchar);
+            pub fn CRYPTO_poly1305_finish(ctx: *mut poly1305_context, mac: *mut c_uchar);
         }
     }
 }

--- a/openssl-sys/src/handwritten/provider.rs
+++ b/openssl-sys/src/handwritten/provider.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_char, c_int};
 
 extern "C" {
     #[cfg(ossl300)]

--- a/openssl-sys/src/handwritten/rand.rs
+++ b/openssl-sys/src/handwritten/rand.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_double, c_int, c_void};
 
 extern "C" {
     pub fn RAND_bytes(buf: *mut u8, num: c_int) -> c_int;

--- a/openssl-sys/src/handwritten/rsa.rs
+++ b/openssl-sys/src/handwritten/rsa.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
 cfg_if! {
     if #[cfg(ossl300)] {

--- a/openssl-sys/src/handwritten/sha.rs
+++ b/openssl-sys/src/handwritten/sha.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_int, c_uchar, c_uint, c_void};
 
 cfg_if! {
     if #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))] {

--- a/openssl-sys/src/handwritten/srtp.rs
+++ b/openssl-sys/src/handwritten/srtp.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_char, c_int};
 
 extern "C" {
     pub fn SSL_CTX_set_tlsext_use_srtp(ctx: *mut SSL_CTX, profiles: *const c_char) -> c_int;

--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::{size_t, timeval};
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
 pub enum SSL_METHOD {}
 pub enum SSL_CIPHER {}
@@ -666,7 +667,7 @@ extern "C" {
 cfg_if! {
     if #[cfg(libressl)] {
         extern "C" {
-            pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const libc::c_void;
+            pub fn SSL_get_current_compression(ssl: *mut SSL) -> *const c_void;
         }
     } else if #[cfg(not(osslconf = "OPENSSL_NO_COMP"))] {
         const_ptr_api! {
@@ -679,7 +680,7 @@ cfg_if! {
 cfg_if! {
     if #[cfg(libressl)] {
         extern "C" {
-            pub fn SSL_COMP_get_name(comp: *const libc::c_void) -> *const c_char;
+            pub fn SSL_COMP_get_name(comp: *const c_void) -> *const c_char;
         }
     } else if #[cfg(not(osslconf = "OPENSSL_NO_COMP"))] {
         extern "C" {

--- a/openssl-sys/src/handwritten/stack.rs
+++ b/openssl-sys/src/handwritten/stack.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_char, c_int, c_void};
 
 cfg_if! {
     if #[cfg(ossl110)] {

--- a/openssl-sys/src/handwritten/thread.rs
+++ b/openssl-sys/src/handwritten/thread.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::c_int;
 
 extern "C" {
     pub fn OSSL_set_max_threads(ctx: *mut OSSL_LIB_CTX, max_threads: u64) -> c_int;

--- a/openssl-sys/src/handwritten/tls1.rs
+++ b/openssl-sys/src/handwritten/tls1.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_char, c_int, c_uchar};
 
 extern "C" {
     pub fn SSL_get_servername(ssl: *const SSL, name_type: c_int) -> *const c_char;

--- a/openssl-sys/src/handwritten/types.rs
+++ b/openssl-sys/src/handwritten/types.rs
@@ -1,4 +1,5 @@
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_char, c_int, c_uint, c_void};
 
 #[allow(unused_imports)]
 use super::super::*;
@@ -129,7 +130,7 @@ cfg_if! {
         pub struct SSL_CONN_CLOSE_INFO {
             pub error_code: u64,
             pub frame_type: u64,
-            pub reason: *const ::libc::c_char,
+            pub reason: *const c_char,
             pub reason_len: usize,
             pub flags: u32,
         }

--- a/openssl-sys/src/handwritten/x509.rs
+++ b/openssl-sys/src/handwritten/x509.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
 cfg_if! {
     if #[cfg(libressl400)] {

--- a/openssl-sys/src/handwritten/x509_vfy.rs
+++ b/openssl-sys/src/handwritten/x509_vfy.rs
@@ -1,5 +1,6 @@
 use super::super::*;
-use libc::*;
+use libc::{size_t, time_t};
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
 #[cfg(all(libressl, not(libressl430)))]
 pub enum X509_VERIFY_PARAM_ID {}

--- a/openssl-sys/src/handwritten/x509v3.rs
+++ b/openssl-sys/src/handwritten/x509v3.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
 pub enum CONF_METHOD {}
 

--- a/openssl-sys/src/lib.rs
+++ b/openssl-sys/src/lib.rs
@@ -10,7 +10,7 @@
 #![recursion_limit = "128"] // configure fixed limit across all rust versions
 
 extern crate libc;
-pub use libc::c_int;
+pub use std::ffi::c_int;
 
 #[cfg(feature = "unstable_boringssl")]
 extern crate bssl_sys;
@@ -45,7 +45,7 @@ mod aws_lc {
     #[cfg(not(any(feature = "aws-lc", feature = "aws-lc-fips")))]
     include!(concat!(env!("OUT_DIR"), "/bindgen.rs"));
 
-    use libc::{c_char, c_long, c_void};
+    use std::ffi::{c_char, c_int, c_long, c_uint, c_void};
 
     pub fn init() {
         unsafe { CRYPTO_library_init() }
@@ -66,19 +66,19 @@ mod aws_lc {
     // (wrap_static_fns), they're in the generated output.
     #[cfg(awslc_pregenerated)]
     #[allow(non_snake_case, clippy::cast_possible_wrap)]
-    pub fn ERR_GET_LIB(packed_error: ::libc::c_uint) -> ::libc::c_int {
-        ((packed_error >> 24) & 0xFF) as ::libc::c_int
+    pub fn ERR_GET_LIB(packed_error: c_uint) -> c_int {
+        ((packed_error >> 24) & 0xFF) as c_int
     }
 
     #[cfg(awslc_pregenerated)]
     #[allow(non_snake_case, clippy::cast_possible_wrap)]
-    pub fn ERR_GET_REASON(packed_error: ::libc::c_uint) -> ::libc::c_int {
-        (packed_error & 0xFFF) as ::libc::c_int
+    pub fn ERR_GET_REASON(packed_error: c_uint) -> c_int {
+        (packed_error & 0xFFF) as c_int
     }
 
     #[cfg(awslc_pregenerated)]
     #[allow(non_snake_case)]
-    pub fn ERR_GET_FUNC(_packed_error: ::libc::c_uint) -> ::libc::c_int {
+    pub fn ERR_GET_FUNC(_packed_error: c_uint) -> c_int {
         0
     }
 }
@@ -88,7 +88,7 @@ pub use aws_lc::*;
 #[cfg(openssl)]
 #[path = "."]
 mod openssl {
-    use libc::*;
+    use std::ffi::{c_char, c_int, c_void};
 
     #[cfg(feature = "bindgen")]
     include!(concat!(env!("OUT_DIR"), "/bindgen.rs"));

--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_int;
 
 pub const NID_undef: c_int = 0;
 pub const NID_itu_t: c_int = 645;

--- a/openssl-sys/src/ocsp.rs
+++ b/openssl-sys/src/ocsp.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_int, c_ulong};
 
 pub const OCSP_REVOKED_STATUS_NOSTATUS: c_int = -1;
 pub const OCSP_REVOKED_STATUS_UNSPECIFIED: c_int = 0;

--- a/openssl-sys/src/pem.rs
+++ b/openssl-sys/src/pem.rs
@@ -1,3 +1,3 @@
-use libc::*;
+use std::ffi::c_int;
 
 pub const PEM_R_NO_START_LINE: c_int = 108;

--- a/openssl-sys/src/pkcs7.rs
+++ b/openssl-sys/src/pkcs7.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_int;
 
 pub const PKCS7_TEXT: c_int = 0x1;
 pub const PKCS7_NOCERTS: c_int = 0x2;

--- a/openssl-sys/src/rsa.rs
+++ b/openssl-sys/src/rsa.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_int, c_long, c_void};
 use std::ptr;
 
 use super::super::*;

--- a/openssl-sys/src/sha.rs
+++ b/openssl-sys/src/sha.rs
@@ -1,5 +1,6 @@
 use super::*;
-use libc::*;
+use libc::size_t;
+use std::ffi::{c_char, c_int, c_uchar, c_uint, c_void};
 use std::ptr;
 
 #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]

--- a/openssl-sys/src/srtp.rs
+++ b/openssl-sys/src/srtp.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_ulong;
 
 pub const SRTP_AES128_CM_SHA1_80: c_ulong = 0x0001;
 pub const SRTP_AES128_CM_SHA1_32: c_ulong = 0x0002;

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 use std::ptr;
 
 use super::*;

--- a/openssl-sys/src/ssl3.rs
+++ b/openssl-sys/src/ssl3.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_int;
 
 pub const SSL3_VERSION: c_int = 0x300;
 

--- a/openssl-sys/src/tls1.rs
+++ b/openssl-sys/src/tls1.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_void};
 use std::mem;
 use std::ptr;
 
@@ -77,9 +77,7 @@ pub unsafe fn SSL_CTX_set_tlsext_servername_callback__fixed_rust(
         ctx,
         SSL_CTRL_SET_TLSEXT_SERVERNAME_CB,
         mem::transmute::<
-            std::option::Option<
-                unsafe extern "C" fn(*mut SSL, *mut c_int, *mut libc::c_void) -> i32,
-            >,
+            std::option::Option<unsafe extern "C" fn(*mut SSL, *mut c_int, *mut c_void) -> i32>,
             std::option::Option<unsafe extern "C" fn()>,
         >(cb),
     )

--- a/openssl-sys/src/types.rs
+++ b/openssl-sys/src/types.rs
@@ -1,5 +1,3 @@
-use libc::*;
-
 use super::*;
 
 pub enum EVP_PKEY {}

--- a/openssl-sys/src/x509.rs
+++ b/openssl-sys/src/x509.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::c_int;
 
 pub const X509_FILETYPE_PEM: c_int = 1;
 pub const X509_FILETYPE_ASN1: c_int = 2;

--- a/openssl-sys/src/x509_vfy.rs
+++ b/openssl-sys/src/x509_vfy.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_char, c_int, c_long, c_ulong};
 
 use super::*;
 

--- a/openssl-sys/src/x509v3.rs
+++ b/openssl-sys/src/x509v3.rs
@@ -1,4 +1,4 @@
-use libc::*;
+use std::ffi::{c_int, c_uint, c_ulong, c_void};
 
 use super::*;
 


### PR DESCRIPTION
Swap glob imports from libc for explicit imports of the items each file actually uses, and prefer `std::ffi` for the primitive C integer/char types available there (MSRV is 1.70). `size_t`, `time_t`, `timeval`, and `FILE` still come from libc since they have no `std::ffi` equivalent.