### PR TITLE
Check return values of reference-count increment functions

### DIFF
--- a/openssl/src/dsa.rs
+++ b/openssl/src/dsa.rs
@@ -72,7 +72,8 @@ impl<T> ToOwned for DsaRef<T> {
 
     fn to_owned(&self) -> Dsa<T> {
         unsafe {
-            ffi::DSA_up_ref(self.as_ptr());
+            let r = ffi::DSA_up_ref(self.as_ptr());
+            assert!(r == 1);
             Dsa::from_ptr(self.as_ptr())
         }
     }

--- a/openssl/src/macros.rs
+++ b/openssl/src/macros.rs
@@ -206,6 +206,7 @@ macro_rules! generic_foreign_type_and_impl_send_sync {
                 fn clone(&self) -> $owned<T> {
                     unsafe {
                         let handle: *mut $ctype = $clone(self.0);
+                        assert!(!handle.is_null());
                         ::foreign_types::ForeignType::from_ptr(handle)
                     }
                 }
@@ -218,6 +219,7 @@ macro_rules! generic_foreign_type_and_impl_send_sync {
                     unsafe {
                         let handle: *mut $ctype =
                             $clone(::foreign_types::ForeignTypeRef::as_ptr(self));
+                        assert!(!handle.is_null());
                         $crate::ForeignType::from_ptr(handle)
                     }
                 }

--- a/openssl/src/pkey.rs
+++ b/openssl/src/pkey.rs
@@ -189,7 +189,8 @@ impl<T> ToOwned for PKeyRef<T> {
 
     fn to_owned(&self) -> PKey<T> {
         unsafe {
-            EVP_PKEY_up_ref(self.as_ptr());
+            let r = EVP_PKEY_up_ref(self.as_ptr());
+            assert!(r == 1);
             PKey::from_ptr(self.as_ptr())
         }
     }

--- a/openssl/src/rsa.rs
+++ b/openssl/src/rsa.rs
@@ -84,7 +84,8 @@ impl<T> ToOwned for RsaRef<T> {
 
     fn to_owned(&self) -> Rsa<T> {
         unsafe {
-            ffi::RSA_up_ref(self.as_ptr());
+            let r = ffi::RSA_up_ref(self.as_ptr());
+            assert!(r == 1);
             Rsa::from_ptr(self.as_ptr())
         }
     }

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1796,7 +1796,8 @@ impl ToOwned for SslContextRef {
 
     fn to_owned(&self) -> Self::Owned {
         unsafe {
-            SSL_CTX_up_ref(self.as_ptr());
+            let r = SSL_CTX_up_ref(self.as_ptr());
+            assert!(r == 1);
             SslContext::from_ptr(self.as_ptr())
         }
     }
@@ -2186,7 +2187,8 @@ impl ToOwned for SslSessionRef {
 
     fn to_owned(&self) -> SslSession {
         unsafe {
-            SSL_SESSION_up_ref(self.as_ptr());
+            let r = SSL_SESSION_up_ref(self.as_ptr());
+            assert!(r == 1);
             SslSession(self.as_ptr())
         }
     }

--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -710,7 +710,8 @@ impl ToOwned for X509Ref {
 
     fn to_owned(&self) -> X509 {
         unsafe {
-            X509_up_ref(self.as_ptr());
+            let r = X509_up_ref(self.as_ptr());
+            assert!(r == 1);
             X509::from_ptr(self.as_ptr())
         }
     }


### PR DESCRIPTION
The various `ToOwned::to_owned` impls (`SslContext`, `SslSession`, `X509`, `PKey`, `Rsa`, `Dsa`) called OpenSSL `*_up_ref` functions without checking their return value. These functions return `0` on failure (e.g. reference-count overflow), which would leave two owned wrappers sharing a single reference count and lead to a double-free / use-after-free on drop. This now asserts on success, matching the existing pattern in `EcKeyRef::to_owned`.

Also added a non-null assertion on the cloned handle in the `generic_foreign_type_and_impl_send_sync!` clone/to_owned macro impls.

Fixes #2658

🤖 Generated with [Claude Code](https://claude.com/claude-code)