### PR TITLE
Add brainpoolP224r1 and brainpoolP224t1 NID constants

### DIFF
--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -96,6 +96,11 @@ pub const NID_sect571k1: c_int = 733;
 pub const NID_sect571r1: c_int = 734;
 
 #[cfg(ossl110)]
+pub const NID_brainpoolP224r1: c_int = 925;
+#[cfg(libressl)]
+pub const NID_brainpoolP224r1: c_int = 926;
+
+#[cfg(ossl110)]
 pub const NID_brainpoolP256r1: c_int = 927;
 #[cfg(libressl)]
 pub const NID_brainpoolP256r1: c_int = 928;
@@ -114,6 +119,11 @@ pub const NID_brainpoolP384r1: c_int = 932;
 pub const NID_brainpoolP512r1: c_int = 933;
 #[cfg(libressl)]
 pub const NID_brainpoolP512r1: c_int = 934;
+
+#[cfg(ossl110)]
+pub const NID_brainpoolP224t1: c_int = 926;
+#[cfg(libressl)]
+pub const NID_brainpoolP224t1: c_int = 927;
 
 #[cfg(ossl110)]
 pub const NID_brainpoolP256t1: c_int = 928;

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -215,6 +215,8 @@ impl Nid {
     pub const SECT571K1: Nid = Nid(ffi::NID_sect571k1);
     pub const SECT571R1: Nid = Nid(ffi::NID_sect571r1);
     #[cfg(any(ossl110, libressl))]
+    pub const BRAINPOOL_P224R1: Nid = Nid(ffi::NID_brainpoolP224r1);
+    #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P256R1: Nid = Nid(ffi::NID_brainpoolP256r1);
     #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P320R1: Nid = Nid(ffi::NID_brainpoolP320r1);
@@ -222,6 +224,8 @@ impl Nid {
     pub const BRAINPOOL_P384R1: Nid = Nid(ffi::NID_brainpoolP384r1);
     #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P512R1: Nid = Nid(ffi::NID_brainpoolP512r1);
+    #[cfg(any(ossl110, libressl))]
+    pub const BRAINPOOL_P224T1: Nid = Nid(ffi::NID_brainpoolP224t1);
     #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P256T1: Nid = Nid(ffi::NID_brainpoolP256t1);
     #[cfg(any(ossl110, libressl))]


### PR DESCRIPTION
## Summary

Add `NID_brainpoolP224r1` / `NID_brainpoolP224t1` constants to openssl-sys and the corresponding `BRAINPOOL_P224R1` / `BRAINPOOL_P224T1` constants to openssl. These are the only Brainpool curve sizes missing — P256 through P512 are already present.

## Motivation

These curves are defined in [RFC 5639](https://datatracker.ietf.org/doc/html/rfc5639) and supported by OpenSSL since 1.1.0 (NID 925/926). They are needed by [pyca/cryptography](https://github.com/pyca/cryptography) to add brainpoolP224r1 support for ICAO 9303 ePassport certificate processing. Belgium uses brainpoolP224r1 for Active Authentication keys, and Germany has Document Signer certificates using this curve.

## Changes

- `openssl-sys/src/obj_mac.rs`: Add `NID_brainpoolP224r1` (925/926) and `NID_brainpoolP224t1` (926/927), with the standard `ossl110`/`libressl` cfg split
- `openssl/src/nid.rs`: Add `BRAINPOOL_P224R1` and `BRAINPOOL_P224T1` wrapping the FFI constants, gated behind `cfg(any(ossl110, libressl))`

Both follow the exact pattern of the existing P256/P320/P384/P512 entries.
