### PR TITLE
Prefer Homebrew openssl@4 and stop looking for openssl@1.1

### DIFF
--- a/openssl-sys/CHANGELOG.md
+++ b/openssl-sys/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+* On macOS, the Homebrew auto-detection now prefers `openssl@4`, falls back to `openssl@3`/`openssl@3.0`, and no longer looks for `openssl@1.1`.
+
 ## [v0.9.115] - 2026-05-03
 
 ### Added

--- a/openssl-sys/build/find_normal.rs
+++ b/openssl-sys/build/find_normal.rs
@@ -32,7 +32,7 @@ pub fn get_openssl(target: &str) -> (Vec<PathBuf>, PathBuf) {
 }
 
 fn resolve_with_wellknown_homebrew_location(dir: &str) -> Option<PathBuf> {
-    let versions = ["openssl@3", "openssl@3.0", "openssl@1.1"];
+    let versions = ["openssl@4", "openssl@3", "openssl@3.0"];
 
     // Check up default aarch 64 Homebrew installation location first
     // for quick resolution if possible.

--- a/openssl-sys/build/main.rs
+++ b/openssl-sys/build/main.rs
@@ -308,7 +308,7 @@ fn postprocess(include_dirs: &[PathBuf]) -> Version {
 /// version string of OpenSSL.
 #[allow(clippy::unusual_byte_groupings)]
 fn validate_headers(include_dirs: &[PathBuf]) -> Version {
-    // This `*-sys` crate only works with OpenSSL 1.1.0, 1.1.1 and 3.x.
+    // This `*-sys` crate only works with OpenSSL 1.1.0, 1.1.1, 3.x, and 4.x.
     // To correctly expose the right API from this crate, take a look at
     // `opensslv.h` to see what version OpenSSL claims to be.
     println!("cargo:rerun-if-changed=build/expando.c");

--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ```not_rust
 //! # macOS (Homebrew)
-//! $ brew install openssl@3
+//! $ brew install openssl@4
 //!
 //! # macOS (MacPorts)
 //! $ sudo port install openssl


### PR DESCRIPTION
Updates the macOS Homebrew auto-detection to try `openssl@4` first, falling back to `openssl@3` / `openssl@3.0`. The pre-3.0 `openssl@1.1` formula is no longer probed.