### PR TITLE
Drop once_cell in favor of std::sync::{LazyLock, OnceLock}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
       - run: |
           cargo update -p unicode-ident --precise 1.0.22
           cargo update -p syn --precise 2.0.114
-          cargo update -p once_cell --precise 1.20.3
           cargo update -p wasip2 --precise 1.0.1+wasi-0.2.4
           cargo update -p quote --precise 1.0.44
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/openssl/CHANGELOG.md
+++ b/openssl/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 * Bumped MSRV to 1.80.
+* Removed the `once_cell` dependency in favor of `std::sync::{LazyLock, OnceLock}`.
 
 ### Added
 

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -30,7 +30,6 @@ bitflags = "2.2.1"
 cfg-if = "1.0"
 foreign-types = "0.3.1"
 libc = "0.2"
-once_cell = "1.5.2"
 
 openssl-macros = { version = "0.1.1", path = "../openssl-macros" }
 ffi = { package = "openssl-sys", version = "0.9.114", path = "../openssl-sys" }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -86,7 +86,6 @@ use bitflags::bitflags;
 use cfg_if::cfg_if;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_void};
-use once_cell::sync::{Lazy, OnceCell};
 use openssl_macros::corresponds;
 use std::any::TypeId;
 use std::collections::HashMap;
@@ -101,7 +100,7 @@ use std::panic::resume_unwind;
 use std::path::Path;
 use std::ptr;
 use std::str;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 
 pub use crate::ssl::connector::{
     ConnectConfiguration, SslAcceptor, SslAcceptorBuilder, SslConnector, SslConnectorBuilder,
@@ -563,12 +562,20 @@ impl NameType {
     }
 }
 
-static INDEXES: Lazy<Mutex<HashMap<TypeId, c_int>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-static SSL_INDEXES: Lazy<Mutex<HashMap<TypeId, c_int>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-static SESSION_CTX_INDEX: OnceCell<Index<Ssl, SslContext>> = OnceCell::new();
+static INDEXES: LazyLock<Mutex<HashMap<TypeId, c_int>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static SSL_INDEXES: LazyLock<Mutex<HashMap<TypeId, c_int>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static SESSION_CTX_INDEX: OnceLock<Index<Ssl, SslContext>> = OnceLock::new();
 
 fn try_get_session_ctx_index() -> Result<&'static Index<Ssl, SslContext>, ErrorStack> {
-    SESSION_CTX_INDEX.get_or_try_init(Ssl::new_ex_index)
+    // Once `OnceLock::get_or_try_init` (rust-lang/rust#109737) is stable, this
+    // can collapse to `SESSION_CTX_INDEX.get_or_try_init(Ssl::new_ex_index)`.
+    if let Some(idx) = SESSION_CTX_INDEX.get() {
+        return Ok(idx);
+    }
+    let new = Ssl::new_ex_index::<SslContext>()?;
+    Ok(SESSION_CTX_INDEX.get_or_init(|| new))
 }
 
 unsafe extern "C" fn free_data_box<T>(


### PR DESCRIPTION
LazyLock and OnceLock have been stable since 1.80, so the once_cell dependency is no longer needed.