### PR TITLE
Fix unrelated CI failures: clippy 1.97 lint and stale wasip2 pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,9 @@ jobs:
       - run: |
           cargo update -p unicode-ident --precise 1.0.22
           cargo update -p syn --precise 2.0.114
-          cargo update -p wasip2 --precise 1.0.1+wasi-0.2.4
           cargo update -p quote --precise 1.0.44
+          cargo update -p jobserver --precise 0.1.34
+          cargo update -p wasip2 --precise 1.0.1+wasi-0.2.4
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/registry/cache

--- a/openssl/src/bn.rs
+++ b/openssl/src/bn.rs
@@ -1169,7 +1169,7 @@ impl fmt::UpperHex for BigNumRef {
                 let s = s.to_uppercase();
 
                 if f.alternate() {
-                    <String as fmt::Display>::fmt(&format!("0x{}", &s), f)
+                    <String as fmt::Display>::fmt(&format!("0x{}", s), f)
                 } else {
                     <str as fmt::Display>::fmt(&s, f)
                 }


### PR DESCRIPTION
Two CI failures currently breaking unrelated PRs (e.g. #2662):

- **clippy**: clippy 1.97's new `useless_borrows_in_formatting` lint flags a redundant `&` in `format!` in `BigNumRef`'s `UpperHex` impl.
- **min-version**: jobserver 0.1.35 (pulled in via cc) requires rust 1.85 and getrandom ^0.4, whose manifests use edition 2024 that cargo 1.80 cannot parse during `cargo fetch`. Pin jobserver to 0.1.34. That downgrade puts getrandom 0.3/wasip2 back in the graph, so the existing wasip2 1.0.1 pin (from 1eaf3fa6, avoiding an edition-2024 wit-bindgen) stays, moved after the jobserver pin it depends on.

Verified locally with genuine rustc/cargo 1.80.0 by replicating the min-version job's exact steps end to end (drop systest, generate lockfile, all pins, `cargo fetch`, `RUSTFLAGS=-Dwarnings cargo check -p openssl`), and `cargo clippy --all --all-targets` with clippy 0.1.97 and `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)