### PR TITLE
Bump MSRV to 1.80

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       # Remember to also update `--rust-target` in `openssl-sys/build/run_bindgen.rs`
       - uses: sfackler/actions/rustup@55af96fecc6b2ff28431120e3d9b723e5c1bccbf # master
         with:
-          version: 1.70.0
+          version: 1.80.0
       - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
         id: rust-version
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -77,7 +77,7 @@ jobs:
           key: index-${{ runner.os }}-${{ github.run_number }}
           restore-keys: |
             index-${{ runner.os }}-
-      # ctest 0.5 uses edition 2024 which Rust 1.70's cargo can't parse
+      # ctest 0.5 uses edition 2024 which Rust 1.80's cargo can't parse
       - run: sed -i '/"systest",/d' Cargo.toml
       - run: cargo generate-lockfile
       - run: |

--- a/openssl-errors/Cargo.toml
+++ b/openssl-errors/Cargo.toml
@@ -8,7 +8,7 @@ description = "Custom error library support for the openssl crate."
 repository = "https://github.com/rust-openssl/rust-openssl"
 readme = "README.md"
 categories = ["api-bindings"]
-rust-version = "1.70.0"
+rust-version = "1.80.0"
 
 [dependencies]
 cfg-if = "1.0"

--- a/openssl-macros/Cargo.toml
+++ b/openssl-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Internal macros used by the openssl crate."
 repository = "https://github.com/rust-openssl/rust-openssl"
-rust-version = "1.70.0"
+rust-version = "1.80.0"
 
 [lib]
 proc-macro = true

--- a/openssl-sys/CHANGELOG.md
+++ b/openssl-sys/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Bumped MSRV to 1.80.
+
 ## [v0.9.114] - 2026-04-19
 
 ### Added

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "external-ffi-bindings"]
 links = "openssl"
 build = "build/main.rs"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.80.0"
 
 [features]
 vendored = ['openssl-src']

