### PR TITLE
Fix process abort when verify/PSK callbacks fire after SSL_CTX swap

### DIFF
--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -37,14 +37,23 @@ where
     unsafe {
         let ctx = X509StoreContextRef::from_ptr_mut(x509_ctx);
         let ssl_idx = X509StoreContext::ssl_idx().expect("BUG: store context ssl index missing");
+        let session_ctx_index =
+            try_get_session_ctx_index().expect("BUG: session context index initialization failed");
         let verify_idx = SslContext::cached_ex_index::<F>();
 
+        // The verify-callback function pointer is copied from the SSL_CTX into the SSL at SSL_new
+        // time and is *not* updated by SSL_set_SSL_CTX (e.g. an SNI swap). So this trampoline can
+        // fire even after the SSL's current SSL_CTX has been replaced. Look up the closure on the
+        // original SSL_CTX (stashed at SESSION_CTX_INDEX in Ssl::new) rather than on the current
+        // one, otherwise the lookup would miss and the .expect() would abort the process.
+        //
         // raw pointer shenanigans to break the borrow of ctx
         // the callback can't mess with its own ex_data slot so this is safe
         let verify = ctx
             .ex_data(ssl_idx)
             .expect("BUG: store context missing ssl")
-            .ssl_context()
+            .ex_data(*session_ctx_index)
+            .expect("BUG: session context missing")
             .ex_data(verify_idx)
             .expect("BUG: verify callback missing") as *const F;
 
@@ -69,10 +78,16 @@ where
 {
     unsafe {
         let ssl = SslRef::from_ptr_mut(ssl);
+        let session_ctx_index =
+            try_get_session_ctx_index().expect("BUG: session context index initialization failed");
         let callback_idx = SslContext::cached_ex_index::<F>();
 
+        // See raw_verify for the rationale: psk_client_callback is copied from the SSL_CTX into
+        // the SSL at SSL_new time and is not updated by SSL_set_SSL_CTX, so we must look up the
+        // closure on the original SSL_CTX rather than the current (potentially swapped) one.
         let callback = ssl
-            .ssl_context()
+            .ex_data(*session_ctx_index)
+            .expect("BUG: session context missing")
             .ex_data(callback_idx)
             .expect("BUG: psk callback missing") as *const F;
         let hint = if !hint.is_null() {
@@ -111,10 +126,16 @@ where
 {
     unsafe {
         let ssl = SslRef::from_ptr_mut(ssl);
+        let session_ctx_index =
+            try_get_session_ctx_index().expect("BUG: session context index initialization failed");
         let callback_idx = SslContext::cached_ex_index::<F>();
 
+        // See raw_verify for the rationale: psk_server_callback is copied from the SSL_CTX into
+        // the SSL at SSL_new time and is not updated by SSL_set_SSL_CTX, so we must look up the
+        // closure on the original SSL_CTX rather than the current (potentially swapped) one.
         let callback = ssl
-            .ssl_context()
+            .ex_data(*session_ctx_index)
+            .expect("BUG: session context missing")
             .ex_data(callback_idx)
             .expect("BUG: psk callback missing") as *const F;
         let identity = if identity.is_null() {

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -1614,6 +1614,38 @@ fn sni_callback_swapped_ctx() {
     assert!(CALLED_BACK.load(Ordering::SeqCst));
 }
 
+// Regression test: the verify_callback function pointer is per-SSL (copied from the SSL_CTX into
+// the SSL at SSL_new time) and is *not* updated when SSL_set_SSL_CTX swaps the context. Before the
+// fix, the trampoline still invoked the original raw_verify::<F_a> after a swap, but it looked up
+// the closure on the *current* (swapped) ctx, which doesn't have an F_a entry — the .expect() then
+// aborted the process via a panic across an extern "C" boundary.
+#[test]
+fn verify_callback_after_swapped_ctx() {
+    static CALLED_BACK: AtomicBool = AtomicBool::new(false);
+
+    let server = Server::builder().build();
+
+    let mut client = server.client();
+    client
+        .ctx()
+        .set_verify_callback(SslVerifyMode::PEER, |_, _| {
+            CALLED_BACK.store(true, Ordering::SeqCst);
+            true
+        });
+
+    let mut client = client.build().builder();
+
+    // Swap to a fresh ctx that has no verify callback registered. The per-SSL verify function
+    // pointer raw_verify::<F> is unaffected by the swap and will still fire during the handshake;
+    // it must still find the original closure and not abort.
+    let other_ctx = SslContextBuilder::new(SslMethod::tls()).unwrap().build();
+    client.ssl().set_ssl_context(&other_ctx).unwrap();
+
+    client.connect();
+
+    assert!(CALLED_BACK.load(Ordering::SeqCst));
+}
+
 #[test]
 #[cfg(ossl111)]
 fn client_hello() {


### PR DESCRIPTION
The verify_callback, psk_client_callback, and psk_server_callback function pointers are copied from the SSL_CTX into the SSL at SSL_new time and are *not* updated by SSL_set_SSL_CTX. After an SNI handler swaps the context, these per-SSL function pointers still point at the trampoline `raw_X::<F_a>` registered by the original ctx. The trampoline was looking up the closure on `ssl.ssl_context()` (the new, swapped ctx), which has no entry at `cached_ex_index::<F_a>()`, so the `.expect()` panicked across the extern "C" boundary and aborted the process — turning a routine multi-tenant TLS handshake into a server crash.

Look up the closure on the original ctx (already stashed on the SSL at SESSION_CTX_INDEX by Ssl::new) instead, mirroring what raw_new_session and raw_get_session already do. Other per-CTX callbacks (ALPN, OCSP, cookies, keylog, custom-ext, tmp-DH, client-hello) are dispatched via `s->ctx` by OpenSSL and so are not affected — the trampoline that fires after a swap is always the one registered on the current ctx, which has the matching closure.