### PR TITLE
Fix verify_mode() panic on unmodeled verify mode bits

### DIFF
--- a/openssl-sys/CHANGELOG.md
+++ b/openssl-sys/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* Added `SSL_VERIFY_CLIENT_ONCE` and `SSL_VERIFY_POST_HANDSHAKE`.
+
 ## [v0.9.116] - 2026-05-16
 
 ### Changed

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -295,6 +295,9 @@ pub const SSL_ERROR_WANT_CLIENT_HELLO_CB: c_int = 11;
 pub const SSL_VERIFY_NONE: c_int = 0;
 pub const SSL_VERIFY_PEER: c_int = 1;
 pub const SSL_VERIFY_FAIL_IF_NO_PEER_CERT: c_int = 2;
+pub const SSL_VERIFY_CLIENT_ONCE: c_int = 4;
+#[cfg(ossl111)]
+pub const SSL_VERIFY_POST_HANDSHAKE: c_int = 8;
 #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]
 pub const SSL_CTRL_SET_TMP_DH: c_int = 3;
 #[cfg(not(osslconf = "OPENSSL_NO_DEPRECATED_3_0"))]

--- a/openssl/CHANGELOG.md
+++ b/openssl/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* `SslContextRef::verify_mode` and `SslRef::verify_mode` no longer panic when the verify mode contains bits not modeled by `SslVerifyMode`.
+
+### Added
+
+* Added `SslVerifyMode::CLIENT_ONCE` and `SslVerifyMode::POST_HANDSHAKE`.
+
 ## [v0.10.80] - 2026-05-16
 
 ### Fixed

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -412,6 +412,22 @@ bitflags! {
         ///
         /// This should be paired with `SSL_VERIFY_PEER`. It has no effect on the client side.
         const FAIL_IF_NO_PEER_CERT = ffi::SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+
+        /// On the server side, only request a certificate from the client during the initial
+        /// handshake, and not during renegotiations.
+        ///
+        /// This should be paired with `SSL_VERIFY_PEER`. It has no effect on the client side.
+        #[cfg(not(any(boringssl, awslc)))]
+        const CLIENT_ONCE = ffi::SSL_VERIFY_CLIENT_ONCE;
+
+        /// On the server side, request a certificate from the client via a TLSv1.3
+        /// post-handshake authentication request rather than during the initial handshake.
+        ///
+        /// This should be paired with `SSL_VERIFY_PEER`. It has no effect on the client side.
+        ///
+        /// Requires OpenSSL 1.1.1 or newer.
+        #[cfg(ossl111)]
+        const POST_HANDSHAKE = ffi::SSL_VERIFY_POST_HANDSHAKE;
     }
 }
 
@@ -1938,7 +1954,7 @@ impl SslContextRef {
     #[corresponds(SSL_CTX_get_verify_mode)]
     pub fn verify_mode(&self) -> SslVerifyMode {
         let mode = unsafe { ffi::SSL_CTX_get_verify_mode(self.as_ptr()) };
-        SslVerifyMode::from_bits(mode).expect("SSL_CTX_get_verify_mode returned invalid mode")
+        SslVerifyMode::from_bits_retain(mode)
     }
 
     /// Gets the number of TLS 1.3 session tickets that will be sent to a client after a full
@@ -2391,7 +2407,7 @@ impl SslRef {
     #[corresponds(SSL_set_verify_mode)]
     pub fn verify_mode(&self) -> SslVerifyMode {
         let mode = unsafe { ffi::SSL_get_verify_mode(self.as_ptr()) };
-        SslVerifyMode::from_bits(mode).expect("SSL_get_verify_mode returned invalid mode")
+        SslVerifyMode::from_bits_retain(mode)
     }
 
     /// Like [`SslContextBuilder::set_verify_callback`].

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -696,6 +696,26 @@ fn default_verify_paths() {
 }
 
 #[test]
+fn verify_mode_round_trip() {
+    let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
+    let mut mode = SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT;
+    #[cfg(not(any(boringssl, awslc)))]
+    {
+        mode |= SslVerifyMode::CLIENT_ONCE;
+    }
+    #[cfg(ossl111)]
+    {
+        mode |= SslVerifyMode::POST_HANDSHAKE;
+    }
+    ctx.set_verify(mode);
+
+    let ctx = ctx.build();
+    assert_eq!(ctx.verify_mode(), mode);
+    let ssl = Ssl::new(&ctx).unwrap();
+    assert_eq!(ssl.verify_mode(), mode);
+}
+
+#[test]
 fn add_extra_chain_cert() {
     let cert = X509::from_pem(CERT).unwrap();
     let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();

--- a/openssl/src/ssl/test/mod.rs
+++ b/openssl/src/ssl/test/mod.rs
@@ -698,7 +698,8 @@ fn default_verify_paths() {
 #[test]
 fn verify_mode_round_trip() {
     let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
-    let mut mode = SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT;
+    let mut mode = SslVerifyMode::PEER;
+    mode |= SslVerifyMode::FAIL_IF_NO_PEER_CERT;
     #[cfg(not(any(boringssl, awslc)))]
     {
         mode |= SslVerifyMode::CLIENT_ONCE;


### PR DESCRIPTION
SslContextRef::verify_mode() and SslRef::verify_mode() used from_bits(...).expect(...), which panics if OpenSSL returns verify mode bits not modeled by SslVerifyMode — e.g. SSL_VERIFY_CLIENT_ONCE (0x4) or SSL_VERIFY_POST_HANDSHAKE (0x8), both of which OpenSSL happily accepts via set_verify.

- Add SSL_VERIFY_CLIENT_ONCE and SSL_VERIFY_POST_HANDSHAKE to openssl-sys, and corresponding SslVerifyMode::CLIENT_ONCE / POST_HANDSHAKE flags.
- Switch the getters to from_bits_retain so unknown bits are preserved rather than panicking.

https://claude.ai/code/session_01SpKgNpVDkf7ihjxpZYZ4o3