### PR TITLE
Add brainpoolP192r1 and brainpoolP192t1 curve constants

### DIFF
--- a/openssl-sys/src/obj_mac.rs
+++ b/openssl-sys/src/obj_mac.rs
@@ -96,6 +96,11 @@ pub const NID_sect571k1: c_int = 733;
 pub const NID_sect571r1: c_int = 734;
 
 #[cfg(ossl110)]
+pub const NID_brainpoolP192r1: c_int = 923;
+#[cfg(libressl)]
+pub const NID_brainpoolP192r1: c_int = 924;
+
+#[cfg(ossl110)]
 pub const NID_brainpoolP224r1: c_int = 925;
 #[cfg(libressl)]
 pub const NID_brainpoolP224r1: c_int = 926;
@@ -119,6 +124,11 @@ pub const NID_brainpoolP384r1: c_int = 932;
 pub const NID_brainpoolP512r1: c_int = 933;
 #[cfg(libressl)]
 pub const NID_brainpoolP512r1: c_int = 934;
+
+#[cfg(ossl110)]
+pub const NID_brainpoolP192t1: c_int = 924;
+#[cfg(libressl)]
+pub const NID_brainpoolP192t1: c_int = 925;
 
 #[cfg(ossl110)]
 pub const NID_brainpoolP224t1: c_int = 926;

--- a/openssl/src/nid.rs
+++ b/openssl/src/nid.rs
@@ -215,6 +215,8 @@ impl Nid {
     pub const SECT571K1: Nid = Nid(ffi::NID_sect571k1);
     pub const SECT571R1: Nid = Nid(ffi::NID_sect571r1);
     #[cfg(any(ossl110, libressl))]
+    pub const BRAINPOOL_P192R1: Nid = Nid(ffi::NID_brainpoolP192r1);
+    #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P224R1: Nid = Nid(ffi::NID_brainpoolP224r1);
     #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P256R1: Nid = Nid(ffi::NID_brainpoolP256r1);
@@ -224,6 +226,8 @@ impl Nid {
     pub const BRAINPOOL_P384R1: Nid = Nid(ffi::NID_brainpoolP384r1);
     #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P512R1: Nid = Nid(ffi::NID_brainpoolP512r1);
+    #[cfg(any(ossl110, libressl))]
+    pub const BRAINPOOL_P192T1: Nid = Nid(ffi::NID_brainpoolP192t1);
     #[cfg(any(ossl110, libressl))]
     pub const BRAINPOOL_P224T1: Nid = Nid(ffi::NID_brainpoolP224t1);
     #[cfg(any(ossl110, libressl))]


### PR DESCRIPTION
This PR adds NIDs for the EC curves `brainpoolP192r1` and `brainpoolP192t1`.