### PR TITLE
Fix output buffer overflow for AES key-wrap-with-padding ciphers

### DIFF
--- a/openssl-sys/src/evp.rs
+++ b/openssl-sys/src/evp.rs
@@ -1,6 +1,6 @@
 use super::*;
 use libc::size_t;
-use std::ffi::{c_int, c_uint, c_void};
+use std::ffi::{c_int, c_uint, c_ulong, c_void};
 
 pub const EVP_MAX_MD_SIZE: c_uint = 64;
 
@@ -34,6 +34,9 @@ pub const EVP_PKEY_HKDF: c_int = NID_hkdf;
 
 #[cfg(ossl110)]
 pub const EVP_CIPHER_CTX_FLAG_WRAP_ALLOW: c_int = 0x1;
+
+pub const EVP_CIPH_MODE: c_ulong = 0xF0007;
+pub const EVP_CIPH_WRAP_MODE: c_ulong = 0x10002;
 
 pub const EVP_CTRL_GCM_SET_IVLEN: c_int = 0x9;
 pub const EVP_CTRL_GCM_GET_TAG: c_int = 0x10;
@@ -105,6 +108,11 @@ cfg_if! {
         #[inline]
         pub unsafe fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> c_int {
             EVP_CIPHER_get_nid(cipher)
+        }
+
+        #[inline]
+        pub unsafe fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> c_ulong {
+            EVP_CIPHER_get_flags(cipher)
         }
 
         #[inline]

--- a/openssl-sys/src/handwritten/evp.rs
+++ b/openssl-sys/src/handwritten/evp.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use libc::size_t;
-use std::ffi::{c_char, c_int, c_long, c_uchar, c_void};
+use std::ffi::{c_char, c_int, c_long, c_uchar, c_ulong, c_void};
 
 cfg_if! {
     if #[cfg(ossl300)] {
@@ -15,6 +15,7 @@ cfg_if! {
             pub fn EVP_CIPHER_get_block_size(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_get_iv_length(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_get_nid(cipher: *const EVP_CIPHER) -> c_int;
+            pub fn EVP_CIPHER_get_flags(cipher: *const EVP_CIPHER) -> c_ulong;
             pub fn EVP_CIPHER_fetch(
                 ctx: *mut OSSL_LIB_CTX,
                 algorithm: *const c_char,
@@ -41,6 +42,7 @@ cfg_if! {
             pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> c_int;
             pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> c_int;
+            pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> c_ulong;
 
             pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
             pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> c_int;

--- a/openssl/src/cipher_ctx.rs
+++ b/openssl/src/cipher_ctx.rs
@@ -296,6 +296,38 @@ impl CipherCtxRef {
         }
     }
 
+    #[cfg(not(any(boringssl, awslc)))]
+    fn is_wrap_mode(&self) -> bool {
+        unsafe {
+            let cipher = EVP_CIPHER_CTX_get0_cipher(self.as_ptr());
+            if cipher.is_null() {
+                return false;
+            }
+            ffi::EVP_CIPHER_flags(cipher) & ffi::EVP_CIPH_MODE == ffi::EVP_CIPH_WRAP_MODE
+        }
+    }
+
+    #[cfg(any(boringssl, awslc))]
+    fn is_wrap_mode(&self) -> bool {
+        false
+    }
+
+    fn cipher_update_output_size(&self, input_len: usize) -> usize {
+        // Wrap-mode ciphers have EVP_CIPH_FLAG_CUSTOM_CIPHER set and emit their
+        // entire output (plaintext rounded up to 8 bytes + 8-byte IV) in a
+        // single update call, so the usual `inlen + block_size` bound is too
+        // small for key-wrap-with-padding inputs that aren't already a
+        // multiple of 8.
+        if self.is_wrap_mode() {
+            return input_len.saturating_add(7) / 8 * 8 + 8;
+        }
+        let mut block_size = self.block_size();
+        if block_size == 1 {
+            block_size = 0;
+        }
+        input_len + block_size
+    }
+
     /// Returns the block size of the context's cipher.
     ///
     /// Stream ciphers will report a block size of 1.
@@ -552,11 +584,7 @@ impl CipherCtxRef {
         output: Option<&mut [u8]>,
     ) -> Result<usize, ErrorStack> {
         if let Some(output) = &output {
-            let mut block_size = self.block_size();
-            if block_size == 1 {
-                block_size = 0;
-            }
-            let min_output_size = input.len() + block_size;
+            let min_output_size = self.cipher_update_output_size(input.len());
             assert!(
                 output.len() >= min_output_size,
                 "Output buffer size should be at least {} bytes.",
@@ -612,7 +640,7 @@ impl CipherCtxRef {
         output: &mut Vec<u8>,
     ) -> Result<usize, ErrorStack> {
         let base = output.len();
-        output.resize(base + input.len() + self.block_size(), 0);
+        output.resize(base + self.cipher_update_output_size(input.len()), 0);
         let len = self.cipher_update(input, Some(&mut output[base..]))?;
         output.truncate(base + len);
 
@@ -1267,5 +1295,25 @@ mod test {
         let key = "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4";
 
         cipher_wrap_test(Cipher::aes_256_wrap_pad(), pt, ct, key, None);
+    }
+
+    #[test]
+    #[cfg(ossl110)]
+    fn test_aes_wrap_pad_cipher_update_vec_buffer_size() {
+        let cipher = Cipher::aes_256_wrap_pad();
+        let key = [0u8; 32];
+        let iv = [0u8; 4];
+        let pt = [0u8; 9];
+
+        let mut ctx = CipherCtx::new().unwrap();
+        ctx.set_flags(CipherCtxFlags::FLAG_WRAP_ALLOW);
+        ctx.encrypt_init(Some(cipher), Some(&key), Some(&iv))
+            .unwrap();
+
+        let mut out = vec![];
+        let len = ctx.cipher_update_vec(&pt, &mut out).unwrap();
+        // The vec must be large enough to fit the amount of data we wrote.
+        assert!(out.capacity() >= len);
+        assert_eq!(len, 24);
     }
 }


### PR DESCRIPTION
CipherCtxRef::cipher_update and cipher_update_vec sized their output buffer as input.len() + block_size (= 8 for AES-*-WRAP-PAD). However, those ciphers have EVP_CIPH_FLAG_CUSTOM_CIPHER set and emit the entire wrapped output (plaintext rounded up to 8 + 8-byte IV, i.e. up to input.len() + 15) during the update call, so the existing bound was up to 7 bytes too small.

Detect wrap-mode ciphers via EVP_CIPHER_flags & EVP_CIPH_MODE and use a bound of ((inlen + 7) / 8) * 8 + 8 for them.