--- a/openssl-sys/build/run_bindgen.rs
+++ b/openssl-sys/build/run_bindgen.rs
@@ -237,7 +237,7 @@ pub fn run_boringssl(include_dirs: &[PathBuf]) {
     bindgen_cmd
         .arg("-o")
         .arg(out_dir.join("bindgen.rs"))
-        .arg("--rust-target=1.70")
+        .arg("--rust-target=1.80")
         .arg("--ctypes-prefix=::libc")
         .arg("--raw-line=use libc::*;")
         .arg("--no-derive-default")
@@ -373,7 +373,7 @@ pub fn run_awslc(include_dirs: &[PathBuf], symbol_prefix: Option<String>) {
     bindgen_cmd
         .arg("-o")
         .arg(out_dir.join("bindgen.rs"))
-        .arg("--rust-target=1.70")
+        .arg("--rust-target=1.80")
         .arg("--ctypes-prefix=::libc")
         .arg("--raw-line=use libc::*;")
         .arg("--no-derive-default")

--- a/openssl-sys/src/ec.rs
+++ b/openssl-sys/src/ec.rs
@@ -21,12 +21,7 @@ cfg_if! {
 }
 #[cfg(ossl300)]
 pub unsafe fn EVP_EC_gen(curve: *const c_char) -> *mut EVP_PKEY {
-    EVP_PKEY_Q_keygen(
-        ptr::null_mut(),
-        ptr::null_mut(),
-        "EC\0".as_ptr().cast(),
-        curve,
-    )
+    EVP_PKEY_Q_keygen(ptr::null_mut(), ptr::null_mut(), c"EC".as_ptr(), curve)
 }
 
 pub const EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID: c_int = EVP_PKEY_ALG_CTRL + 1;

--- a/openssl-sys/src/sha.rs
+++ b/openssl-sys/src/sha.rs
@@ -1,6 +1,6 @@
 use super::*;
 use libc::size_t;
-use std::ffi::{c_char, c_int, c_uchar, c_uint, c_void};
+use std::ffi::{c_int, c_uchar, c_uint, c_void};
 use std::ptr;
 
 #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
@@ -16,7 +16,7 @@ cfg_if! {
         pub unsafe fn SHA1(d: *const c_uchar, n: size_t, md: *mut c_uchar) -> *mut c_uchar {
             if EVP_Q_digest(
                 ptr::null_mut(),
-                "SHA1\0".as_ptr() as *const c_char,
+                c"SHA1".as_ptr(),
                 ptr::null(),
                 d as *const c_void,
                 n,
@@ -33,7 +33,7 @@ cfg_if! {
         pub unsafe fn SHA224(d: *const c_uchar, n: size_t, md: *mut c_uchar) -> *mut c_uchar {
             if EVP_Q_digest(
                 ptr::null_mut(),
-                "SHA224\0".as_ptr() as *const c_char,
+                c"SHA224".as_ptr(),
                 ptr::null(),
                 d as *const c_void,
                 n,
@@ -49,7 +49,7 @@ cfg_if! {
         pub unsafe fn SHA256(d: *const c_uchar, n: size_t, md: *mut c_uchar) -> *mut c_uchar {
             if EVP_Q_digest(
                 ptr::null_mut(),
-                "SHA256\0".as_ptr() as *const c_char,
+                c"SHA256".as_ptr(),
                 ptr::null(),
                 d as *const c_void,
                 n,
@@ -72,7 +72,7 @@ cfg_if! {
         pub unsafe fn SHA384(d: *const c_uchar, n: size_t, md: *mut c_uchar) -> *mut c_uchar {
             if EVP_Q_digest(
                 ptr::null_mut(),
-                "SHA384\0".as_ptr() as *const c_char,
+                c"SHA384".as_ptr(),
                 ptr::null(),
                 d as *const c_void,
                 n,
@@ -88,7 +88,7 @@ cfg_if! {
         pub unsafe fn SHA512(d: *const c_uchar, n: size_t, md: *mut c_uchar) -> *mut c_uchar {
             if EVP_Q_digest(
                 ptr::null_mut(),
-                "SHA512\0".as_ptr() as *const c_char,
+                c"SHA512".as_ptr(),
                 ptr::null(),
                 d as *const c_void,
                 n,

--- a/openssl/CHANGELOG.md
+++ b/openssl/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Bumped MSRV to 1.80.
+
 ### Added
 
 * Added `EcGroupRef::generator_opt`, which returns `Option<&EcPointRef>`.

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["crypto", "tls", "ssl", "dtls"]
 categories = ["cryptography", "api-bindings"]
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.80.0"
 
 # these are deprecated and don't do anything anymore
 [features]

--- a/openssl/src/encrypt.rs
+++ b/openssl/src/encrypt.rs
@@ -160,9 +160,8 @@ impl<'a> Encrypter<'a> {
                 label.len() as _,
             ))
             .map(|_| ())
-            .map_err(|e| {
+            .inspect_err(|_| {
                 ffi::OPENSSL_free(p);
-                e
             })
         }
     }
@@ -344,9 +343,8 @@ impl<'a> Decrypter<'a> {
                 label.len() as _,
             ))
             .map(|_| ())
-            .map_err(|e| {
+            .inspect_err(|_| {
                 ffi::OPENSSL_free(p);
-                e
             })
         }
     }

--- a/openssl/src/error.rs
+++ b/openssl/src/error.rs
@@ -85,7 +85,7 @@ impl error::Error for ErrorStack {}
 
 impl From<ErrorStack> for io::Error {
     fn from(e: ErrorStack) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, e)
+        io::Error::other(e)
     }
 }
 

--- a/openssl/src/kdf.rs
+++ b/openssl/src/kdf.rs
@@ -42,15 +42,11 @@ cfg_if::cfg_if! {
         use crate::ossl_param::{OsslParamBuilder, OsslParamArray};
         use crate::md::MdRef;
 
-        const OSSL_KDF_PARAM_DIGEST: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"digest\0") };
-        const OSSL_KDF_PARAM_KEY: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"key\0") };
-        const OSSL_KDF_PARAM_SALT: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"salt\0") };
-        const OSSL_KDF_PARAM_INFO: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"info\0") };
-        const OSSL_KDF_PARAM_MODE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"mode\0") };
-
-        // Safety: these all have null terminators.
-        // We cen remove these CStr::from_bytes_with_nul_unchecked calls
-        // when we upgrade to Rust 1.77+ with literal c"" syntax.
+        const OSSL_KDF_PARAM_DIGEST: &CStr = c"digest";
+        const OSSL_KDF_PARAM_KEY: &CStr = c"key";
+        const OSSL_KDF_PARAM_SALT: &CStr = c"salt";
+        const OSSL_KDF_PARAM_INFO: &CStr = c"info";
+        const OSSL_KDF_PARAM_MODE: &CStr = c"mode";
 
         /// Derives a key using a KDF.
         fn kdf_digest(
@@ -103,7 +99,7 @@ cfg_if::cfg_if! {
             };
             bld.add_int(OSSL_KDF_PARAM_MODE, mode_value)?;
             let params = bld.to_param()?;
-            kdf_digest(CStr::from_bytes_with_nul(b"HKDF\0").unwrap(), ctx, &params, out)
+            kdf_digest(c"HKDF", ctx, &params, out)
         }
     }
 }
@@ -112,14 +108,14 @@ cfg_if::cfg_if! {
     if #[cfg(all(ossl320, not(osslconf = "OPENSSL_NO_ARGON2")))] {
         use std::cmp;
 
-        const OSSL_KDF_PARAM_PASSWORD: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"pass\0") };
-        const OSSL_KDF_PARAM_SECRET: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"secret\0") };
-        const OSSL_KDF_PARAM_ITER: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"iter\0") };
-        const OSSL_KDF_PARAM_SIZE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"size\0") };
-        const OSSL_KDF_PARAM_THREADS: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"threads\0") };
-        const OSSL_KDF_PARAM_ARGON2_AD: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"ad\0") };
-        const OSSL_KDF_PARAM_ARGON2_LANES: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"lanes\0") };
-        const OSSL_KDF_PARAM_ARGON2_MEMCOST: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"memcost\0") };
+        const OSSL_KDF_PARAM_PASSWORD: &CStr = c"pass";
+        const OSSL_KDF_PARAM_SECRET: &CStr = c"secret";
+        const OSSL_KDF_PARAM_ITER: &CStr = c"iter";
+        const OSSL_KDF_PARAM_SIZE: &CStr = c"size";
+        const OSSL_KDF_PARAM_THREADS: &CStr = c"threads";
+        const OSSL_KDF_PARAM_ARGON2_AD: &CStr = c"ad";
+        const OSSL_KDF_PARAM_ARGON2_LANES: &CStr = c"lanes";
+        const OSSL_KDF_PARAM_ARGON2_MEMCOST: &CStr = c"memcost";
 
         #[allow(clippy::too_many_arguments)]
         pub fn argon2d(
@@ -133,7 +129,7 @@ cfg_if::cfg_if! {
             memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            argon2_helper(CStr::from_bytes_with_nul(b"ARGON2D\0").unwrap(), ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
+            argon2_helper(c"ARGON2D", ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -148,7 +144,7 @@ cfg_if::cfg_if! {
             memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            argon2_helper(CStr::from_bytes_with_nul(b"ARGON2I\0").unwrap(), ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
+            argon2_helper(c"ARGON2I", ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -163,7 +159,7 @@ cfg_if::cfg_if! {
             memcost: u32,
             out: &mut [u8],
         ) -> Result<(), ErrorStack> {
-            argon2_helper(CStr::from_bytes_with_nul(b"ARGON2ID\0").unwrap(), ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
+            argon2_helper(c"ARGON2ID", ctx, pass, salt, ad, secret, iter, lanes, memcost, out)
         }
 
         /// Derives a key using the argon2* algorithms.

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -182,18 +182,12 @@ mod tests {
     #[test]
     fn test_builder_locate_octet_string() {
         let mut builder = OsslParamBuilder::new().unwrap();
-        builder
-            .add_octet_string(CStr::from_bytes_with_nul(b"key1\0").unwrap(), b"value1")
-            .unwrap();
+        builder.add_octet_string(c"key1", b"value1").unwrap();
         let params = builder.to_param().unwrap();
 
-        assert!(params
-            .locate_octet_string(CStr::from_bytes_with_nul(b"invalid\0").unwrap())
-            .is_err());
+        assert!(params.locate_octet_string(c"invalid").is_err());
         assert_eq!(
-            params
-                .locate_octet_string(CStr::from_bytes_with_nul(b"key1\0").unwrap())
-                .unwrap(),
+            params.locate_octet_string(c"key1").unwrap(),
             b"value1"
         );
     }

--- a/openssl/src/ossl_param.rs
+++ b/openssl/src/ossl_param.rs
@@ -186,9 +186,6 @@ mod tests {
         let params = builder.to_param().unwrap();
 
         assert!(params.locate_octet_string(c"invalid").is_err());
-        assert_eq!(
-            params.locate_octet_string(c"key1").unwrap(),
-            b"value1"
-        );
+        assert_eq!(params.locate_octet_string(c"key1").unwrap(), b"value1");
     }
 }

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -130,39 +130,23 @@ impl Id {
 pub struct KeyType(&'static CStr);
 
 impl KeyType {
-    // SAFETY for the const initializers below: each byte literal is
-    // NUL-terminated and contains no interior NULs, which satisfies the
-    // unsafe contract on `KeyType::from_bytes_with_nul`.
-    pub const RSA: KeyType = unsafe { KeyType::from_bytes_with_nul(b"RSA\0") };
-    pub const RSA_PSS: KeyType = unsafe { KeyType::from_bytes_with_nul(b"RSA-PSS\0") };
-    pub const DSA: KeyType = unsafe { KeyType::from_bytes_with_nul(b"DSA\0") };
-    pub const DH: KeyType = unsafe { KeyType::from_bytes_with_nul(b"DH\0") };
-    pub const EC: KeyType = unsafe { KeyType::from_bytes_with_nul(b"EC\0") };
-    pub const ED25519: KeyType = unsafe { KeyType::from_bytes_with_nul(b"ED25519\0") };
-    pub const ED448: KeyType = unsafe { KeyType::from_bytes_with_nul(b"ED448\0") };
-    pub const X25519: KeyType = unsafe { KeyType::from_bytes_with_nul(b"X25519\0") };
-    pub const X448: KeyType = unsafe { KeyType::from_bytes_with_nul(b"X448\0") };
-    pub const HMAC: KeyType = unsafe { KeyType::from_bytes_with_nul(b"HMAC\0") };
-    pub const CMAC: KeyType = unsafe { KeyType::from_bytes_with_nul(b"CMAC\0") };
-    pub const ML_DSA_44: KeyType = unsafe { KeyType::from_bytes_with_nul(b"ML-DSA-44\0") };
-    pub const ML_DSA_65: KeyType = unsafe { KeyType::from_bytes_with_nul(b"ML-DSA-65\0") };
-    pub const ML_DSA_87: KeyType = unsafe { KeyType::from_bytes_with_nul(b"ML-DSA-87\0") };
-    pub const ML_KEM_512: KeyType = unsafe { KeyType::from_bytes_with_nul(b"ML-KEM-512\0") };
-    pub const ML_KEM_768: KeyType = unsafe { KeyType::from_bytes_with_nul(b"ML-KEM-768\0") };
-    pub const ML_KEM_1024: KeyType = unsafe { KeyType::from_bytes_with_nul(b"ML-KEM-1024\0") };
-
-    /// # Safety
-    ///
-    /// `bytes` must be NUL-terminated and contain no interior NULs.
-    ///
-    // Once MSRV is >= 1.72 this whole helper can become a safe `const fn`
-    // using `CStr::from_bytes_with_nul(bytes).unwrap()`; once MSRV is >= 1.77
-    // the helper goes away entirely in favor of `c"..."` literals.
-    const unsafe fn from_bytes_with_nul(bytes: &'static [u8]) -> KeyType {
-        // SAFETY: the caller has promised `bytes` meets the contract of
-        // `CStr::from_bytes_with_nul_unchecked`.
-        KeyType(CStr::from_bytes_with_nul_unchecked(bytes))
-    }
+    pub const RSA: KeyType = KeyType(c"RSA");
+    pub const RSA_PSS: KeyType = KeyType(c"RSA-PSS");
+    pub const DSA: KeyType = KeyType(c"DSA");
+    pub const DH: KeyType = KeyType(c"DH");
+    pub const EC: KeyType = KeyType(c"EC");
+    pub const ED25519: KeyType = KeyType(c"ED25519");
+    pub const ED448: KeyType = KeyType(c"ED448");
+    pub const X25519: KeyType = KeyType(c"X25519");
+    pub const X448: KeyType = KeyType(c"X448");
+    pub const HMAC: KeyType = KeyType(c"HMAC");
+    pub const CMAC: KeyType = KeyType(c"CMAC");
+    pub const ML_DSA_44: KeyType = KeyType(c"ML-DSA-44");
+    pub const ML_DSA_65: KeyType = KeyType(c"ML-DSA-65");
+    pub const ML_DSA_87: KeyType = KeyType(c"ML-DSA-87");
+    pub const ML_KEM_512: KeyType = KeyType(c"ML-KEM-512");
+    pub const ML_KEM_768: KeyType = KeyType(c"ML-KEM-768");
+    pub const ML_KEM_1024: KeyType = KeyType(c"ML-KEM-1024");
 
     /// Returns the algorithm name as a C string.
     #[cfg(ossl300)]

--- a/openssl/src/pkey_ctx.rs
+++ b/openssl/src/pkey_ctx.rs
@@ -82,8 +82,6 @@ use libc::c_int;
 use libc::c_uint;
 use openssl_macros::corresponds;
 use std::convert::TryFrom;
-#[cfg(ossl320)]
-use std::ffi::CStr;
 use std::ptr;
 
 /// HKDF modes of operation.
@@ -924,7 +922,7 @@ impl<T> PkeyCtxRef<T> {
     #[cfg(ossl320)]
     #[corresponds(EVP_PKEY_CTX_set_params)]
     pub fn set_nonce_type(&mut self, nonce_type: NonceType) -> Result<(), ErrorStack> {
-        let nonce_field_name = CStr::from_bytes_with_nul(b"nonce-type\0").unwrap();
+        let nonce_field_name = c"nonce-type";
         let mut nonce_type = nonce_type.0;
         unsafe {
             let param_nonce =
@@ -946,7 +944,7 @@ impl<T> PkeyCtxRef<T> {
     #[cfg(ossl320)]
     #[corresponds(EVP_PKEY_CTX_get_params)]
     pub fn nonce_type(&mut self) -> Result<NonceType, ErrorStack> {
-        let nonce_field_name = CStr::from_bytes_with_nul(b"nonce-type\0").unwrap();
+        let nonce_field_name = c"nonce-type";
         let mut nonce_type: c_uint = 0;
         unsafe {
             let param_nonce =

--- a/openssl/src/ssl/bio.rs
+++ b/openssl/src/ssl/bio.rs
@@ -206,10 +206,7 @@ impl BioMethod {
         };
 
         unsafe {
-            let ptr = cvt_p(ffi::BIO_meth_new(
-                ffi::BIO_TYPE_NONE,
-                b"rust\0".as_ptr() as *const _,
-            ))?;
+            let ptr = cvt_p(ffi::BIO_meth_new(ffi::BIO_TYPE_NONE, c"rust".as_ptr()))?;
             let method = BioMethod::from_ptr(ptr);
             cvt(BIO_meth_set_write(method.as_ptr(), Some(bwrite::<S>)))?;
             cvt(BIO_meth_set_read(method.as_ptr(), Some(bread::<S>)))?;

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -2912,9 +2912,8 @@ impl SslRef {
                 response.len() as c_long,
             ) as c_int)
             .map(|_| ())
-            .map_err(|e| {
+            .inspect_err(|_| {
                 ffi::OPENSSL_free(p);
-                e
             })
         }
     }
@@ -3705,9 +3704,7 @@ impl<S: Read + Write> SslStream<S> {
                 }
                 Err(ref e) if e.code() == ErrorCode::WANT_READ && e.io_error().is_none() => {}
                 Err(e) => {
-                    return Err(e
-                        .into_io_error()
-                        .unwrap_or_else(|e| io::Error::new(io::ErrorKind::Other, e)));
+                    return Err(e.into_io_error().unwrap_or_else(io::Error::other));
                 }
             }
         }
@@ -3969,9 +3966,7 @@ impl<S: Read + Write> Write for SslStream<S> {
                 Ok(n) => return Ok(n),
                 Err(ref e) if e.code() == ErrorCode::WANT_READ && e.io_error().is_none() => {}
                 Err(e) => {
-                    return Err(e
-                        .into_io_error()
-                        .unwrap_or_else(|e| io::Error::new(io::ErrorKind::Other, e)));
+                    return Err(e.into_io_error().unwrap_or_else(io::Error::other));
                 }
             }
         }


### PR DESCRIPTION
This was released July 2024. Raising to 1.80 gets us both CStr literals (in this PR) and allows us to drop once_cell as a dependency (separate PR).