### PR TITLE
Deprecate Asn1StringRef::as_utf8 in favor of a NUL-safe to_string

### DIFF
--- a/openssl/src/asn1.rs
+++ b/openssl/src/asn1.rs
@@ -25,7 +25,7 @@
 //! let tomorrow = Asn1Time::days_from_now(1);
 //! ```
 use foreign_types::{ForeignType, ForeignTypeRef};
-use libc::{c_char, c_int, c_long, time_t};
+use libc::{c_char, c_int, c_long, c_void, time_t};
 use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::ffi::CString;
@@ -443,6 +443,10 @@ impl Asn1StringRef {
     /// consume the string in a meaningful way without knowing the underlying
     /// format.
     #[corresponds(ASN1_STRING_to_UTF8)]
+    #[deprecated(
+        since = "0.10.81",
+        note = "truncates at the first interior NUL byte; use `to_string` instead"
+    )]
     pub fn as_utf8(&self) -> Result<OpensslString, ErrorStack> {
         unsafe {
             let mut ptr = ptr::null_mut();
@@ -455,12 +459,64 @@ impl Asn1StringRef {
         }
     }
 
+    /// Converts the ASN.1 underlying format to a UTF-8 string.
+    ///
+    /// ASN.1 strings may utilize UTF-16, ASCII, BMP, or UTF8.  This is important to
+    /// consume the string in a meaningful way without knowing the underlying
+    /// format.
+    ///
+    /// The full contents of the string are preserved, including any interior
+    /// NUL bytes. Any bytes that do not form valid UTF-8 after conversion are
+    /// replaced with U+FFFD.
+    #[corresponds(ASN1_STRING_to_UTF8)]
+    pub fn to_string(&self) -> Result<String, ErrorStack> {
+        // For string types whose conversion to UTF-8 is the identity
+        // function, copy directly out of the underlying buffer, avoiding
+        // ASN1_STRING_to_UTF8's intermediate allocation of it.
+        match unsafe { ffi::ASN1_STRING_type(self.as_ptr()) } {
+            ffi::V_ASN1_UTF8STRING => {
+                if let Ok(s) = str::from_utf8(self.as_slice()) {
+                    return Ok(s.to_owned());
+                }
+            }
+            // Latin-1 types, whose UTF-8 conversion is the identity on ASCII.
+            ffi::V_ASN1_NUMERICSTRING
+            | ffi::V_ASN1_PRINTABLESTRING
+            | ffi::V_ASN1_T61STRING
+            | ffi::V_ASN1_IA5STRING
+            | ffi::V_ASN1_VISIBLESTRING => {
+                let slice = self.as_slice();
+                if slice.is_ascii() {
+                    // SAFETY: ASCII is valid UTF-8.
+                    return Ok(unsafe { str::from_utf8_unchecked(slice) }.to_owned());
+                }
+            }
+            _ => {}
+        }
+
+        unsafe {
+            let mut ptr = ptr::null_mut();
+            let len = ffi::ASN1_STRING_to_UTF8(&mut ptr, self.as_ptr());
+            if len < 0 {
+                return Err(ErrorStack::get());
+            }
+
+            // This copies the buffer exactly once: for valid UTF-8,
+            // from_utf8_lossy is a no-op returning Cow::Borrowed and
+            // into_owned performs the copy; for invalid UTF-8, from_utf8_lossy
+            // copies with replacements and into_owned is a no-op.
+            let s = String::from_utf8_lossy(util::from_raw_parts(ptr, len as usize)).into_owned();
+            openssl_free(ptr.cast());
+            Ok(s)
+        }
+    }
+
     /// Return the string as an array of bytes.
     ///
     /// The bytes do not directly correspond to UTF-8 encoding.  To interact with
-    /// strings in rust, it is preferable to use [`as_utf8`]
+    /// strings in rust, it is preferable to use [`to_string`]
     ///
-    /// [`as_utf8`]: struct.Asn1String.html#method.as_utf8
+    /// [`to_string`]: struct.Asn1StringRef.html#method.to_string
     #[corresponds(ASN1_STRING_get0_data)]
     pub fn as_slice(&self) -> &[u8] {
         unsafe { util::from_raw_parts(ASN1_STRING_get0_data(self.as_ptr()), self.len()) }
@@ -480,11 +536,27 @@ impl Asn1StringRef {
 
 impl fmt::Debug for Asn1StringRef {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.as_utf8() {
-            Ok(openssl_string) => openssl_string.fmt(fmt),
+        match self.to_string() {
+            Ok(string) => string.fmt(fmt),
             Err(_) => fmt.write_str("error"),
         }
     }
+}
+
+#[inline]
+#[cfg(not(any(boringssl, awslc)))]
+unsafe fn openssl_free(buf: *mut c_void) {
+    ffi::OPENSSL_free(buf);
+}
+
+#[inline]
+#[cfg(any(boringssl, awslc))]
+unsafe fn openssl_free(buf: *mut c_void) {
+    ffi::CRYPTO_free(
+        buf,
+        concat!(file!(), "\0").as_ptr() as *const c_char,
+        line!() as c_int,
+    );
 }
 
 foreign_type_and_impl_send_sync! {
@@ -805,6 +877,36 @@ mod tests {
         roundtrip(-BigNum::from_dec_str("1000000000000000000000000000000000").unwrap());
         roundtrip(BigNum::from_u32(1234).unwrap());
         roundtrip(-BigNum::from_u32(1234).unwrap());
+    }
+
+    /// Tests that interior NUL bytes are preserved when converting to UTF-8.
+    #[test]
+    fn string_with_interior_nul() {
+        fn make_string(typ: c_int, data: &[u8]) -> Asn1String {
+            unsafe {
+                let ptr = cvt_p(ffi::ASN1_STRING_type_new(typ)).unwrap();
+                let s = Asn1String::from_ptr(ptr);
+                cvt(ffi::ASN1_STRING_set(
+                    s.as_ptr(),
+                    data.as_ptr().cast(),
+                    data.len().try_into().unwrap(),
+                ))
+                .unwrap();
+                s
+            }
+        }
+
+        // Copied directly out of the underlying buffer.
+        let s = make_string(ffi::V_ASN1_UTF8STRING, b"foo\0bar.com");
+        assert_eq!(s.as_slice(), b"foo\0bar.com");
+        assert_eq!(s.to_string().unwrap(), "foo\0bar.com");
+
+        let s = make_string(ffi::V_ASN1_IA5STRING, b"foo\0bar.com");
+        assert_eq!(s.to_string().unwrap(), "foo\0bar.com");
+
+        // Converted through ASN1_STRING_to_UTF8.
+        let s = make_string(ffi::V_ASN1_BMPSTRING, b"\0f\0\0\0o");
+        assert_eq!(s.to_string().unwrap(), "f\0o");
     }
 
     #[test]

--- a/openssl/src/x509/tests.rs
+++ b/openssl/src/x509/tests.rs
@@ -111,7 +111,7 @@ fn test_nid_values() {
     assert_eq!(email.data().as_slice(), b"test@example.com");
 
     let friendly = subject.entries_by_nid(Nid::FRIENDLYNAME).next().unwrap();
-    assert_eq!(&**friendly.data().as_utf8().unwrap(), "Example");
+    assert_eq!(friendly.data().to_string().unwrap(), "Example");
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn test_nameref_iterator() {
 
     let friendly = all_entries.next().unwrap();
     assert_eq!(friendly.object().nid().as_raw(), Nid::FRIENDLYNAME.as_raw());
-    assert_eq!(&**friendly.data().as_utf8().unwrap(), "Example");
+    assert_eq!(friendly.data().to_string().unwrap(), "Example");
 
     if all_entries.next().is_some() {
         panic!();
@@ -220,10 +220,10 @@ fn test_authority_issuer_and_serial() {
     assert_eq!(1, authority_issuer.len());
     let dn = authority_issuer[0].directory_name().unwrap();
     let mut o = dn.entries_by_nid(Nid::ORGANIZATIONNAME);
-    let o = o.next().unwrap().data().as_utf8().unwrap();
+    let o = o.next().unwrap().data().to_string().unwrap();
     assert_eq!(o.as_bytes(), b"PyCA");
     let mut cn = dn.entries_by_nid(Nid::COMMONNAME);
-    let cn = cn.next().unwrap().data().as_utf8().unwrap();
+    let cn = cn.next().unwrap().data().to_string().unwrap();
     assert_eq!(cn.as_bytes(), b"cryptography.io");
 
     let authority_serial = cert.authority_serial().unwrap();


### PR DESCRIPTION
as_utf8 calls ASN1_STRING_to_UTF8, which returns an explicit length, but discards it: the result is read back through CStr::from_ptr (in OpensslStringRef's Deref), dropping everything after the first NUL byte. X.509 name entries can legally contain interior NULs, and seeing them matters for detecting the classic NUL-byte-CN spoofing trick (e.g. "example.com\0evil.com"). The truncation can't be fixed in place because OpensslString's representation is inherently NUL-terminated.

Add Asn1StringRef::to_string, which preserves the full contents using the length reported for the conversion. For string types whose UTF-8 conversion is the identity (UTF8String already containing valid UTF-8, and the Latin-1 family when ASCII-only), it copies directly out of the underlying buffer with a single allocation; otherwise it converts through ASN1_STRING_to_UTF8 and copies the result (replacing any invalid UTF-8 with U+FFFD rather than assuming validity unchecked). The Debug impl now uses to_string, so interior NULs show up there too.

https://claude.ai/code/session_01JS5sEpf4jRcbgsqsfNnMPs