### PR TITLE
Bind OSSL_PARAM_modified and use it for seed_into

### DIFF
--- a/openssl-sys/CHANGELOG.md
+++ b/openssl-sys/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* Added `OSSL_PARAM_modified` and exposed the `OSSL_PARAM` struct fields, so callers can detect whether a get-params call wrote into a parameter and read its `return_size`.
+
 ### Changed
 
 * Bumped MSRV to 1.80.

--- a/openssl-sys/src/core_dispatch.rs
+++ b/openssl-sys/src/core_dispatch.rs
@@ -1,5 +1,4 @@
 use super::*;
-use libc::size_t;
 use std::ffi::c_int;
 
 /* OpenSSL 3.* only */
@@ -10,9 +9,3 @@ pub const OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS: c_int = 0x04;
 pub const OSSL_KEYMGMT_SELECT_OTHER_PARAMETERS: c_int = 0x80;
 pub const OSSL_KEYMGMT_SELECT_ALL_PARAMETERS: c_int =
     OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS | OSSL_KEYMGMT_SELECT_OTHER_PARAMETERS;
-
-/// Sentinel value the `OSSL_PARAM_construct_*` typed constructors initialise
-/// `OSSL_PARAM::return_size` to. After a get-params call, a `return_size`
-/// still equal to this value indicates the parameter was not modified by
-/// the keymgmt (typically because it did not recognise the parameter name).
-pub const OSSL_PARAM_UNMODIFIED: size_t = size_t::MAX;

--- a/openssl-sys/src/handwritten/params.rs
+++ b/openssl-sys/src/handwritten/params.rs
@@ -17,6 +17,8 @@ extern "C" {
         bsize: size_t,
     ) -> OSSL_PARAM;
 
+    pub fn OSSL_PARAM_modified(p: *const OSSL_PARAM) -> c_int;
+
     pub fn OSSL_PARAM_locate(p: *mut OSSL_PARAM, key: *const c_char) -> *mut OSSL_PARAM;
     pub fn OSSL_PARAM_locate_const(
         params: *const OSSL_PARAM,

--- a/openssl-sys/src/handwritten/types.rs
+++ b/openssl-sys/src/handwritten/types.rs
@@ -168,20 +168,11 @@ pub struct OSSL_PARAM {
     pub data_type: c_uint,
     pub data: *mut c_void,
     pub data_size: size_t,
-    /// Possible values:
-    ///
-    /// * The number of bytes the most recent get-params operation wrote
-    ///   into this parameter's data buffer.
-    /// * [`crate::OSSL_PARAM_UNMODIFIED`] — the value that all of the
-    ///   `OSSL_PARAM_construct_*` typed constructors initialise this
-    ///   field to. Indicates the parameter has not been touched by any
-    ///   get-params call (typically because the keymgmt did not
-    ///   recognise the parameter name).
-    /// * `0` — the value on the array-terminator entry produced by
-    ///   `OSSL_PARAM_construct_end()`, since the terminator is fully
-    ///   zero-initialised. Reading `return_size` on the terminator entry
-    ///   of an `OSSL_PARAM` array is almost certainly a bug; this value
-    ///   does *not* mean "0 bytes written".
+    /// Number of bytes the most recent get-params call wrote into this
+    /// parameter's data buffer. Only meaningful once
+    /// [`crate::OSSL_PARAM_modified`] has confirmed the parameter was
+    /// touched -- before that, this field still holds the sentinel set
+    /// by the `OSSL_PARAM_construct_*` typed constructors.
     pub return_size: size_t,
 }
 

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -413,14 +413,12 @@ where
             ];
             cvt(ffi::EVP_PKEY_get_params(self.as_ptr(), params.as_mut_ptr()))?;
             // OpenSSL silently ignores OSSL_PARAMs the keymgmt doesn't
-            // recognise and returns success, leaving the param's
-            // `return_size` at OSSL_PARAM_UNMODIFIED. Treat that as an
-            // error.
-            let written = params[0].return_size;
-            if written == ffi::OSSL_PARAM_UNMODIFIED {
+            // recognise and returns success. Detect that case via
+            // OSSL_PARAM_modified before trusting return_size.
+            if ffi::OSSL_PARAM_modified(&params[0]) == 0 {
                 return Err(ErrorStack::get());
             }
-            Ok(written)
+            Ok(params[0].return_size)
         }
     }
 


### PR DESCRIPTION
Replaces the OSSL_PARAM_UNMODIFIED sentinel comparison in PKeyRef::seed_into with a call to OSSL_PARAM_modified, the public OpenSSL API for detecting whether a get-params call wrote into a parameter. return_size remains exposed since callers still need the byte count once the param has been confirmed modified.