### PR TITLE
Release openssl 0.10.81 and openssl-sys 0.9.117

### DIFF
--- a/openssl-sys/CHANGELOG.md
+++ b/openssl-sys/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+## [v0.9.117] - 2026-06-12
+
 ### Added
 
 * Added `SSL_VERIFY_CLIENT_ONCE` and `SSL_VERIFY_POST_HANDSHAKE`.
+* Added `NID_brainpoolP224r1` and `NID_brainpoolP224t1`.
+* Added ML-DSA bindings on BoringSSL.
+
+### Changed
+
+* Bumped `aws-lc-sys` to 0.41.
 
 ## [v0.9.116] - 2026-05-16
 
@@ -752,7 +760,8 @@ Fixed builds against OpenSSL built with `no-cast`.
 * Added `X509_verify` and `X509_REQ_verify`.
 * Added `EVP_MD_type` and `EVP_GROUP_get_curve_name`.
 
-[Unreleased]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.116...master
+[Unreleased]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.117...master
+[v0.9.117]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.116...openssl-sys-v0.9.117
 [v0.9.116]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.115...openssl-sys-v0.9.116
 [v0.9.115]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.114...openssl-sys-v0.9.115
 [v0.9.114]: https://github.com/rust-openssl/rust-openssl/compare/openssl-sys-v0.9.113...openssl-sys-v0.9.114

--- a/openssl-sys/Cargo.toml
+++ b/openssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Steven Fackler <sfackler@gmail.com>",

--- a/openssl/CHANGELOG.md
+++ b/openssl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v0.10.81] - 2026-06-12
+
 ### Fixed
 
 * `SslContextRef::verify_mode` and `SslRef::verify_mode` no longer panic when the verify mode contains bits not modeled by `SslVerifyMode`.
@@ -9,6 +11,13 @@
 ### Added
 
 * Added `SslVerifyMode::CLIENT_ONCE` and `SslVerifyMode::POST_HANDSHAKE`.
+* Added `X509CrlBuilder` and `X509RevokedBuilder`, for building and signing CRLs, along with the `CrlNumber` extension builder.
+* Added `Nid::BRAINPOOL_P224R1` and `Nid::BRAINPOOL_P224T1`.
+* Added `Asn1StringRef::to_string`, which converts the string to UTF-8 without truncating at interior NUL bytes.
+
+### Changed
+
+* Deprecated `Asn1StringRef::as_utf8`, which truncates at the first interior NUL byte, in favor of `Asn1StringRef::to_string`.
 
 ## [v0.10.80] - 2026-05-16
 
@@ -1108,7 +1117,8 @@
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.80...master
+[Unreleased]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.81...master
+[v0.10.81]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.80...openssl-v0.10.81
 [v0.10.80]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.79...openssl-v0.10.80
 [v0.10.79]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.78...openssl-v0.10.79
 [v0.10.78]: https://github.com/rust-openssl/rust-openssl/compare/openssl-v0.10.77...openssl-v0.10.78

--- a/openssl/Cargo.toml
+++ b/openssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 license = "Apache-2.0"
 description = "OpenSSL bindings"
@@ -32,7 +32,7 @@ foreign-types = "0.3.1"
 libc = "0.2"
 
 openssl-macros = { version = "0.1.1", path = "../openssl-macros" }
-ffi = { package = "openssl-sys", version = "0.9.116", path = "../openssl-sys" }
+ffi = { package = "openssl-sys", version = "0.9.117", path = "../openssl-sys" }
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
Bumps versions and fills in changelog entries for everything since the 0.10.80 / 0.9.116 release:

**openssl 0.10.81**
- verify_mode panic fix and new `SslVerifyMode` flags (#2651)
- `X509CrlBuilder` / `X509RevokedBuilder` / `CrlNumber` (#2538)
- brainpoolP224 `Nid` constants (#2642)
- `Asn1StringRef::to_string` + `as_utf8` deprecation (#2652)

**openssl-sys 0.9.117**
- `SSL_VERIFY_CLIENT_ONCE` / `SSL_VERIFY_POST_HANDSHAKE` (#2651)
- brainpoolP224 NIDs (#2642)
- ML-DSA bindings on BoringSSL (#2650)
- aws-lc-sys 0.41 (#2640)

🤖 Generated with [Claude Code](https://claude.com/claude-code)